### PR TITLE
fix(ci): give the Windows CI job room to rebuild its cache

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -43,7 +43,13 @@ jobs:
 
   ci:
     name: CI
-    timeout-minutes: 15
+    # Windows takes 12 to 13 minutes here even with its Go build cache warm, so
+    # a 15 minute cap left almost no headroom: once that cache was evicted the
+    # job compiled from scratch, hit the limit while still linking, and died
+    # before the post step that saves a new one. That made the timeout
+    # self-sustaining, because every following run also started cold. 30 gives a
+    # cold run room to finish and repopulate the cache.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Every `Lint and Test` run on main since 2026-09-02 has ended cancelled or failed, always on `Run full tests (Windows)`. The job hits its 15 minute timeout, which GitHub reports as cancelled.

## Cause

Windows takes 12 to 13 minutes with its Go build cache warm, measured on runs 33238676182 and 33235697558, the last two that passed. The 15 minute cap left two to three minutes of headroom.

Actions cache pressure then evicted every `Windows-gobuild` entry, so the job started compiling from scratch. That is the case the existing comment on that cache step describes: cgo plus a `-race` test binary per package at two cores, still linking when the timeout fires.

It locked itself in. The job is killed before the post step that saves the build cache, so it never writes one, and the next run also starts cold. It cannot recover on its own.

## Change

Raise `timeout-minutes` on the `ci` job from 15 to 30, so one cold run can finish and repopulate the cache. Later runs return to their usual length. Ubuntu and macOS share this job and finish well inside the old limit, so the only effect there is that a genuinely hung job takes longer to be killed.

Worth revisiting once the cache storage limit is confirmed to be holding, since a persistent build cache is what keeps this job at 12 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the automated validation workflow timeout to accommodate longer-running checks on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->