### PR TITLE
fix(ci): install only the native dependencies Linux needs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install native dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libnfc-dev libgtk-3-dev libx11-dev libpcsclite-dev libasound2-dev
+          sudo apt-get install --no-install-recommends -y libnfc-dev libpcsclite-dev
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -42,11 +42,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # These two are the only native libraries a Linux build needs: libnfc for
+      # the clausecker/nfc binding and libpcsclite for the scard binding. They
+      # pull six packages between them, so installing them outright is as quick
+      # as restoring a cache and cannot go stale.
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
-        with:
-          packages: libnfc-dev libgtk-3-dev libx11-dev libpcsclite-dev libasound2-dev
-          version: 1.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libnfc-dev \
+            libpcsclite-dev
 
       - name: Download Go modules
         run: go mod download

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -134,12 +134,17 @@ jobs:
         if: matrix.os != 'windows'
         run: go mod download
 
-      - name: Cache APT packages (Ubuntu)
+      # These two are the only native libraries a Linux build needs: libnfc for
+      # the clausecker/nfc binding and libpcsclite for the scard binding. They
+      # pull six packages between them, so installing them outright is as quick
+      # as restoring a cache and cannot go stale.
+      - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu'
-        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
-        with:
-          packages: libnfc-dev libgtk-3-dev libx11-dev libpcsclite-dev libasound2-dev
-          version: 1.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libnfc-dev \
+            libpcsclite-dev
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
@@ -255,7 +260,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            libasound2-dev \
             libnfc-dev \
             libpcsclite-dev
 

--- a/pkg/ui/systray/dialog_desktop.go
+++ b/pkg/ui/systray/dialog_desktop.go
@@ -1,0 +1,34 @@
+//go:build windows || darwin
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package systray
+
+import "github.com/nixinwang/dialog"
+
+// nativeDialog puts a message in a window belonging to the desktop session.
+//
+// The import lives in this file rather than beside its callers because the
+// library binds GTK on Linux through cgo. Only the Windows and macOS binaries
+// build a tray, so confining it here keeps a Linux build of this package free
+// of GTK and X11.
+func nativeDialog(title, message string) {
+	dialog.Message("%s", message).Title(title).Info()
+}

--- a/pkg/ui/systray/dialog_headless.go
+++ b/pkg/ui/systray/dialog_headless.go
@@ -1,0 +1,33 @@
+//go:build !windows && !darwin
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package systray
+
+import "github.com/rs/zerolog/log"
+
+// nativeDialog records the message instead of opening a window.
+//
+// Only the Windows and macOS binaries build a tray, so nothing here reaches
+// this at run time. It exists so the package still compiles on other platforms
+// without pulling in the GTK-backed dialog library.
+func nativeDialog(title, message string) {
+	log.Info().Str("title", title).Msg(message)
+}

--- a/pkg/ui/systray/systray.go
+++ b/pkg/ui/systray/systray.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
-	"github.com/nixinwang/dialog"
 	"github.com/rs/zerolog/log"
 	"golang.design/x/clipboard"
 )
@@ -154,7 +153,8 @@ func systrayOnReady(
 						"© %d Zaparoo Contributors\n" +
 						"License: GPLv3\n\n" +
 						"www.zaparoo.org"
-					dialog.Message(msg, config.AppVersion, time.Now().Year()).Title("About Zaparoo Core").Info()
+					nativeDialog("About Zaparoo Core",
+						fmt.Sprintf(msg, config.AppVersion, time.Now().Year()))
 				case <-mQuit.ClickedCh:
 					systray.Quit()
 				}

--- a/pkg/ui/systray/update.go
+++ b/pkg/ui/systray/update.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
-	"github.com/nixinwang/dialog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -87,14 +86,13 @@ type menuEntry interface {
 // apiCaller is how these entries reach Core, and showDialog is how they get a
 // message in front of someone. Both are injected so the menu's decisions can be
 // tested without a running service or a native window.
+//
+// nativeDialog is the real implementation of showDialog and is defined per
+// platform in dialog_desktop.go and dialog_headless.go.
 type (
 	apiCaller  func(ctx context.Context, cfg *config.Instance, method, params string) (string, error)
 	showDialog func(title, message string)
 )
-
-func nativeDialog(title, message string) {
-	dialog.Message("%s", message).Title(title).Info()
-}
 
 func watchUpdateStatus(cfg *config.Instance, item *systray.MenuItem) {
 	for {


### PR DESCRIPTION
The nightly fuzz run failed to build `pkg/platforms/shared/launchers` because libnfc was missing from pkg-config. No fuzz target crashed.

## Cause

`awalsh128/cache-apt-pkgs-action` installed nothing and reported success:

1. The repository's Actions cache is near its 10 GiB cap, so the apt entry was evicted despite an unchanged key.
2. On a miss the action installs without refreshing APT lists. The runner image was 11 days old, so superseded `.deb` files returned 404 and apt aborted.
3. The failure was swallowed. Its installer sets `set -e`, then sources a library whose first line is `set +e`, so the script logged "done" and exited zero.
4. It then saved a 3.7 KB cache holding zero packages under the same key, on `main`. That entry is shared with the Ubuntu CI job, which hashed to the same key.

Upstream has not fixed this. v1.6.3 is still the newest release and its default branch still clears errexit and still skips the APT refresh.

## Changes

Installing directly means a failed install fails the step, since GitHub runs `run:` blocks under `bash -e`, and there is no cache entry to go stale.

The package list was also wrong. A Linux build needs `libnfc-dev` for the clausecker/nfc binding and `libpcsclite-dev` for the scard binding, and nothing else.

- `libasound2-dev` was never needed. malgo declares no pkg-config and `dlopen`s ALSA at run time; its ALSA include sits behind `#ifdef MA_NO_RUNTIME_LINKING`, which nothing defines.
- `libgtk-3-dev` and `libx11-dev` were reachable only through `github.com/nixinwang/dialog` in `pkg/ui/systray`. Only `cmd/windows` and `cmd/mac` import that package, so no Linux binary links it, but `go build ./...` still compiled it. The first commit moves that import into a desktop-only file, using the `showDialog` seam the package already had. The package still compiles and its tests still run on Linux, which a build tag on the whole package would have prevented.

| Package set | Transitive packages | Install |
| --- | --- | --- |
| Previous five | 282 in a bare container, 107 on the runner | 24s |
| `libnfc-dev` + `libpcsclite-dev` | 6 | 3s |
| The cache restore this replaces | n/a | 2s |

Applied to all four install sites: the Ubuntu CI step and the MiSTer smoke step in `lint-and-test.yml`, `fuzz.yml`, and `codeql.yml`.

Fixes #1397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the About information experience on Windows and macOS with native informational dialogs.
  - On other platforms, About messages are now recorded in application logs instead of opening a window.

- **Chores**
  - Streamlined automated build, test, and security-check environments by installing only the system libraries required for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->