### PR TITLE
fix(discovery): advertise mDNS on every live interface

### DIFF
--- a/cmd/windows/setup.iss.tmpl
+++ b/cmd/windows/setup.iss.tmpl
@@ -43,9 +43,12 @@ Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
   Tasks: runonstartup; Flags: uninsdeletevalue
 ; Registers the cleanup of the firewall marker. The marker itself is written
 ; by MarkFirewallRuleAdded, so that it records a rule that was really created
-; rather than a task that was merely ticked.
-Root: HKCU; Subkey: "Software\Zaparoo\Core"; Flags: dontcreatekey uninsdeletekey
-Root: HKCU; Subkey: "Software\Zaparoo"; Flags: dontcreatekey uninsdeletekeyifempty
+; rather than a task that was merely ticked. HKA follows the install mode: a
+; firewall rule is machine-wide, so an administrative install must record it
+; somewhere any administrator can find it again at uninstall time, not in the
+; installing user's hive.
+Root: HKA; Subkey: "Software\Zaparoo\Core"; Flags: dontcreatekey uninsdeletekey
+Root: HKA; Subkey: "Software\Zaparoo"; Flags: dontcreatekey uninsdeletekeyifempty
 
 [Files]
 Source: "{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
@@ -93,12 +96,12 @@ LaunchAfterInstall=&Launch Zaparoo Core after installation
 // silent install must not show.
 procedure MarkFirewallRuleAdded;
 begin
-  RegWriteDWordValue(HKEY_CURRENT_USER, 'Software\Zaparoo\Core', 'FirewallRule', 1);
+  RegWriteDWordValue(HKEY_AUTO, 'Software\Zaparoo\Core', 'FirewallRule', 1);
 end;
 
 // FirewallRuleWasAdded gates the uninstaller's netsh step, so an uninstall
 // only raises an elevation prompt when there is a rule to remove.
 function FirewallRuleWasAdded: Boolean;
 begin
-  Result := RegValueExists(HKEY_CURRENT_USER, 'Software\Zaparoo\Core', 'FirewallRule');
+  Result := RegValueExists(HKEY_AUTO, 'Software\Zaparoo\Core', 'FirewallRule');
 end;

--- a/cmd/windows/setup.iss.tmpl
+++ b/cmd/windows/setup.iss.tmpl
@@ -35,11 +35,17 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "runonstartup"; Description: "Run Zaparoo Core on startup"; GroupDescription: "Startup options:"
+Name: "firewall"; Description: "Allow Zaparoo Core through Windows Firewall"; GroupDescription: "Network:"
 
 [Registry]
 Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
   ValueType: string; ValueName: "ZaparooCore"; ValueData: """{app}\Zaparoo.exe"""; \
   Tasks: runonstartup; Flags: uninsdeletevalue
+; Registers the cleanup of the firewall marker. The marker itself is written
+; by MarkFirewallRuleAdded, so that it records a rule that was really created
+; rather than a task that was merely ticked.
+Root: HKCU; Subkey: "Software\Zaparoo\Core"; Flags: dontcreatekey uninsdeletekey
+Root: HKCU; Subkey: "Software\Zaparoo"; Flags: dontcreatekey uninsdeletekeyifempty
 
 [Files]
 Source: "{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
@@ -52,11 +58,47 @@ Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
+; Without a rule of our own, Windows falls back to the "allow access" popup the
+; first time Core binds a socket. That popup scopes the rule to whichever of
+; Private/Public happens to be ticked, so Core ends up reachable on one network
+; profile and silently firewalled on another - the usual cause of a device that
+; the app finds over Wi-Fi but not over Ethernet. profile=any covers all three.
+; The rule is deleted first so repeat installs do not stack duplicates.
+Filename: "{cmd}"; Parameters: "/c netsh advfirewall firewall delete rule name=""{#MyAppName}"" >nul 2>&1 & netsh advfirewall firewall add rule name=""{#MyAppName}"" dir=in action=allow program=""{app}\{#MyAppExeName}"" enable=yes profile=any"; \
+  StatusMsg: "Adding Windows Firewall rule..."; Flags: runhidden waituntilterminated; \
+  Tasks: firewall; Check: IsAdminInstallMode; AfterInstall: MarkFirewallRuleAdded
+; A per-user install is not elevated, but netsh is. Ask for it once, and carry
+; on with the install if the prompt is declined.
+Filename: "{cmd}"; Parameters: "/c netsh advfirewall firewall delete rule name=""{#MyAppName}"" >nul 2>&1 & netsh advfirewall firewall add rule name=""{#MyAppName}"" dir=in action=allow program=""{app}\{#MyAppExeName}"" enable=yes profile=any"; \
+  StatusMsg: "Adding Windows Firewall rule..."; Flags: shellexec waituntilterminated runhidden skipifsilent; Verb: runas; \
+  Tasks: firewall; Check: not IsAdminInstallMode; AfterInstall: MarkFirewallRuleAdded
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 Filename: "{app}\README.txt"; Description: "View README"; Flags: shellexec postinstall skipifsilent unchecked
 
 [UninstallRun]
 Filename: "taskkill.exe"; Parameters: "/F /IM ""{#MyAppExeName}"""; Flags: runhidden; RunOnceId: "KillService"
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""{#MyAppName}"""; \
+  Flags: runhidden waituntilterminated; RunOnceId: "DelFirewallRule"; \
+  Check: FirewallRuleWasAdded and IsAdminInstallMode
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""{#MyAppName}"""; \
+  Flags: shellexec waituntilterminated runhidden; Verb: runas; RunOnceId: "DelFirewallRuleElevated"; \
+  Check: FirewallRuleWasAdded and not IsAdminInstallMode
 
 [CustomMessages]
 LaunchAfterInstall=&Launch Zaparoo Core after installation
+
+[Code]
+// MarkFirewallRuleAdded records that the netsh step actually ran. A silent
+// per-user install skips it, because netsh needs an elevation prompt that a
+// silent install must not show.
+procedure MarkFirewallRuleAdded;
+begin
+  RegWriteDWordValue(HKEY_CURRENT_USER, 'Software\Zaparoo\Core', 'FirewallRule', 1);
+end;
+
+// FirewallRuleWasAdded gates the uninstaller's netsh step, so an uninstall
+// only raises an elevation prompt when there is a rule to remove.
+function FirewallRuleWasAdded: Boolean;
+begin
+  Result := RegValueExists(HKEY_CURRENT_USER, 'Software\Zaparoo\Core', 'FirewallRule');
+end;

--- a/go.mod
+++ b/go.mod
@@ -37,12 +37,12 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gopxl/beep/v2 v2.1.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/grandcat/zeroconf v1.0.0
 	github.com/hbollon/go-edlib v1.7.0
 	github.com/hsanjuan/go-ndef v0.0.1
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/mackerelio/go-osstat v0.2.8
 	github.com/mattn/go-sqlite3 v1.14.50
+	github.com/miekg/dns v1.1.72
 	github.com/nixinwang/dialog v0.0.0-20240524023314-b4bad92eff4d
 	github.com/olahol/melody v1.4.0
 	github.com/pelletier/go-toml/v2 v2.4.3
@@ -59,6 +59,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	golang.design/x/clipboard v0.9.0
 	golang.org/x/image v0.45.0
+	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.41.0
@@ -79,7 +80,6 @@ require (
 	github.com/bodgit/sevenzip v1.6.1 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
-	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cloudsoda/sddl v0.0.0-20250224235906-926454e91efc // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/ebitengine/purego v0.10.2 // indirect
@@ -117,7 +117,6 @@ require (
 	github.com/mewkiz/flac v1.0.12 // indirect
 	github.com/mewkiz/pkg v0.0.0-20230226050401-4010bf0fec14 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
-	github.com/miekg/dns v1.1.27 // indirect
 	github.com/nwaples/rardecode/v2 v2.2.2 // indirect
 	github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe // indirect
 	github.com/pierrec/lz4/v4 v4.1.27 // indirect
@@ -139,9 +138,10 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
-	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
+	golang.org/x/tools v0.48.0 // indirect
 	periph.io/x/conn/v3 v3.7.3 // indirect
 	periph.io/x/host/v3 v3.8.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,6 @@ github.com/bodgit/windows v1.0.1 h1:tF7K6KOluPYygXa3Z2594zxlkbKPAOvqr97etrGNIz4=
 github.com/bodgit/windows v1.0.1/go.mod h1:a6JLwrB4KrTR5hBpp8FI9/9W9jJfeQ2h4XDXU74ZCdM=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
-github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -181,8 +179,6 @@ github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7Fsg
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grandcat/zeroconf v1.0.0 h1:uHhahLBKqwWBV6WZUDAT71044vwOTL+McW0mBJvo6kE=
-github.com/grandcat/zeroconf v1.0.0/go.mod h1:lTKmG1zh86XyCoUeIHSA4FJMBwCJiQmGfcP2PdzytEs=
 github.com/graph-gophers/graphql-go v1.9.0 h1:yu0ucKHLc5qGpRwLYKIWtr9bOoxovkWasuBrPQwlHls=
 github.com/graph-gophers/graphql-go v1.9.0/go.mod h1:23olKZ7duEvHlF/2ELEoSZaY1aNPfShjP782SOoNTyM=
 github.com/hajimehoshi/go-mp3 v0.3.4 h1:NUP7pBYH8OguP4diaTZ9wJbUbk3tC0KlfzsEpWmYj68=
@@ -264,8 +260,8 @@ github.com/mewkiz/pkg v0.0.0-20230226050401-4010bf0fec14 h1:tnAPMExbRERsyEYkmR1Y
 github.com/mewkiz/pkg v0.0.0-20230226050401-4010bf0fec14/go.mod h1:QYCFBiH5q6XTHEbWhR0uhR3M9qNPoD2CSQzr0g75kE4=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
 github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
-github.com/miekg/dns v1.1.27 h1:aEH/kqUzUxGJ/UHcEKdJY+ugH6WEzsEBBSPa8zuy1aM=
-github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
+github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=
+github.com/miekg/dns v1.1.72/go.mod h1:+EuEPhdHOsfk6Wk5TT2CzssZdqkmFhf8r+aVyDEToIs=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nixinwang/dialog v0.0.0-20240524023314-b4bad92eff4d h1:ksFeg+t5pSq0iJpb5ywqaVCAfc0UvD/4gyq3vWggFsw=
@@ -408,6 +404,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
+golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -419,7 +417,6 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -457,7 +454,6 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -510,7 +506,6 @@ golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
@@ -518,6 +513,8 @@ golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
+golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -906,9 +906,9 @@ func expandCustomOrigins(customOrigins []string, port int) []string {
 // publishes for it: responders derive the host record from the OS hostname, so
 // a device called "mister" answers to "mister.local" regardless of what
 // instance name Core advertises over DNS-SD. Hostnames that are already fully
-// qualified contribute their short label too, because avahi publishes the short
-// name under ".local" while the bundled responder appends the suffix to the
-// whole name. Results are deduplicated case-insensitively.
+// qualified contribute their short label too, because both avahi and the
+// bundled responder publish the short name under ".local". Results are
+// deduplicated case-insensitively.
 func localHostNames(hostname string) []string {
 	hostname = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(hostname), "."))
 	if hostname == "" {

--- a/pkg/service/discovery/discovery.go
+++ b/pkg/service/discovery/discovery.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/discovery/mdns"
+	"github.com/jonboulle/clockwork"
 	"github.com/rs/zerolog/log"
 )
 
@@ -117,22 +118,40 @@ func isVirtualInterface(name string) bool {
 	return false
 }
 
+// responder is the part of mdns.Responder the discovery service drives. The
+// watch loop is the fix for an interface that appears after startup, so it is
+// worth being able to test it without opening a socket.
+type responder interface {
+	Start(ifaces []net.Interface) error
+	SetInterfaces(ifaces []net.Interface) (bool, error)
+	Interfaces() []string
+	Stop()
+}
+
 // Service manages mDNS service advertising for network discovery.
 // It allows mobile apps to discover Zaparoo Core instances without
 // manual IP configuration.
 type Service struct {
-	responder    *mdns.Responder
-	cfg          *config.Instance
-	cancelFunc   context.CancelFunc
-	instanceName string
-	mu           syncutil.Mutex
-	stopped      bool
+	clock          clockwork.Clock
+	listInterfaces func() ([]net.Interface, error)
+	newResponder   func(svc *mdns.Service, logf func(string, ...any)) responder
+	responder      responder
+	cfg            *config.Instance
+	cancelFunc     context.CancelFunc
+	instanceName   string
+	mu             syncutil.Mutex
+	stopped        bool
 }
 
 // New creates a new discovery service.
 func New(cfg *config.Instance) *Service {
 	return &Service{
-		cfg: cfg,
+		cfg:            cfg,
+		clock:          clockwork.NewRealClock(),
+		listInterfaces: getPreferredInterfaces,
+		newResponder: func(svc *mdns.Service, logf func(string, ...any)) responder {
+			return mdns.New(svc, logf)
+		},
 	}
 }
 
@@ -152,7 +171,7 @@ func (s *Service) Start() error {
 	}
 	s.instanceName = instanceName
 
-	responder := mdns.New(&mdns.Service{
+	newResponder := s.newResponder(&mdns.Service{
 		Instance: instanceName,
 		Type:     ServiceType,
 		Host:     hostLabel(instanceName),
@@ -167,14 +186,14 @@ func (s *Service) Start() error {
 		s.mu.Unlock()
 		return nil
 	}
-	s.responder = responder
+	s.responder = newResponder
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancelFunc = cancel
 	s.mu.Unlock()
 
-	started := s.tryStart(responder, false)
+	started := s.tryStart(newResponder, false)
 
-	go s.watchInterfaces(ctx, responder, started)
+	go s.watchInterfaces(ctx, newResponder, started)
 
 	return nil
 }
@@ -182,8 +201,8 @@ func (s *Service) Start() error {
 // tryStart attempts registration once, reporting whether it succeeded. quiet
 // suppresses the failure log, so a machine that stays offline does not repeat
 // the same line every tick for as long as it runs.
-func (s *Service) tryStart(responder *mdns.Responder, quiet bool) bool {
-	ifaces, err := getPreferredInterfaces()
+func (s *Service) tryStart(mdnsResponder responder, quiet bool) bool {
+	ifaces, err := s.listInterfaces()
 	if err != nil {
 		if !quiet {
 			log.Debug().Err(err).Msg("failed to get network interfaces")
@@ -197,7 +216,7 @@ func (s *Service) tryStart(responder *mdns.Responder, quiet bool) bool {
 		return false
 	}
 
-	if err := responder.Start(ifaces); err != nil {
+	if err := mdnsResponder.Start(ifaces); err != nil {
 		if !quiet {
 			log.Debug().Err(err).Msg("mDNS registration attempt failed, will keep watching")
 		}
@@ -208,15 +227,15 @@ func (s *Service) tryStart(responder *mdns.Responder, quiet bool) bool {
 		Str("instance", s.instanceName).
 		Int("port", s.cfg.APIPort()).
 		Str("type", ServiceType).
-		Strs("interfaces", responder.Interfaces()).
+		Strs("interfaces", mdnsResponder.Interfaces()).
 		Msg("mDNS service advertising started")
 
 	return true
 }
 
 // watchInterfaces keeps the advertised interface set in step with the machine.
-func (s *Service) watchInterfaces(ctx context.Context, responder *mdns.Responder, started bool) {
-	ticker := time.NewTicker(watchInterval)
+func (s *Service) watchInterfaces(ctx context.Context, mdnsResponder responder, started bool) {
+	ticker := s.clock.NewTicker(watchInterval)
 	defer ticker.Stop()
 
 	reportedFailure := !started
@@ -225,29 +244,29 @@ func (s *Service) watchInterfaces(ctx context.Context, responder *mdns.Responder
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-ticker.Chan():
 		}
 
 		if !started {
-			started = s.tryStart(responder, reportedFailure)
+			started = s.tryStart(mdnsResponder, reportedFailure)
 			reportedFailure = !started
 			continue
 		}
 
-		ifaces, err := getPreferredInterfaces()
+		ifaces, err := s.listInterfaces()
 		if err != nil {
 			log.Debug().Err(err).Msg("failed to get network interfaces")
 			continue
 		}
 
-		changed, err := responder.SetInterfaces(ifaces)
+		changed, err := mdnsResponder.SetInterfaces(ifaces)
 		if err != nil {
 			log.Debug().Err(err).Msg("mDNS interface update failed")
 			continue
 		}
 		if changed {
 			log.Info().
-				Strs("interfaces", responder.Interfaces()).
+				Strs("interfaces", mdnsResponder.Interfaces()).
 				Msg("mDNS interfaces changed, advertising updated")
 		}
 	}
@@ -258,7 +277,7 @@ func (s *Service) Stop() {
 	s.mu.Lock()
 	s.stopped = true
 	cancel := s.cancelFunc
-	responder := s.responder
+	mdnsResponder := s.responder
 	s.cancelFunc = nil
 	s.responder = nil
 	s.mu.Unlock()
@@ -267,9 +286,9 @@ func (s *Service) Stop() {
 		cancel()
 	}
 
-	if responder != nil {
+	if mdnsResponder != nil {
 		log.Debug().Msg("stopping mDNS service advertising")
-		responder.Stop()
+		mdnsResponder.Stop()
 	}
 }
 
@@ -289,14 +308,20 @@ func (s *Service) resolveInstanceName() (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to get hostname, using fallback")
-		deviceID := s.cfg.DeviceID()
-		if len(deviceID) >= 8 {
-			return "zaparoo-" + deviceID[:8], nil
-		}
-		return "zaparoo", nil
+		return fallbackInstanceName(s.cfg.DeviceID()), nil
 	}
 
 	return hostname, nil
+}
+
+// fallbackInstanceName names the service when the machine will not say what it
+// is called. A slice of the device ID keeps two Zaparoo devices on one network
+// from colliding under the same name.
+func fallbackInstanceName(deviceID string) string {
+	if len(deviceID) >= 8 {
+		return "zaparoo-" + deviceID[:8]
+	}
+	return "zaparoo"
 }
 
 // hostLabel picks the single DNS label the SRV record targets. The machine's
@@ -309,6 +334,14 @@ func hostLabel(fallback string) string {
 	if err != nil || name == "" {
 		name = fallback
 	}
+	return firstLabel(name)
+}
+
+// firstLabel reduces a host name to the single DNS label the ".local" suffix
+// is appended to, so a machine named "mister.lan" is published as
+// "mister.local" the way avahi and Windows both publish it, rather than
+// "mister.lan.local".
+func firstLabel(name string) string {
 	if idx := strings.Index(name, "."); idx > 0 {
 		name = name[:idx]
 	}

--- a/pkg/service/discovery/discovery.go
+++ b/pkg/service/discovery/discovery.go
@@ -29,35 +29,46 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
-	"github.com/grandcat/zeroconf"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/discovery/mdns"
 	"github.com/rs/zerolog/log"
 )
 
 // ServiceType is the DNS-SD service type for Zaparoo Core.
 const ServiceType = "_zaparoo._tcp"
 
-// retryInterval is how often to retry mDNS registration when network is unavailable.
-const retryInterval = 30 * time.Second
+// watchInterval is how often the interface list is re-examined. It covers both
+// a network that was not ready when Core started and one that changes later:
+// an Ethernet cable plugged in after startup is advertised within a tick,
+// without restarting Core.
+const watchInterval = 15 * time.Second
 
-// maxRetryDuration is the maximum time to keep retrying mDNS registration.
-const maxRetryDuration = 5 * time.Minute
-
-// virtualInterfacePrefixes lists common prefixes for virtual/container network interfaces
-// that should be excluded from mDNS registration.
+// virtualInterfacePrefixes lists common prefixes for virtual/container network
+// interfaces that should be excluded from mDNS registration. "veth" also
+// covers Windows Hyper-V and WSL adapters, which are named
+// "vEthernet (<switch>)".
 var virtualInterfacePrefixes = []string{
 	"docker", "br-", "veth", "virbr", "lxc", "lxd",
 	"cni", "flannel", "cali", "tunl", "wg",
+	"vmware", "virtualbox",
 }
 
-// defaultTXTRecords is intentionally empty: device ID, version, and platform
-// are exposed only via the authenticated API. Broadcasting them on the LAN
-// would expose information useful for targeted attacks (version → known
-// vulnerabilities, platform → attack surface). Any change to this slice must
-// be pinned by TestDefaultTXTRecordsAreEmpty.
-var defaultTXTRecords = []string{}
+// defaultTXTRecords carries no data: device ID, version, and platform are
+// exposed only via the authenticated API. Broadcasting them on the LAN would
+// expose information useful for targeted attacks (version → known
+// vulnerabilities, platform → attack surface).
+//
+// "No data" is one zero-length string, not an empty slice. A TXT record must
+// hold at least one character-string (RFC 1035 §3.3.14, RFC 6763 §6.1), and an
+// empty slice packs to a TXT record with rdlength 0, which strict resolvers
+// reject — Apple's mDNSResponder drops the record outright, and some parsers
+// fail the whole response, taking the address records with it. Any change to
+// this slice must be pinned by TestDefaultTXTRecordsCarryNoData.
+var defaultTXTRecords = []string{""}
 
-// getPreferredInterfaces returns network interfaces suitable for mDNS registration.
-// It filters out loopback, down, non-multicast, and virtual interfaces.
+// getPreferredInterfaces returns network interfaces suitable for mDNS
+// registration. It filters out loopback, down, non-multicast, and virtual
+// interfaces. Interfaces with no address worth advertising are dropped later,
+// by the responder, which is where addresses are already being inspected.
 func getPreferredInterfaces() ([]net.Interface, error) {
 	allIfaces, err := net.Interfaces()
 	if err != nil {
@@ -110,12 +121,12 @@ func isVirtualInterface(name string) bool {
 // It allows mobile apps to discover Zaparoo Core instances without
 // manual IP configuration.
 type Service struct {
-	server       *zeroconf.Server
+	responder    *mdns.Responder
 	cfg          *config.Instance
 	cancelFunc   context.CancelFunc
 	instanceName string
-	stopped      bool
 	mu           syncutil.Mutex
+	stopped      bool
 }
 
 // New creates a new discovery service.
@@ -125,9 +136,10 @@ func New(cfg *config.Instance) *Service {
 	}
 }
 
-// Start begins mDNS service advertising. If initial registration fails due to
-// network unavailability, it starts a background retry loop. Returns an error
-// only for permanent failures (e.g., disabled by config).
+// Start begins mDNS service advertising and keeps it in step with the
+// machine's network interfaces. Registration failing right now is not an
+// error: the watch loop retries for as long as the service runs, because a
+// network that is not ready at boot usually becomes ready shortly after.
 func (s *Service) Start() error {
 	if !s.cfg.DiscoveryEnabled() {
 		log.Info().Msg("mDNS discovery disabled by configuration")
@@ -140,99 +152,103 @@ func (s *Service) Start() error {
 	}
 	s.instanceName = instanceName
 
-	if s.tryRegister() {
+	responder := mdns.New(&mdns.Service{
+		Instance: instanceName,
+		Type:     ServiceType,
+		Host:     hostLabel(instanceName),
+		Port:     uint16(s.cfg.APIPort()), //nolint:gosec // a TCP port cannot exceed uint16
+		Text:     defaultTXTRecords,
+	}, func(format string, args ...any) {
+		log.Debug().Msgf("mDNS: "+format, args...)
+	})
+
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
 		return nil
 	}
-
-	log.Info().
-		Dur("retryInterval", retryInterval).
-		Dur("maxDuration", maxRetryDuration).
-		Msg("mDNS registration failed, starting background retry (network may not be ready)")
-
-	ctx, cancel := context.WithTimeout(context.Background(), maxRetryDuration)
-	s.mu.Lock()
+	s.responder = responder
+	ctx, cancel := context.WithCancel(context.Background())
 	s.cancelFunc = cancel
 	s.mu.Unlock()
 
-	go s.retryLoop(ctx)
+	started := s.tryStart(responder, false)
+
+	go s.watchInterfaces(ctx, responder, started)
 
 	return nil
 }
 
-// tryRegister attempts to register the mDNS service. Returns true on success.
-func (s *Service) tryRegister() bool {
-	port := s.cfg.APIPort()
-
-	// See defaultTXTRecords for the rationale behind broadcasting an empty
-	// TXT record set.
-	txtRecords := defaultTXTRecords
-
+// tryStart attempts registration once, reporting whether it succeeded. quiet
+// suppresses the failure log, so a machine that stays offline does not repeat
+// the same line every tick for as long as it runs.
+func (s *Service) tryStart(responder *mdns.Responder, quiet bool) bool {
 	ifaces, err := getPreferredInterfaces()
 	if err != nil {
-		log.Debug().Err(err).Msg("failed to get network interfaces")
+		if !quiet {
+			log.Debug().Err(err).Msg("failed to get network interfaces")
+		}
 		return false
 	}
-
 	if len(ifaces) == 0 {
-		log.Debug().Msg("no suitable network interfaces found for mDNS")
+		if !quiet {
+			log.Debug().Msg("no suitable network interfaces found for mDNS, will keep watching")
+		}
 		return false
 	}
 
-	ifaceNames := make([]string, len(ifaces))
-	for i, iface := range ifaces {
-		ifaceNames[i] = iface.Name
-	}
-	log.Debug().Strs("interfaces", ifaceNames).Msg("selected interfaces for mDNS")
-
-	server, err := zeroconf.Register(
-		s.instanceName,
-		ServiceType,
-		"local.",
-		port,
-		txtRecords,
-		ifaces,
-	)
-	if err != nil {
-		log.Debug().Err(err).Msg("mDNS registration attempt failed")
+	if err := responder.Start(ifaces); err != nil {
+		if !quiet {
+			log.Debug().Err(err).Msg("mDNS registration attempt failed, will keep watching")
+		}
 		return false
 	}
-
-	s.mu.Lock()
-	// Check if Stop() was called while we were registering. If so, shut down
-	// the newly created server immediately to avoid a resource leak.
-	if s.stopped {
-		s.mu.Unlock()
-		server.Shutdown()
-		return false
-	}
-	s.server = server
-	s.mu.Unlock()
 
 	log.Info().
 		Str("instance", s.instanceName).
-		Int("port", port).
+		Int("port", s.cfg.APIPort()).
 		Str("type", ServiceType).
-		Strs("interfaces", ifaceNames).
+		Strs("interfaces", responder.Interfaces()).
 		Msg("mDNS service advertising started")
 
 	return true
 }
 
-// retryLoop periodically retries mDNS registration until successful or context expires.
-func (s *Service) retryLoop(ctx context.Context) {
-	ticker := time.NewTicker(retryInterval)
+// watchInterfaces keeps the advertised interface set in step with the machine.
+func (s *Service) watchInterfaces(ctx context.Context, responder *mdns.Responder, started bool) {
+	ticker := time.NewTicker(watchInterval)
 	defer ticker.Stop()
+
+	reportedFailure := !started
 
 	for {
 		select {
-		case <-ticker.C:
-			if s.tryRegister() {
-				log.Info().Msg("mDNS registration succeeded after retry")
-				return
-			}
 		case <-ctx.Done():
-			log.Warn().Msg("mDNS registration retry timed out, discovery will not be available")
 			return
+		case <-ticker.C:
+		}
+
+		if !started {
+			started = s.tryStart(responder, reportedFailure)
+			reportedFailure = !started
+			continue
+		}
+
+		ifaces, err := getPreferredInterfaces()
+		if err != nil {
+			log.Debug().Err(err).Msg("failed to get network interfaces")
+			continue
+		}
+
+		changed, err := responder.SetInterfaces(ifaces)
+		if err != nil {
+			log.Debug().Err(err).Msg("mDNS interface update failed")
+			continue
+		}
+		if changed {
+			log.Info().
+				Strs("interfaces", responder.Interfaces()).
+				Msg("mDNS interfaces changed, advertising updated")
 		}
 	}
 }
@@ -240,19 +256,20 @@ func (s *Service) retryLoop(ctx context.Context) {
 // Stop gracefully shuts down mDNS advertising, sending goodbye packets.
 func (s *Service) Stop() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	s.stopped = true
+	cancel := s.cancelFunc
+	responder := s.responder
+	s.cancelFunc = nil
+	s.responder = nil
+	s.mu.Unlock()
 
-	if s.cancelFunc != nil {
-		s.cancelFunc()
-		s.cancelFunc = nil
+	if cancel != nil {
+		cancel()
 	}
 
-	if s.server != nil {
+	if responder != nil {
 		log.Debug().Msg("stopping mDNS service advertising")
-		s.server.Shutdown()
-		s.server = nil
+		responder.Stop()
 	}
 }
 
@@ -280,4 +297,23 @@ func (s *Service) resolveInstanceName() (string, error) {
 	}
 
 	return hostname, nil
+}
+
+// hostLabel picks the single DNS label the SRV record targets. The machine's
+// own hostname is preferred so that "<host>.local" resolves the way the rest
+// of the network already expects; a configured instance name is only a
+// display name and may not match. A hostname that is already qualified is cut
+// back to its first label, because the responder appends ".local".
+func hostLabel(fallback string) string {
+	name, err := os.Hostname()
+	if err != nil || name == "" {
+		name = fallback
+	}
+	if idx := strings.Index(name, "."); idx > 0 {
+		name = name[:idx]
+	}
+	if name == "" {
+		return "zaparoo"
+	}
+	return name
 }

--- a/pkg/service/discovery/discovery_test.go
+++ b/pkg/service/discovery/discovery_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/discovery/mdns"
+	"github.com/jonboulle/clockwork"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -136,12 +138,9 @@ func TestInstanceNameUsesHostname(t *testing.T) {
 	expectedHostname, err := os.Hostname()
 	require.NoError(t, err)
 
-	svc := New(cfg)
+	svc := newTestService(t, cfg)
 	t.Cleanup(svc.Stop)
-
-	// Start may fail to open a socket, but instanceName is resolved before
-	// that happens, so the resolution is still observable.
-	_ = svc.Start() // Ignore error - registration may fail without network
+	require.NoError(t, svc.Start())
 
 	// instanceName should be set to the hostname (since no config override)
 	assert.Equal(t, expectedHostname, svc.InstanceName())
@@ -157,9 +156,9 @@ func TestInstanceNameUsesConfigOverride(t *testing.T) {
 	// Set a custom instance name in config
 	cfg.SetDiscoveryInstanceName("my-custom-name")
 
-	svc := New(cfg)
+	svc := newTestService(t, cfg)
 	t.Cleanup(svc.Stop)
-	_ = svc.Start() // Ignore error - registration may fail without network
+	require.NoError(t, svc.Start())
 
 	// instanceName should use the config override, not hostname
 	assert.Equal(t, "my-custom-name", svc.InstanceName())
@@ -358,4 +357,55 @@ func TestGetPreferredInterfaces(t *testing.T) {
 		assert.False(t, isVirtualInterface(iface.Name),
 			"interface %s should not be a virtual interface", iface.Name)
 	}
+}
+
+// newTestService builds a discovery service that resolves names and runs its
+// watch loop without opening a socket or putting mDNS traffic on the tester's
+// network.
+func newTestService(t *testing.T, cfg *config.Instance) *Service {
+	t.Helper()
+
+	svc := New(cfg)
+	svc.clock = clockwork.NewFakeClock()
+	svc.listInterfaces = func() ([]net.Interface, error) { return nil, nil }
+	svc.newResponder = func(*mdns.Service, func(string, ...any)) responder {
+		return newFakeResponder()
+	}
+	return svc
+}
+
+func TestFirstLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		hostname string
+		expected string
+	}{
+		{"plain hostname", "MiSTer", "MiSTer"},
+		// A responder appends ".local", so a qualified name has to be cut
+		// back or it would be published as "mister.lan.local".
+		{"qualified hostname", "mister.lan", "mister"},
+		{"deeply qualified", "pc.office.example.com", "pc"},
+		{"already local", "batocera.local", "batocera"},
+		{"leading dot keeps the label", ".mister", ".mister"},
+		{"empty falls back", "", "zaparoo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, firstLabel(tt.hostname))
+		})
+	}
+}
+
+func TestFallbackInstanceName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "zaparoo-46ebdfcb",
+		fallbackInstanceName("46ebdfcb-51b7-4600-9c28-7970787b686b"),
+		"the name stays distinct when two devices cannot report a hostname")
+	assert.Equal(t, "zaparoo", fallbackInstanceName("short"))
+	assert.Equal(t, "zaparoo", fallbackInstanceName(""))
 }

--- a/pkg/service/discovery/discovery_test.go
+++ b/pkg/service/discovery/discovery_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,14 +36,50 @@ func TestServiceType(t *testing.T) {
 	assert.Equal(t, "_zaparoo._tcp", ServiceType)
 }
 
-// TestDefaultTXTRecordsAreEmpty pins the security-driven design that mDNS
-// service announcements carry NO TXT records. See defaultTXTRecords doc
-// comment for the rationale.
-func TestDefaultTXTRecordsAreEmpty(t *testing.T) {
+// TestDefaultTXTRecordsCarryNoData pins the security-driven design that mDNS
+// service announcements carry no TXT data, and the DNS-level requirement that
+// "no data" is spelled as one zero-length string. See the defaultTXTRecords
+// doc comment for the rationale.
+func TestDefaultTXTRecordsCarryNoData(t *testing.T) {
 	t.Parallel()
 
-	assert.Empty(t, defaultTXTRecords,
-		"mDNS TXT records must remain empty to avoid leaking version/platform/id on the LAN")
+	require.Len(t, defaultTXTRecords, 1,
+		"a TXT record needs exactly one character-string to encode 'no data'")
+	assert.Empty(t, defaultTXTRecords[0],
+		"mDNS TXT records must stay empty to avoid leaking version/platform/id on the LAN")
+}
+
+// TestDefaultTXTRecordsPackToOneEmptyString checks the wire encoding rather
+// than the Go value: an empty slice and a slice holding one empty string look
+// equally harmless in Go, but only the latter packs to a valid TXT record.
+// An empty slice yields rdlength 0, which resolvers are entitled to reject.
+func TestDefaultTXTRecordsPackToOneEmptyString(t *testing.T) {
+	t.Parallel()
+
+	txt := &dns.TXT{
+		Hdr: dns.RR_Header{
+			Name:   "zaparoo." + ServiceType + ".local.",
+			Rrtype: dns.TypeTXT,
+			Class:  dns.ClassINET,
+			Ttl:    120,
+		},
+		Txt: defaultTXTRecords,
+	}
+
+	msg := new(dns.Msg)
+	msg.Answer = []dns.RR{txt}
+	wire, err := msg.Pack()
+	require.NoError(t, err)
+
+	unpacked := new(dns.Msg)
+	require.NoError(t, unpacked.Unpack(wire), "packed TXT record must round-trip")
+	require.Len(t, unpacked.Answer, 1)
+
+	got, ok := unpacked.Answer[0].(*dns.TXT)
+	require.True(t, ok, "expected a TXT record, got %T", unpacked.Answer[0])
+	assert.Equal(t, uint16(1), got.Hdr.Rdlength,
+		"TXT rdata must be the single length byte of one zero-length string")
+	assert.Equal(t, []string{""}, got.Txt)
 }
 
 func TestStopIdempotent(t *testing.T) {
@@ -56,7 +93,7 @@ func TestStopIdempotent(t *testing.T) {
 	svc.Stop()
 
 	// No panic means success
-	assert.Nil(t, svc.server)
+	assert.Nil(t, svc.responder)
 }
 
 func TestInstanceNameBeforeStart(t *testing.T) {
@@ -100,10 +137,11 @@ func TestInstanceNameUsesHostname(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := New(cfg)
+	t.Cleanup(svc.Stop)
 
-	// Start will fail at zeroconf.Register, but instanceName is set
-	// before Register is called, so we can still verify the resolution
-	_ = svc.Start() // Ignore error - Register may fail without network
+	// Start may fail to open a socket, but instanceName is resolved before
+	// that happens, so the resolution is still observable.
+	_ = svc.Start() // Ignore error - registration may fail without network
 
 	// instanceName should be set to the hostname (since no config override)
 	assert.Equal(t, expectedHostname, svc.InstanceName())
@@ -120,7 +158,8 @@ func TestInstanceNameUsesConfigOverride(t *testing.T) {
 	cfg.SetDiscoveryInstanceName("my-custom-name")
 
 	svc := New(cfg)
-	_ = svc.Start() // Ignore error - Register may fail without network
+	t.Cleanup(svc.Stop)
+	_ = svc.Start() // Ignore error - registration may fail without network
 
 	// instanceName should use the config override, not hostname
 	assert.Equal(t, "my-custom-name", svc.InstanceName())
@@ -149,6 +188,10 @@ func TestIsVirtualInterface(t *testing.T) {
 		{"tunnel interface", "tunl0", true},
 		{"wireguard", "wg0", true},
 		{"wireguard numbered", "wg1", true},
+		{"hyper-v switch", "vEthernet (Default Switch)", true},
+		{"wsl switch", "vEthernet (WSL (Hyper-V firewall))", true},
+		{"vmware host-only", "VMware Network Adapter VMnet1", true},
+		{"virtualbox host-only", "VirtualBox Host-Only Network", true},
 
 		// Real interfaces that should NOT be filtered
 		{"ethernet", "eth0", false},
@@ -180,6 +223,7 @@ func TestVirtualInterfacePrefixes(t *testing.T) {
 	expectedPrefixes := []string{
 		"docker", "br-", "veth", "virbr", "lxc", "lxd",
 		"cni", "flannel", "cali", "tunl", "wg",
+		"vmware", "virtualbox",
 	}
 
 	assert.Equal(t, expectedPrefixes, virtualInterfacePrefixes,

--- a/pkg/service/discovery/main_test.go
+++ b/pkg/service/discovery/main_test.go
@@ -1,0 +1,35 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"go.uber.org/goleak"
+)
+
+// The responder runs receive and announce goroutines and the discovery
+// service runs an interface watcher, so a leak here means a socket or a
+// ticker outliving Stop.
+func TestMain(m *testing.M) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/service/discovery/mdns/addrs.go
+++ b/pkg/service/discovery/mdns/addrs.go
@@ -1,0 +1,99 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mdns
+
+import (
+	"fmt"
+	"net"
+)
+
+// InterfaceAddrs returns the addresses of iface worth putting in an mDNS
+// answer, split by family and in a stable order.
+//
+// IPv4 link-local addresses are dropped: Windows leaves a 169.254.0.0/16
+// address on adapters that are up but not connected to anything, and
+// advertising one sends clients to an address that cannot answer. IPv6
+// link-local addresses are only used when the interface has no other IPv6
+// address, matching what a client can actually reach without a scope id.
+func InterfaceAddrs(iface *net.Interface) (v4, v6 []net.IP, err error) {
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, nil, fmt.Errorf("list addresses for %s: %w", iface.Name, err)
+	}
+
+	v4, v6 = selectAddrs(addrs)
+	return v4, v6, nil
+}
+
+// selectAddrs applies the address rules described on InterfaceAddrs.
+func selectAddrs(addrs []net.Addr) (v4, v6 []net.IP) {
+	var v6Local []net.IP
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip := ipNet.IP
+		if ip.IsLoopback() || ip.IsUnspecified() || ip.IsMulticast() {
+			continue
+		}
+
+		if ip4 := ip.To4(); ip4 != nil {
+			if ip4.IsLinkLocalUnicast() {
+				continue
+			}
+			v4 = appendUniqueIP(v4, ip4)
+			continue
+		}
+
+		if ip.To16() == nil {
+			continue
+		}
+		if ip.IsLinkLocalUnicast() {
+			v6Local = appendUniqueIP(v6Local, ip)
+			continue
+		}
+		v6 = appendUniqueIP(v6, ip)
+	}
+
+	if len(v6) == 0 {
+		v6 = v6Local
+	}
+
+	return v4, v6
+}
+
+// HasUsableAddr reports whether iface has any address worth advertising.
+func HasUsableAddr(iface *net.Interface) bool {
+	v4, v6, err := InterfaceAddrs(iface)
+	if err != nil {
+		return false
+	}
+	return len(v4) > 0 || len(v6) > 0
+}
+
+func appendUniqueIP(list []net.IP, ip net.IP) []net.IP {
+	for _, existing := range list {
+		if existing.Equal(ip) {
+			return list
+		}
+	}
+	return append(list, ip)
+}

--- a/pkg/service/discovery/mdns/addrs.go
+++ b/pkg/service/discovery/mdns/addrs.go
@@ -80,15 +80,6 @@ func selectAddrs(addrs []net.Addr) (v4, v6 []net.IP) {
 	return v4, v6
 }
 
-// HasUsableAddr reports whether iface has any address worth advertising.
-func HasUsableAddr(iface *net.Interface) bool {
-	v4, v6, err := InterfaceAddrs(iface)
-	if err != nil {
-		return false
-	}
-	return len(v4) > 0 || len(v6) > 0
-}
-
 func appendUniqueIP(list []net.IP, ip net.IP) []net.IP {
 	for _, existing := range list {
 		if existing.Equal(ip) {

--- a/pkg/service/discovery/mdns/main_test.go
+++ b/pkg/service/discovery/mdns/main_test.go
@@ -1,0 +1,35 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mdns
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"go.uber.org/goleak"
+)
+
+// The responder runs receive and announce goroutines and the discovery
+// service runs an interface watcher, so a leak here means a socket or a
+// ticker outliving Stop.
+func TestMain(m *testing.M) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/service/discovery/mdns/mdns_test.go
+++ b/pkg/service/discovery/mdns/mdns_test.go
@@ -386,3 +386,462 @@ func TestBuildLinksDropsInterfacesWithoutUsableAddresses(t *testing.T) {
 	links := buildLinks([]net.Interface{{Index: 0, Name: "phantom0"}})
 	assert.Empty(t, links)
 }
+
+// twoLinks is a machine with a wired and a wireless interface on different
+// subnets, which is the shape that exposed the original bug.
+func twoLinks() []link {
+	return []link{
+		{
+			index: 14, name: "Ethernet 4",
+			addrs:    linkAddrs{v4: []net.IP{net.ParseIP("192.168.1.50").To4()}},
+			prefixes: []*net.IPNet{ipNet("192.168.1.50/24")},
+		},
+		{
+			index: 22, name: "Wi-Fi",
+			addrs:    linkAddrs{v4: []net.IP{net.ParseIP("10.0.0.241").To4()}},
+			prefixes: []*net.IPNet{ipNet("10.0.0.241/24")},
+		},
+	}
+}
+
+func browseQuery() *dns.Msg {
+	query := new(dns.Msg)
+	query.Id = 0x1234
+	query.Question = []dns.Question{{
+		Name:   "_zaparoo._tcp.local.",
+		Qtype:  dns.TypePTR,
+		Qclass: dns.ClassINET,
+	}}
+	return query
+}
+
+// mdnsPeer is a querier that is itself an mDNS responder, so it listens on the
+// mDNS port and expects a multicast answer.
+func mdnsPeer(ip string) *net.UDPAddr {
+	return &net.UDPAddr{IP: net.ParseIP(ip), Port: Port}
+}
+
+// legacyPeer is an ordinary DNS client that happened to ask the multicast
+// group from an ephemeral port. RFC 6762 section 6.7.
+func legacyPeer(ip string) *net.UDPAddr {
+	return &net.UDPAddr{IP: net.ParseIP(ip), Port: 51000}
+}
+
+func addrStrings(records []dns.RR) []string {
+	var out []string
+	for _, record := range records {
+		if a, ok := record.(*dns.A); ok {
+			out = append(out, a.A.String())
+		}
+	}
+	return out
+}
+
+func TestPlanRepliesAnswersOnEveryInterface(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	links := twoLinks()
+
+	replies := svc.planReplies(browseQuery(), links, mdnsPeer("10.0.0.167"))
+
+	require.Len(t, replies, 2, "every interface answers, not just the one the OS would route by")
+	byName := map[string][]string{}
+	for _, reply := range replies {
+		require.NotNil(t, reply.link)
+		require.Nil(t, reply.unicast)
+		assert.Zero(t, reply.msg.Id, "RFC 6762 18.1: a multicast response carries a zero id")
+		assert.Empty(t, reply.msg.Question, "RFC 6762 6: a response repeats no questions")
+		byName[reply.link.name] = addrStrings(reply.msg.Extra)
+	}
+
+	assert.Equal(t, []string{"192.168.1.50"}, byName["Ethernet 4"])
+	assert.Equal(t, []string{"10.0.0.241"}, byName["Wi-Fi"],
+		"each interface offers only an address reachable through it")
+}
+
+func TestPlanRepliesUnicastsWhenQUBitIsSet(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	links := twoLinks()
+
+	query := browseQuery()
+	query.Question[0].Qclass |= cacheFlush // the QU bit
+	from := mdnsPeer("192.168.1.7")
+
+	replies := svc.planReplies(query, links, from)
+
+	require.Len(t, replies, 1)
+	assert.Equal(t, from, replies[0].unicast)
+	assert.Nil(t, replies[0].link)
+	assert.Equal(t, query.Id, replies[0].msg.Id, "a unicast reply is matched by id")
+	assert.Empty(t, replies[0].msg.Question)
+	assert.Equal(t, []string{"192.168.1.50"}, addrStrings(replies[0].msg.Extra),
+		"the reply describes the interface the querier is on")
+}
+
+func TestPlanRepliesUsesLegacyShapeForNonMDNSPort(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	links := twoLinks()
+
+	// No QU bit: a legacy resolver does not know to set one, and would never
+	// see a multicast answer sent to port 5353.
+	query := browseQuery()
+	from := legacyPeer("10.0.0.167")
+
+	replies := svc.planReplies(query, links, from)
+
+	require.Len(t, replies, 1)
+	assert.Equal(t, from, replies[0].unicast)
+	assert.Equal(t, query.Id, replies[0].msg.Id)
+	assert.Equal(t, query.Question, replies[0].msg.Question,
+		"RFC 6762 6.7: a legacy client matches the answer by its question")
+	assert.Equal(t, []string{"10.0.0.241"}, addrStrings(replies[0].msg.Extra))
+
+	for _, record := range append(replies[0].msg.Answer, replies[0].msg.Extra...) {
+		assert.LessOrEqual(t, record.Header().Ttl, uint32(legacyTTL),
+			"legacy TTLs are capped because the client never sees the goodbye")
+		assert.Zero(t, record.Header().Class&cacheFlush,
+			"a legacy client has no mDNS cache to flush")
+	}
+}
+
+func TestPlanRepliesLegacyShapeWinsOverQUBit(t *testing.T) {
+	t.Parallel()
+
+	// The source port decides. A legacy client that happens to set the QU bit
+	// still needs its question echoed back.
+	svc := testService()
+	query := browseQuery()
+	query.Question[0].Qclass |= cacheFlush
+
+	replies := svc.planReplies(query, twoLinks(), legacyPeer("10.0.0.167"))
+
+	require.Len(t, replies, 1)
+	assert.Equal(t, query.Question, replies[0].msg.Question)
+}
+
+func TestPlanRepliesIgnoresWhatIsNotAQuery(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	links := twoLinks()
+	from := mdnsPeer("10.0.0.167")
+
+	t.Run("another responder's announcement", func(t *testing.T) {
+		t.Parallel()
+		query := browseQuery()
+		query.Response = true
+		assert.Empty(t, svc.planReplies(query, links, from))
+	})
+
+	t.Run("a probe", func(t *testing.T) {
+		t.Parallel()
+		// An authority section means the sender is probing for a name
+		// conflict. This responder does not take part in probing, and
+		// answering would look like a conflict to the prober.
+		query := browseQuery()
+		query.Ns = []dns.RR{&dns.SRV{Hdr: dns.RR_Header{
+			Name: svc.instanceName(), Rrtype: dns.TypeSRV, Class: dns.ClassINET,
+		}}}
+		assert.Empty(t, svc.planReplies(query, links, from))
+	})
+
+	t.Run("no questions", func(t *testing.T) {
+		t.Parallel()
+		query := browseQuery()
+		query.Question = nil
+		assert.Empty(t, svc.planReplies(query, links, from))
+	})
+
+	t.Run("a class we do not serve", func(t *testing.T) {
+		t.Parallel()
+		query := browseQuery()
+		query.Question[0].Qclass = dns.ClassCHAOS
+		assert.Empty(t, svc.planReplies(query, links, from))
+	})
+
+	t.Run("somebody else's service", func(t *testing.T) {
+		t.Parallel()
+		query := browseQuery()
+		query.Question[0].Name = "_http._tcp.local."
+		assert.Empty(t, svc.planReplies(query, links, from))
+	})
+
+	t.Run("no interfaces left", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, svc.planReplies(browseQuery(), nil, from))
+	})
+}
+
+func TestPlanRepliesAcceptsClassANY(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	query := browseQuery()
+	query.Question[0].Qclass = dns.ClassANY
+
+	assert.Len(t, svc.planReplies(query, twoLinks(), mdnsPeer("10.0.0.167")), 2)
+}
+
+func TestPlanRepliesAnswersEveryQuestionInOneMessage(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	query := browseQuery()
+	query.Question = append(query.Question, dns.Question{
+		Name:   svc.hostName(),
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	})
+
+	replies := svc.planReplies(query, twoLinks(), mdnsPeer("10.0.0.167"))
+
+	// Two interfaces, two questions.
+	assert.Len(t, replies, 4)
+}
+
+func TestPlanRepliesHonoursKnownAnswerSuppression(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	query := browseQuery()
+	query.Answer = []dns.RR{&dns.PTR{
+		Hdr: dns.RR_Header{
+			Name: svc.typeName(), Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: serviceTTL,
+		},
+		Ptr: svc.instanceName(),
+	}}
+
+	assert.Empty(t, svc.planReplies(query, twoLinks(), mdnsPeer("10.0.0.167")))
+}
+
+func TestStartWithoutUsableInterfaces(t *testing.T) {
+	t.Parallel()
+
+	r := New(&Service{Instance: "test", Type: "_zaparoo._tcp", Host: "test", Port: 7497, Text: []string{""}}, nil)
+	t.Cleanup(r.Stop)
+
+	require.ErrorIs(t, r.Start(nil), ErrNoInterfaces)
+	// Index 0 matches no real interface, so it contributes no address.
+	require.ErrorIs(t, r.Start([]net.Interface{{Index: 0, Name: "phantom0"}}), ErrNoInterfaces)
+	assert.Empty(t, r.Interfaces())
+}
+
+func TestStopIsSafeBeforeStartAndRepeatable(t *testing.T) {
+	t.Parallel()
+
+	r := New(&Service{Instance: "test", Type: "_zaparoo._tcp", Host: "test", Port: 7497, Text: []string{""}}, nil)
+
+	r.Stop()
+	r.Stop()
+	r.Stop()
+
+	assert.Empty(t, r.Interfaces())
+}
+
+func TestSetInterfacesBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	r := New(&Service{Instance: "test", Type: "_zaparoo._tcp", Host: "test", Port: 7497, Text: []string{""}}, nil)
+	t.Cleanup(r.Stop)
+
+	changed, err := r.SetInterfaces(nil)
+	assert.False(t, changed)
+	assert.ErrorIs(t, err, ErrNoSockets)
+}
+
+func TestStartAfterStopOpensNothing(t *testing.T) {
+	t.Parallel()
+
+	usable := usableInterface(t)
+
+	r := New(&Service{Instance: "test", Type: "_zaparoo._tcp", Host: "test", Port: 7497, Text: []string{""}}, nil)
+	r.Stop()
+
+	// The guard has to come before the sockets are opened, or a Stop racing
+	// with a Start leaves a listener behind on port 5353.
+	require.ErrorIs(t, r.Start([]net.Interface{usable}), ErrNoSockets)
+	assert.Empty(t, r.Interfaces())
+}
+
+// usableInterface returns a real interface that has an address worth
+// advertising, skipping the test when the machine has none.
+func usableInterface(t *testing.T) net.Interface {
+	t.Helper()
+
+	ifaces, err := net.Interfaces()
+	require.NoError(t, err)
+	for i := range ifaces {
+		if ifaces[i].Flags&net.FlagLoopback != 0 || ifaces[i].Flags&net.FlagUp == 0 {
+			continue
+		}
+		v4, v6, addrErr := InterfaceAddrs(&ifaces[i])
+		if addrErr == nil && (len(v4) > 0 || len(v6) > 0) {
+			return ifaces[i]
+		}
+	}
+	t.Skip("no network interface with a usable address")
+	return net.Interface{}
+}
+
+func TestPlanRepliesRejectsWrongTypeForAName(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	links := twoLinks()
+	from := mdnsPeer("10.0.0.167")
+
+	tests := []struct {
+		name  string
+		qname string
+		qtype uint16
+	}{
+		{"instance asked for an address", svc.instanceName(), dns.TypeA},
+		{"host asked for a service record", svc.hostName(), dns.TypeSRV},
+		{"enumeration asked for a service record", enumerationName, dns.TypeSRV},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			query := browseQuery()
+			query.Question[0] = dns.Question{Name: tt.qname, Qtype: tt.qtype, Qclass: dns.ClassINET}
+			assert.Empty(t, svc.planReplies(query, links, from))
+		})
+	}
+}
+
+func TestPlanRepliesAnswersTypeANY(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	links := twoLinks()
+	from := mdnsPeer("10.0.0.167")
+
+	t.Run("instance", func(t *testing.T) {
+		t.Parallel()
+		query := browseQuery()
+		query.Question[0] = dns.Question{Name: svc.instanceName(), Qtype: dns.TypeANY, Qclass: dns.ClassINET}
+		assert.Len(t, svc.planReplies(query, links, from), 2)
+	})
+
+	t.Run("host", func(t *testing.T) {
+		t.Parallel()
+		query := browseQuery()
+		query.Question[0] = dns.Question{Name: svc.hostName(), Qtype: dns.TypeANY, Qclass: dns.ClassINET}
+		replies := svc.planReplies(query, links, from)
+		require.Len(t, replies, 2)
+		assert.Equal(t, []string{"192.168.1.50"}, addrStrings(replies[0].msg.Answer))
+	})
+}
+
+func TestIsKnownAnswerIgnoresUnrelatedRecords(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	answer := []dns.RR{svc.ptr(serviceTTL)}
+
+	query := new(dns.Msg)
+	query.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: svc.hostName(), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: hostTTL},
+		A:   net.ParseIP("10.0.0.241").To4(),
+	}}
+	assert.False(t, isKnownAnswer(answer, query),
+		"an address the querier already has says nothing about the service record")
+
+	assert.False(t, isKnownAnswer(nil, query))
+	assert.False(t, isKnownAnswer(answer, new(dns.Msg)))
+
+	// Suppression only applies to the shared PTR; an answer led by anything
+	// else is not a known-answer candidate.
+	assert.False(t, isKnownAnswer([]dns.RR{svc.srv(serviceTTL, false)}, query))
+}
+
+func TestSelectAddrsIgnoresNonPrefixAddresses(t *testing.T) {
+	t.Parallel()
+
+	// Interface address tables can yield plain *net.IPAddr entries, which
+	// carry no prefix and are not what an A record is built from.
+	v4, v6 := selectAddrs([]net.Addr{
+		&net.IPAddr{IP: net.ParseIP("10.0.0.241")},
+		ipNet("10.0.0.241/24"),
+	})
+
+	require.Len(t, v4, 1)
+	assert.Empty(t, v6)
+}
+
+func TestSameIPsComparesLength(t *testing.T) {
+	t.Parallel()
+
+	one := []net.IP{net.ParseIP("10.0.0.241").To4()}
+	two := append([]net.IP{}, one...)
+	two = append(two, net.ParseIP("10.0.0.242").To4())
+
+	assert.False(t, sameIPs(one, two))
+	assert.True(t, sameIPs(one, one))
+}
+
+func TestDiffLinksSeesAnAddressAppearing(t *testing.T) {
+	t.Parallel()
+
+	before := link{index: 22, name: "Wi-Fi", addrs: linkAddrs{v4: []net.IP{net.ParseIP("10.0.0.241").To4()}}}
+	after := before
+	after.addrs = linkAddrs{
+		v4: []net.IP{net.ParseIP("10.0.0.241").To4()},
+		v6: []net.IP{net.ParseIP("2403:580e:2024::1")},
+	}
+
+	_, _, readdressed := diffLinks([]link{before}, []link{after})
+	require.Len(t, readdressed, 1)
+	assert.Equal(t, "Wi-Fi", readdressed[0].name)
+}
+
+func TestHandlePacketSurvivesRubbishOnTheWire(t *testing.T) {
+	t.Parallel()
+
+	// Anything on the LAN can send to the multicast group, so a packet that
+	// does not parse must be dropped rather than take the responder down.
+	r := New(&Service{Instance: "test", Type: "_zaparoo._tcp", Host: "test", Port: 7497, Text: []string{""}}, nil)
+	t.Cleanup(r.Stop)
+
+	from := &net.UDPAddr{IP: net.ParseIP("10.0.0.167"), Port: Port}
+	r.handlePacket([]byte{0x00}, from)
+	r.handlePacket(nil, from)
+	r.handlePacket([]byte("not a dns message at all"), from)
+}
+
+func TestSendingWithoutSocketsIsHarmless(t *testing.T) {
+	t.Parallel()
+
+	// Stop closes the sockets while an announcement may still be in flight.
+	// That path has to fall through quietly rather than panic.
+	svc := testService()
+	r := New(&svc, nil)
+	t.Cleanup(r.Stop)
+
+	links := twoLinks()
+	r.sendRecords(links, func(l link) []dns.RR {
+		return r.svc.lookupAnswer(l.addrs, serviceTTL, true)
+	})
+	r.writeUnicast(newReply(1, []dns.RR{svc.ptr(serviceTTL)}, nil),
+		&net.UDPAddr{IP: net.ParseIP("10.0.0.167"), Port: Port})
+	r.writeUnicast(newReply(1, []dns.RR{svc.ptr(serviceTTL)}, nil),
+		&net.UDPAddr{IP: net.ParseIP("fd89:8088:c6b4::1"), Port: Port})
+}
+
+func TestAnnounceAfterStopStartsNoGoroutine(t *testing.T) {
+	t.Parallel()
+
+	// goleak in TestMain is the real assertion here: an announcement queued
+	// after Stop would outlive the responder and race its WaitGroup.
+	svc := testService()
+	r := New(&svc, nil)
+	r.Stop()
+
+	r.announce(twoLinks())
+}

--- a/pkg/service/discovery/mdns/mdns_test.go
+++ b/pkg/service/discovery/mdns/mdns_test.go
@@ -1,0 +1,388 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mdns
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testService() Service {
+	return Service{
+		Instance: "DESKTOP-I500VAN",
+		Type:     "_zaparoo._tcp",
+		Host:     "DESKTOP-I500VAN",
+		Port:     7497,
+		Text:     []string{""},
+	}
+}
+
+func testAddrs() linkAddrs {
+	return linkAddrs{
+		v4: []net.IP{net.ParseIP("10.0.0.241").To4()},
+		v6: []net.IP{net.ParseIP("2403:580e:2024::1")},
+	}
+}
+
+func ipNet(cidr string) *net.IPNet {
+	ip, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	network.IP = ip
+	return network
+}
+
+func TestSelectAddrsDropsIPv4LinkLocal(t *testing.T) {
+	t.Parallel()
+
+	// A Windows adapter that is up but not connected keeps an APIPA address.
+	// Advertising it sends clients somewhere that cannot answer.
+	v4, v6 := selectAddrs([]net.Addr{
+		ipNet("169.254.194.210/16"),
+		ipNet("10.0.0.241/24"),
+	})
+
+	require.Len(t, v4, 1)
+	assert.Equal(t, "10.0.0.241", v4[0].String())
+	assert.Empty(t, v6)
+}
+
+func TestSelectAddrsDropsAPIPAOnlyInterface(t *testing.T) {
+	t.Parallel()
+
+	v4, v6 := selectAddrs([]net.Addr{ipNet("169.254.67.14/16")})
+
+	assert.Empty(t, v4)
+	assert.Empty(t, v6)
+	assert.True(t, linkAddrs{v4: v4, v6: v6}.empty())
+}
+
+func TestSelectAddrsPrefersGlobalIPv6(t *testing.T) {
+	t.Parallel()
+
+	_, v6 := selectAddrs([]net.Addr{
+		ipNet("fe80::d2e8:f3c7:2af0:9cd4/64"),
+		ipNet("2403:580e:2024::1/64"),
+		ipNet("fd89:8088:c6b4::1/64"),
+	})
+
+	require.Len(t, v6, 2, "link-local is dropped when routable addresses exist")
+	assert.Equal(t, "2403:580e:2024::1", v6[0].String())
+	assert.Equal(t, "fd89:8088:c6b4::1", v6[1].String())
+}
+
+func TestSelectAddrsFallsBackToIPv6LinkLocal(t *testing.T) {
+	t.Parallel()
+
+	_, v6 := selectAddrs([]net.Addr{ipNet("fe80::d2e8:f3c7:2af0:9cd4/64")})
+
+	require.Len(t, v6, 1)
+	assert.Equal(t, "fe80::d2e8:f3c7:2af0:9cd4", v6[0].String())
+}
+
+func TestSelectAddrsSkipsLoopbackAndDuplicates(t *testing.T) {
+	t.Parallel()
+
+	v4, v6 := selectAddrs([]net.Addr{
+		ipNet("127.0.0.1/8"),
+		ipNet("::1/128"),
+		ipNet("10.0.0.241/24"),
+		ipNet("10.0.0.241/24"),
+	})
+
+	require.Len(t, v4, 1)
+	assert.Empty(t, v6)
+}
+
+func TestServiceNames(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+
+	assert.Equal(t, "_zaparoo._tcp.local.", svc.typeName())
+	assert.Equal(t, "DESKTOP-I500VAN._zaparoo._tcp.local.", svc.instanceName())
+	assert.Equal(t, "DESKTOP-I500VAN.local.", svc.hostName())
+}
+
+func TestInstanceNameEscapesDots(t *testing.T) {
+	t.Parallel()
+
+	// RFC 6763 4.1.1 allows dots in an instance name; they are a literal part
+	// of the label, not a label separator.
+	svc := testService()
+	svc.Instance = "Callan's PC v1.2"
+
+	name := svc.instanceName()
+	assert.Equal(t, `Callan's PC v1\.2._zaparoo._tcp.local.`, name)
+
+	packed, err := dns.PackDomainName(name, make([]byte, 256), 0, nil, false)
+	require.NoError(t, err, "an escaped instance name must still pack")
+	assert.Positive(t, packed)
+}
+
+func TestBrowsingAnswerCarriesEverythingNeededToConnect(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	answer, extra := svc.browsingAnswer(testAddrs())
+
+	require.Len(t, answer, 1)
+	ptr, ok := answer[0].(*dns.PTR)
+	require.True(t, ok)
+	assert.Equal(t, "_zaparoo._tcp.local.", ptr.Hdr.Name)
+	assert.Equal(t, "DESKTOP-I500VAN._zaparoo._tcp.local.", ptr.Ptr)
+	assert.Equal(t, dns.ClassINET, int(ptr.Hdr.Class),
+		"a PTR is a shared record and must not set the cache-flush bit")
+
+	types := make([]uint16, len(extra))
+	for i, record := range extra {
+		types[i] = record.Header().Rrtype
+	}
+	assert.Equal(t, []uint16{dns.TypeSRV, dns.TypeTXT, dns.TypeA, dns.TypeAAAA}, types)
+}
+
+func TestLookupAnswerSetsCacheFlushOnUniqueRecords(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	answer := svc.lookupAnswer(testAddrs(), serviceTTL, true)
+
+	flushed := map[uint16]bool{}
+	for _, record := range answer {
+		flushed[record.Header().Rrtype] = record.Header().Class&cacheFlush != 0
+	}
+
+	assert.True(t, flushed[dns.TypeSRV])
+	assert.True(t, flushed[dns.TypeTXT])
+	assert.True(t, flushed[dns.TypeA])
+	assert.False(t, flushed[dns.TypePTR], "shared PTR records are never cache-flushed")
+}
+
+func TestGoodbyeZeroesEveryTTL(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	answer := svc.lookupAnswer(testAddrs(), 0, true)
+
+	require.NotEmpty(t, answer)
+	for _, record := range answer {
+		assert.Zero(t, record.Header().Ttl,
+			"a goodbye must expire address records too, not just service records")
+	}
+}
+
+func TestAddrRecordsAreScopedToOneInterface(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	wifi := linkAddrs{v4: []net.IP{net.ParseIP("10.0.0.241").To4()}}
+	wired := linkAddrs{v4: []net.IP{net.ParseIP("192.168.1.50").To4()}}
+
+	wifiRecords := svc.addrRecords(wifi, hostTTL, false)
+	wiredRecords := svc.addrRecords(wired, hostTTL, false)
+
+	require.Len(t, wifiRecords, 1)
+	require.Len(t, wiredRecords, 1)
+	assert.Equal(t, "10.0.0.241", wifiRecords[0].(*dns.A).A.String())
+	assert.Equal(t, "192.168.1.50", wiredRecords[0].(*dns.A).A.String())
+}
+
+func TestResponsePacksValidTXTRecord(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	answer, extra := svc.browsingAnswer(testAddrs())
+
+	wire, err := newReply(0, answer, extra).Pack()
+	require.NoError(t, err)
+
+	unpacked := new(dns.Msg)
+	require.NoError(t, unpacked.Unpack(wire),
+		"a response with a zero-length TXT rdata fails to parse in strict resolvers")
+
+	var txt *dns.TXT
+	for _, record := range unpacked.Extra {
+		if candidate, ok := record.(*dns.TXT); ok {
+			txt = candidate
+		}
+	}
+	require.NotNil(t, txt)
+	assert.Equal(t, uint16(1), txt.Hdr.Rdlength,
+		"TXT rdata must be one zero-length string, not an empty record")
+}
+
+func TestAnswersForRoutesByQuestion(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	addrs := testAddrs()
+
+	tests := []struct {
+		name        string
+		qname       string
+		wantFirst   uint16
+		qtype       uint16
+		wantAnswers bool
+	}{
+		{"service type browse", "_zaparoo._tcp.local.", dns.TypePTR, dns.TypePTR, true},
+		{"type enumeration", enumerationName, dns.TypePTR, dns.TypePTR, true},
+		{"instance lookup", "DESKTOP-I500VAN._zaparoo._tcp.local.", dns.TypeSRV, dns.TypeSRV, true},
+		{"host A", "DESKTOP-I500VAN.local.", dns.TypeA, dns.TypeA, true},
+		{"host AAAA", "DESKTOP-I500VAN.local.", dns.TypeAAAA, dns.TypeAAAA, true},
+		{"case insensitive", "_ZAPAROO._TCP.local.", dns.TypePTR, dns.TypePTR, true},
+		{"someone else's service", "_http._tcp.local.", 0, dns.TypePTR, false},
+		{"wrong type for browse", "_zaparoo._tcp.local.", 0, dns.TypeSRV, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			question := dns.Question{Name: tt.qname, Qtype: tt.qtype, Qclass: dns.ClassINET}
+			answer, _ := svc.answersFor(question, new(dns.Msg), addrs)
+
+			if !tt.wantAnswers {
+				assert.Empty(t, answer)
+				return
+			}
+			require.NotEmpty(t, answer)
+			assert.Equal(t, tt.wantFirst, answer[0].Header().Rrtype)
+		})
+	}
+}
+
+func TestAnswersForSuppressesKnownAnswer(t *testing.T) {
+	t.Parallel()
+
+	svc := testService()
+	question := dns.Question{Name: svc.typeName(), Qtype: dns.TypePTR, Qclass: dns.ClassINET}
+
+	query := new(dns.Msg)
+	query.Answer = []dns.RR{&dns.PTR{
+		Hdr: dns.RR_Header{Name: svc.typeName(), Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: serviceTTL},
+		Ptr: svc.instanceName(),
+	}}
+
+	answer, _ := svc.answersFor(question, query, testAddrs())
+	assert.Empty(t, answer, "RFC 6762 7.1: stay quiet when the querier already knows")
+
+	// A nearly expired known answer is not good enough to stay quiet about.
+	query.Answer[0].Header().Ttl = serviceTTL/2 - 1
+	answer, _ = svc.answersFor(question, query, testAddrs())
+	assert.NotEmpty(t, answer)
+}
+
+func TestWantsUnicast(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, wantsUnicast(dns.Question{Qclass: dns.ClassINET}))
+	assert.True(t, wantsUnicast(dns.Question{Qclass: dns.ClassINET | cacheFlush}))
+}
+
+func TestDiffLinks(t *testing.T) {
+	t.Parallel()
+
+	wifi := link{index: 22, name: "Wi-Fi", addrs: linkAddrs{v4: []net.IP{net.ParseIP("10.0.0.241").To4()}}}
+	wired := link{index: 14, name: "Ethernet 4", addrs: linkAddrs{v4: []net.IP{net.ParseIP("192.168.1.50").To4()}}}
+	wifiMoved := link{index: 22, name: "Wi-Fi", addrs: linkAddrs{v4: []net.IP{net.ParseIP("10.0.0.99").To4()}}}
+
+	t.Run("cable plugged in", func(t *testing.T) {
+		t.Parallel()
+		added, removed, readdressed := diffLinks([]link{wifi}, []link{wifi, wired})
+		require.Len(t, added, 1)
+		assert.Equal(t, "Ethernet 4", added[0].name)
+		assert.Empty(t, removed)
+		assert.Empty(t, readdressed)
+	})
+
+	t.Run("cable pulled out", func(t *testing.T) {
+		t.Parallel()
+		added, removed, readdressed := diffLinks([]link{wifi, wired}, []link{wifi})
+		assert.Empty(t, added)
+		require.Len(t, removed, 1)
+		assert.Equal(t, "Ethernet 4", removed[0].name)
+		assert.Empty(t, readdressed)
+	})
+
+	t.Run("new dhcp lease", func(t *testing.T) {
+		t.Parallel()
+		added, removed, readdressed := diffLinks([]link{wifi}, []link{wifiMoved})
+		assert.Empty(t, added)
+		assert.Empty(t, removed)
+		require.Len(t, readdressed, 1)
+		assert.Equal(t, "Wi-Fi", readdressed[0].name)
+	})
+
+	t.Run("nothing changed", func(t *testing.T) {
+		t.Parallel()
+		added, removed, readdressed := diffLinks([]link{wifi, wired}, []link{wired, wifi})
+		assert.Empty(t, added)
+		assert.Empty(t, removed)
+		assert.Empty(t, readdressed)
+	})
+}
+
+func TestLinkForMatchesRequesterSubnet(t *testing.T) {
+	t.Parallel()
+
+	wifi := link{
+		index: 22, name: "Wi-Fi",
+		prefixes: []*net.IPNet{ipNet("10.0.0.241/24")},
+	}
+	wired := link{
+		index: 14, name: "Ethernet 4",
+		prefixes: []*net.IPNet{ipNet("192.168.1.50/24")},
+	}
+	links := []link{wifi, wired}
+
+	assert.Equal(t, "Ethernet 4",
+		linkFor(links, &net.UDPAddr{IP: net.ParseIP("192.168.1.7")}).name)
+	assert.Equal(t, "Wi-Fi",
+		linkFor(links, &net.UDPAddr{IP: net.ParseIP("10.0.0.167")}).name)
+	assert.Equal(t, "Wi-Fi",
+		linkFor(links, &net.UDPAddr{IP: net.ParseIP("172.16.0.1")}).name,
+		"an unmatched requester still gets an answer rather than silence")
+}
+
+func TestLinkForUsesIPv6Zone(t *testing.T) {
+	t.Parallel()
+
+	links := []link{
+		{index: 22, name: "Wi-Fi"},
+		{index: 14, name: "Ethernet 4"},
+	}
+
+	from := &net.UDPAddr{IP: net.ParseIP("fe80::1"), Zone: "Ethernet 4"}
+	assert.Equal(t, "Ethernet 4", linkFor(links, from).name)
+}
+
+func TestBuildLinksDropsInterfacesWithoutUsableAddresses(t *testing.T) {
+	t.Parallel()
+
+	// Index 0 never matches a real interface, so Addrs() returns nothing and
+	// the interface is dropped rather than advertised with no address.
+	links := buildLinks([]net.Interface{{Index: 0, Name: "phantom0"}})
+	assert.Empty(t, links)
+}

--- a/pkg/service/discovery/mdns/records.go
+++ b/pkg/service/discovery/mdns/records.go
@@ -1,0 +1,250 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mdns
+
+import (
+	"net"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+const (
+	// serviceTTL is the TTL for records naming a service rather than a host.
+	// RFC 6762 section 10 recommends 75 minutes.
+	serviceTTL uint32 = 4500
+
+	// hostTTL is the TTL for A and AAAA records. RFC 6762 section 10
+	// recommends 120 seconds so that address changes propagate quickly.
+	hostTTL uint32 = 120
+
+	// cacheFlush is the top bit of an rrclass in a response, telling
+	// receivers to replace rather than add to what they have cached.
+	// RFC 6762 section 10.2.
+	cacheFlush uint16 = 1 << 15
+
+	// enumerationName is the meta-query answered with the service types this
+	// responder offers. RFC 6763 section 9.
+	enumerationName = "_services._dns-sd._udp.local."
+)
+
+// Service describes the DNS-SD service being advertised.
+type Service struct {
+	// Instance is the human-facing name, usually the device hostname.
+	Instance string
+	// Type is the service type, e.g. "_zaparoo._tcp".
+	Type string
+	// Host is the unqualified host label the SRV record targets.
+	Host string
+	// Text is the TXT record content. One zero-length string means
+	// "no data"; an empty slice is not a valid TXT record.
+	Text []string
+	// Port is the TCP port the service listens on.
+	Port uint16
+}
+
+// typeName is the fully qualified service type, e.g. "_zaparoo._tcp.local.".
+func (s *Service) typeName() string {
+	return strings.Trim(s.Type, ".") + ".local."
+}
+
+// instanceName is the fully qualified service instance name.
+func (s *Service) instanceName() string {
+	return dns.Fqdn(escapeInstance(s.Instance) + "." + s.typeName())
+}
+
+// hostName is the fully qualified host name the SRV record points at.
+func (s *Service) hostName() string {
+	return dns.Fqdn(strings.Trim(s.Host, ".") + ".local.")
+}
+
+// escapeInstance escapes the label separators DNS-SD allows to appear
+// literally in an instance name. RFC 6763 section 4.1.1.
+func escapeInstance(instance string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `.`, `\.`)
+	return replacer.Replace(instance)
+}
+
+// ptr is the shared PTR record that makes the instance show up in a browse.
+func (s *Service) ptr(ttl uint32) dns.RR {
+	return &dns.PTR{
+		Hdr: dns.RR_Header{
+			Name:   s.typeName(),
+			Rrtype: dns.TypePTR,
+			Class:  dns.ClassINET,
+			Ttl:    ttl,
+		},
+		Ptr: s.instanceName(),
+	}
+}
+
+// enumerationPTR advertises the service type in the DNS-SD meta-query.
+func (s *Service) enumerationPTR(ttl uint32) dns.RR {
+	return &dns.PTR{
+		Hdr: dns.RR_Header{
+			Name:   enumerationName,
+			Rrtype: dns.TypePTR,
+			Class:  dns.ClassINET,
+			Ttl:    ttl,
+		},
+		Ptr: s.typeName(),
+	}
+}
+
+func (s *Service) srv(ttl uint32, flush bool) dns.RR {
+	return &dns.SRV{
+		Hdr: dns.RR_Header{
+			Name:   s.instanceName(),
+			Rrtype: dns.TypeSRV,
+			Class:  dns.ClassINET | flushBit(flush),
+			Ttl:    ttl,
+		},
+		Priority: 0,
+		Weight:   0,
+		Port:     s.Port,
+		Target:   s.hostName(),
+	}
+}
+
+func (s *Service) txt(ttl uint32, flush bool) dns.RR {
+	return &dns.TXT{
+		Hdr: dns.RR_Header{
+			Name:   s.instanceName(),
+			Rrtype: dns.TypeTXT,
+			Class:  dns.ClassINET | flushBit(flush),
+			Ttl:    ttl,
+		},
+		Txt: s.Text,
+	}
+}
+
+// addrRecords returns the A and AAAA records for one interface's addresses.
+// Every link answers with only its own addresses, so a client never learns an
+// address belonging to an interface it cannot reach.
+func (s *Service) addrRecords(addrs linkAddrs, ttl uint32, flush bool) []dns.RR {
+	records := make([]dns.RR, 0, len(addrs.v4)+len(addrs.v6))
+	host := s.hostName()
+	class := dns.ClassINET | flushBit(flush)
+
+	for _, ip := range addrs.v4 {
+		records = append(records, &dns.A{
+			Hdr: dns.RR_Header{Name: host, Rrtype: dns.TypeA, Class: class, Ttl: ttl},
+			A:   ip,
+		})
+	}
+	for _, ip := range addrs.v6 {
+		records = append(records, &dns.AAAA{
+			Hdr:  dns.RR_Header{Name: host, Rrtype: dns.TypeAAAA, Class: class, Ttl: ttl},
+			AAAA: ip,
+		})
+	}
+
+	return records
+}
+
+// browsingAnswer answers a query for the service type: the PTR in the answer
+// section, with everything needed to use the service in the additional section
+// so the client does not have to ask again.
+func (s *Service) browsingAnswer(addrs linkAddrs) (answer, extra []dns.RR) {
+	answer = []dns.RR{s.ptr(serviceTTL)}
+	extra = append(extra, s.srv(serviceTTL, false), s.txt(serviceTTL, false))
+	extra = append(extra, s.addrRecords(addrs, hostTTL, false)...)
+	return answer, extra
+}
+
+// lookupAnswer answers a query for the instance name, and is also the record
+// set used for unsolicited announcements and goodbyes.
+func (s *Service) lookupAnswer(addrs linkAddrs, ttl uint32, flush bool) []dns.RR {
+	hostRecordTTL := hostTTL
+	if ttl == 0 {
+		// A goodbye zeroes every TTL, host records included.
+		hostRecordTTL = 0
+	}
+
+	addrRecords := s.addrRecords(addrs, hostRecordTTL, flush)
+	answer := make([]dns.RR, 0, 4+len(addrRecords))
+	answer = append(answer,
+		s.srv(ttl, flush),
+		s.txt(ttl, flush),
+		s.ptr(ttl),
+		s.enumerationPTR(ttl),
+	)
+	return append(answer, addrRecords...)
+}
+
+// hostAnswer answers a direct query for the host's A or AAAA records.
+func (s *Service) hostAnswer(addrs linkAddrs, qtype uint16) []dns.RR {
+	records := s.addrRecords(addrs, hostTTL, true)
+	matched := make([]dns.RR, 0, len(records))
+	for _, record := range records {
+		if record.Header().Rrtype == qtype {
+			matched = append(matched, record)
+		}
+	}
+	return matched
+}
+
+// linkAddrs holds the addresses of a single network interface.
+type linkAddrs struct {
+	v4 []net.IP
+	v6 []net.IP
+}
+
+func (a linkAddrs) empty() bool {
+	return len(a.v4) == 0 && len(a.v6) == 0
+}
+
+func flushBit(flush bool) uint16 {
+	if flush {
+		return cacheFlush
+	}
+	return 0
+}
+
+// wantsUnicast reports whether the querier asked for a unicast reply.
+// RFC 6762 section 18.12 repurposes the top bit of qclass for this.
+func wantsUnicast(q dns.Question) bool {
+	return q.Qclass&cacheFlush != 0
+}
+
+// isKnownAnswer reports whether the querier already listed our PTR with at
+// least half its TTL left, in which case RFC 6762 section 7.1 says stay quiet.
+func isKnownAnswer(answer []dns.RR, query *dns.Msg) bool {
+	if len(answer) == 0 || len(query.Answer) == 0 {
+		return false
+	}
+
+	ptr, ok := answer[0].(*dns.PTR)
+	if !ok {
+		return false
+	}
+
+	for _, known := range query.Answer {
+		knownPTR, ok := known.(*dns.PTR)
+		if !ok {
+			continue
+		}
+		if knownPTR.Ptr == ptr.Ptr && knownPTR.Hdr.Ttl >= ptr.Hdr.Ttl/2 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/service/discovery/mdns/responder.go
+++ b/pkg/service/discovery/mdns/responder.go
@@ -1,0 +1,716 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package mdns advertises a single DNS-SD service over multicast DNS.
+//
+// It exists because grandcat/zeroconf picks the outgoing interface with a
+// per-packet control message, and golang.org/x/net leaves control messages
+// unimplemented on Windows (ipv4/control_windows.go, ipv4/sys_windows.go).
+// Every announcement and response there leaves by whichever interface the
+// routing table happens to pick, so only one NIC on a multi-homed Windows
+// machine is ever discoverable. This package selects the interface with
+// IP_MULTICAST_IF instead, which x/net does support on Windows, and gives each
+// interface its own address records so a client is never handed an address on
+// a network it cannot reach.
+package mdns
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/miekg/dns"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+const (
+	// Port is the mDNS port. RFC 6762 section 5.
+	Port = 5353
+
+	// multicastHops is the TTL/hop limit mandated by RFC 6762 section 11.
+	multicastHops = 255
+
+	// announceCount is how many unsolicited announcements are sent when a
+	// service or interface appears. RFC 6762 section 8.3 asks for at least
+	// two, one second apart.
+	announceCount = 2
+
+	// announceInterval is the gap between those announcements.
+	announceInterval = time.Second
+
+	// maxPacketSize bounds a single read. RFC 6762 section 17 caps an mDNS
+	// message at the interface MTU, but jumbo frames and IP fragmentation
+	// make a generous buffer cheaper than a truncated parse.
+	maxPacketSize = 9000
+)
+
+var (
+	groupIPv4 = net.IPv4(224, 0, 0, 251)
+	groupIPv6 = net.ParseIP("ff02::fb")
+
+	// Binding to the group address rather than the wildcard keeps unicast
+	// traffic on port 5353 with whichever other mDNS stack is running on
+	// this host, instead of competing for it.
+	listenAddrIPv4 = &net.UDPAddr{IP: net.IPv4(224, 0, 0, 0), Port: Port}
+	listenAddrIPv6 = &net.UDPAddr{IP: net.ParseIP("ff02::"), Port: Port}
+
+	sendAddrIPv4 = &net.UDPAddr{IP: groupIPv4, Port: Port}
+	sendAddrIPv6 = &net.UDPAddr{IP: groupIPv6, Port: Port}
+
+	// ErrNoInterfaces means there was nothing to advertise on.
+	ErrNoInterfaces = errors.New("no usable network interfaces for mDNS")
+	// ErrNoSockets means neither address family could be opened.
+	ErrNoSockets = errors.New("could not open an mDNS socket on any address family")
+)
+
+// link is one network interface the responder advertises on.
+type link struct {
+	name     string
+	addrs    linkAddrs
+	prefixes []*net.IPNet
+	iface    net.Interface
+	index    int
+}
+
+// Responder advertises one DNS-SD service on a set of interfaces.
+type Responder struct {
+	v4      *ipv4.PacketConn
+	v6      *ipv6.PacketConn
+	done    chan struct{}
+	logf    func(format string, args ...any)
+	links   []link
+	svc     Service
+	wg      sync.WaitGroup
+	mu      syncutil.Mutex
+	started bool
+	stopped bool
+}
+
+// New creates a responder for svc. logf, if set, receives non-fatal socket
+// errors; the caller decides how loud they should be.
+func New(svc *Service, logf func(format string, args ...any)) *Responder {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &Responder{
+		svc:  *svc,
+		logf: logf,
+		done: make(chan struct{}),
+	}
+}
+
+// Start opens sockets, joins the mDNS groups on every usable interface in
+// ifaces, and announces the service.
+func (r *Responder) Start(ifaces []net.Interface) error {
+	links := buildLinks(ifaces)
+	if len(links) == 0 {
+		return ErrNoInterfaces
+	}
+
+	conn4, err4 := listenIPv4(links)
+	conn6, err6 := listenIPv6(links)
+	if conn4 == nil && conn6 == nil {
+		//nolint:errorlint // both causes are reported together for diagnosis
+		return fmt.Errorf("%w: ipv4: %v, ipv6: %v", ErrNoSockets, err4, err6)
+	}
+
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		closeConns(conn4, conn6)
+		return ErrNoSockets
+	}
+	r.v4, r.v6 = conn4, conn6
+	r.links = links
+	r.started = true
+	// Counted under the lock so that a Stop racing with Start cannot reach
+	// wg.Wait() while the counter is still zero.
+	if conn4 != nil {
+		r.wg.Add(1)
+	}
+	if conn6 != nil {
+		r.wg.Add(1)
+	}
+	r.mu.Unlock()
+
+	if conn4 != nil {
+		go r.receiveIPv4(conn4)
+	}
+	if conn6 != nil {
+		go r.receiveIPv6(conn6)
+	}
+
+	r.announce(links)
+
+	return nil
+}
+
+// Interfaces returns the names of the interfaces currently advertised on.
+func (r *Responder) Interfaces() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	names := make([]string, len(r.links))
+	for i := range r.links {
+		names[i] = r.links[i].name
+	}
+	return names
+}
+
+// SetInterfaces reconciles the advertised interface set with ifaces. Interfaces
+// that went away get a goodbye, new ones get joined and announced, and ones
+// whose addresses changed get re-announced. It is the mechanism that makes a
+// cable plugged in after startup discoverable without restarting Core.
+func (r *Responder) SetInterfaces(ifaces []net.Interface) (changed bool, err error) {
+	next := buildLinks(ifaces)
+
+	r.mu.Lock()
+	if !r.started || r.stopped {
+		r.mu.Unlock()
+		return false, ErrNoSockets
+	}
+	previous := r.links
+	added, removed, readdressed := diffLinks(previous, next)
+	if len(added) == 0 && len(removed) == 0 && len(readdressed) == 0 {
+		r.mu.Unlock()
+		return false, nil
+	}
+	conn4, conn6 := r.v4, r.v6
+	r.mu.Unlock()
+
+	// Say goodbye while the group membership is still in place, otherwise
+	// the packet has no interface to leave by.
+	if len(removed) > 0 {
+		r.sendRecords(removed, func(l link) []dns.RR {
+			return r.svc.lookupAnswer(l.addrs, 0, true)
+		})
+		for i := range removed {
+			leaveGroups(conn4, conn6, &removed[i])
+		}
+	}
+
+	for i := range added {
+		joinGroups(conn4, conn6, &added[i], r.logf)
+	}
+
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return true, nil
+	}
+	r.links = next
+	r.mu.Unlock()
+
+	announceOn := make([]link, 0, len(added)+len(readdressed))
+	announceOn = append(announceOn, added...)
+	announceOn = append(announceOn, readdressed...)
+	if len(announceOn) > 0 {
+		r.announce(announceOn)
+	}
+
+	return true, nil
+}
+
+// Stop sends a goodbye for every interface and closes the sockets.
+func (r *Responder) Stop() {
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return
+	}
+	r.stopped = true
+	links := r.links
+	conn4, conn6 := r.v4, r.v6
+	started := r.started
+	r.mu.Unlock()
+
+	close(r.done)
+
+	if started {
+		r.sendRecords(links, func(l link) []dns.RR {
+			return r.svc.lookupAnswer(l.addrs, 0, true)
+		})
+	}
+
+	closeConns(conn4, conn6)
+	r.wg.Wait()
+
+	r.mu.Lock()
+	r.v4, r.v6 = nil, nil
+	r.links = nil
+	r.mu.Unlock()
+}
+
+// announce sends the unsolicited announcements RFC 6762 section 8.3 requires.
+func (r *Responder) announce(links []link) {
+	snapshot := make([]link, len(links))
+	copy(snapshot, links)
+
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return
+	}
+	r.wg.Add(1)
+	r.mu.Unlock()
+
+	go func() {
+		defer r.wg.Done()
+		for i := range announceCount {
+			if i > 0 {
+				timer := time.NewTimer(announceInterval)
+				select {
+				case <-timer.C:
+				case <-r.done:
+					timer.Stop()
+					return
+				}
+			}
+			r.sendRecords(snapshot, func(l link) []dns.RR {
+				return r.svc.lookupAnswer(l.addrs, serviceTTL, true)
+			})
+		}
+	}()
+}
+
+// sendRecords multicasts one message per interface, each carrying that
+// interface's own address records.
+func (r *Responder) sendRecords(links []link, build func(link) []dns.RR) {
+	for i := range links {
+		msg := new(dns.Msg)
+		msg.Response = true
+		msg.Authoritative = true
+		msg.Compress = true
+		msg.Answer = build(links[i])
+		r.writeMulticast(msg, &links[i])
+	}
+}
+
+// writeMulticast sends msg out a single interface. IP_MULTICAST_IF is what
+// makes this work on Windows, where the per-packet interface control message
+// x/net would otherwise use is unimplemented.
+func (r *Responder) writeMulticast(msg *dns.Msg, l *link) {
+	// RFC 6762 section 18.1: a multicast response carries a zero query id.
+	msg.Id = 0
+
+	buf, err := msg.Pack()
+	if err != nil {
+		r.logf("pack mDNS response for %s: %v", l.name, err)
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.v4 != nil && len(l.addrs.v4) > 0 {
+		if err := r.v4.SetMulticastInterface(&l.iface); err != nil {
+			r.logf("select ipv4 multicast interface %s: %v", l.name, err)
+		} else if _, err := r.v4.WriteTo(buf, nil, sendAddrIPv4); err != nil {
+			r.logf("send ipv4 mDNS on %s: %v", l.name, err)
+		}
+	}
+
+	if r.v6 != nil && len(l.addrs.v6) > 0 {
+		if err := r.v6.SetMulticastInterface(&l.iface); err != nil {
+			r.logf("select ipv6 multicast interface %s: %v", l.name, err)
+		} else if _, err := r.v6.WriteTo(buf, nil, sendAddrIPv6); err != nil {
+			r.logf("send ipv6 mDNS on %s: %v", l.name, err)
+		}
+	}
+}
+
+func (r *Responder) writeUnicast(msg *dns.Msg, to net.Addr) {
+	buf, err := msg.Pack()
+	if err != nil {
+		r.logf("pack unicast mDNS response: %v", err)
+		return
+	}
+
+	udpAddr, ok := to.(*net.UDPAddr)
+	if !ok {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if udpAddr.IP.To4() != nil {
+		if r.v4 != nil {
+			_, _ = r.v4.WriteTo(buf, nil, to)
+		}
+		return
+	}
+	if r.v6 != nil {
+		_, _ = r.v6.WriteTo(buf, nil, to)
+	}
+}
+
+func (r *Responder) receiveIPv4(conn *ipv4.PacketConn) {
+	defer r.wg.Done()
+
+	buf := make([]byte, maxPacketSize)
+	for {
+		n, _, from, err := conn.ReadFrom(buf)
+		if err != nil {
+			select {
+			case <-r.done:
+				return
+			default:
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			continue
+		}
+		r.handlePacket(buf[:n], from)
+	}
+}
+
+func (r *Responder) receiveIPv6(conn *ipv6.PacketConn) {
+	defer r.wg.Done()
+
+	buf := make([]byte, maxPacketSize)
+	for {
+		n, _, from, err := conn.ReadFrom(buf)
+		if err != nil {
+			select {
+			case <-r.done:
+				return
+			default:
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			continue
+		}
+		r.handlePacket(buf[:n], from)
+	}
+}
+
+func (r *Responder) handlePacket(packet []byte, from net.Addr) {
+	msg := new(dns.Msg)
+	if err := msg.Unpack(packet); err != nil {
+		return
+	}
+	if msg.Response || len(msg.Question) == 0 {
+		return
+	}
+	// A query carrying an authority section is a probe for conflict
+	// detection. This responder does not participate in probing.
+	if len(msg.Ns) > 0 {
+		return
+	}
+
+	r.mu.Lock()
+	links := r.links
+	stopped := r.stopped
+	r.mu.Unlock()
+	if stopped || len(links) == 0 {
+		return
+	}
+
+	for _, question := range msg.Question {
+		r.answerQuestion(question, msg, links, from)
+	}
+}
+
+func (r *Responder) answerQuestion(q dns.Question, query *dns.Msg, links []link, from net.Addr) {
+	if q.Qclass&^cacheFlush != dns.ClassINET && q.Qclass&^cacheFlush != dns.ClassANY {
+		return
+	}
+
+	if wantsUnicast(q) {
+		l := linkFor(links, from)
+		answer, extra := r.svc.answersFor(q, query, l.addrs)
+		if len(answer) == 0 {
+			return
+		}
+		reply := newReply(query.Id, answer, extra)
+		r.writeUnicast(reply, from)
+		return
+	}
+
+	for i := range links {
+		answer, extra := r.svc.answersFor(q, query, links[i].addrs)
+		if len(answer) == 0 {
+			continue
+		}
+		reply := newReply(0, answer, extra)
+		r.writeMulticast(reply, &links[i])
+	}
+}
+
+// answersFor returns the answer and additional sections for one question, or
+// nothing if the question is not ours.
+func (s *Service) answersFor(q dns.Question, query *dns.Msg, addrs linkAddrs) (answer, extra []dns.RR) {
+	switch {
+	case equalName(q.Name, enumerationName):
+		if q.Qtype != dns.TypePTR && q.Qtype != dns.TypeANY {
+			return nil, nil
+		}
+		return []dns.RR{s.enumerationPTR(serviceTTL)}, nil
+
+	case equalName(q.Name, s.typeName()):
+		if q.Qtype != dns.TypePTR && q.Qtype != dns.TypeANY {
+			return nil, nil
+		}
+		answer, extra = s.browsingAnswer(addrs)
+		if isKnownAnswer(answer, query) {
+			return nil, nil
+		}
+		return answer, extra
+
+	case equalName(q.Name, s.instanceName()):
+		switch q.Qtype {
+		case dns.TypeSRV, dns.TypeTXT, dns.TypeANY:
+			return s.lookupAnswer(addrs, serviceTTL, false), nil
+		default:
+			return nil, nil
+		}
+
+	case equalName(q.Name, s.hostName()):
+		switch q.Qtype {
+		case dns.TypeA, dns.TypeAAAA:
+			return s.hostAnswer(addrs, q.Qtype), nil
+		case dns.TypeANY:
+			return s.addrRecords(addrs, hostTTL, true), nil
+		default:
+			return nil, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func newReply(id uint16, answer, extra []dns.RR) *dns.Msg {
+	msg := new(dns.Msg)
+	msg.Id = id
+	msg.Response = true
+	msg.Authoritative = true
+	msg.Compress = true
+	// RFC 6762 section 6: responses must not repeat the question.
+	msg.Question = nil
+	msg.Answer = answer
+	msg.Extra = extra
+	return msg
+}
+
+// linkFor picks the interface a unicast reply should describe, by matching the
+// requester's address against each interface's prefixes. Falling back to the
+// first link keeps a reply going out rather than none at all.
+func linkFor(links []link, from net.Addr) link {
+	udpAddr, ok := from.(*net.UDPAddr)
+	if ok {
+		if udpAddr.Zone != "" {
+			for i := range links {
+				if links[i].name == udpAddr.Zone {
+					return links[i]
+				}
+			}
+		}
+		for i := range links {
+			for _, prefix := range links[i].prefixes {
+				if prefix.Contains(udpAddr.IP) {
+					return links[i]
+				}
+			}
+		}
+	}
+	return links[0]
+}
+
+func equalName(a, b string) bool {
+	return dns.CanonicalName(a) == dns.CanonicalName(b)
+}
+
+// buildLinks turns interfaces into links, dropping any with no address worth
+// advertising.
+func buildLinks(ifaces []net.Interface) []link {
+	links := make([]link, 0, len(ifaces))
+	for i := range ifaces {
+		iface := ifaces[i]
+		v4, v6, err := InterfaceAddrs(&iface)
+		if err != nil {
+			continue
+		}
+		addrs := linkAddrs{v4: v4, v6: v6}
+		if addrs.empty() {
+			continue
+		}
+		links = append(links, link{
+			index:    iface.Index,
+			name:     iface.Name,
+			iface:    iface,
+			addrs:    addrs,
+			prefixes: interfacePrefixes(&iface),
+		})
+	}
+	return links
+}
+
+func interfacePrefixes(iface *net.Interface) []*net.IPNet {
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil
+	}
+	prefixes := make([]*net.IPNet, 0, len(addrs))
+	for _, addr := range addrs {
+		if ipNet, ok := addr.(*net.IPNet); ok {
+			prefixes = append(prefixes, ipNet)
+		}
+	}
+	return prefixes
+}
+
+// diffLinks reports which links appeared, disappeared, or kept their identity
+// but changed addresses.
+func diffLinks(previous, next []link) (added, removed, readdressed []link) {
+	byIndex := make(map[int]int, len(previous))
+	for i := range previous {
+		byIndex[previous[i].index] = i
+	}
+
+	seen := make(map[int]struct{}, len(next))
+	for i := range next {
+		seen[next[i].index] = struct{}{}
+		old, existed := byIndex[next[i].index]
+		switch {
+		case !existed:
+			added = append(added, next[i])
+		case !sameAddrs(previous[old].addrs, next[i].addrs):
+			readdressed = append(readdressed, next[i])
+		}
+	}
+
+	for i := range previous {
+		if _, ok := seen[previous[i].index]; !ok {
+			removed = append(removed, previous[i])
+		}
+	}
+
+	return added, removed, readdressed
+}
+
+func sameAddrs(a, b linkAddrs) bool {
+	return sameIPs(a.v4, b.v4) && sameIPs(a.v6, b.v6)
+}
+
+func sameIPs(a, b []net.IP) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].Equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func listenIPv4(links []link) (*ipv4.PacketConn, error) {
+	udpConn, err := net.ListenUDP("udp4", listenAddrIPv4)
+	if err != nil {
+		return nil, fmt.Errorf("listen udp4: %w", err)
+	}
+
+	conn := ipv4.NewPacketConn(udpConn)
+	if err := conn.SetMulticastTTL(multicastHops); err != nil {
+		// Not fatal: the default TTL of 1 still reaches the local link.
+		_ = err
+	}
+
+	joined := 0
+	for i := range links {
+		if len(links[i].addrs.v4) == 0 {
+			continue
+		}
+		if err := conn.JoinGroup(&links[i].iface, &net.UDPAddr{IP: groupIPv4}); err == nil {
+			joined++
+		}
+	}
+	if joined == 0 {
+		_ = conn.Close()
+		return nil, fmt.Errorf("udp4: %w", ErrNoInterfaces)
+	}
+
+	return conn, nil
+}
+
+func listenIPv6(links []link) (*ipv6.PacketConn, error) {
+	udpConn, err := net.ListenUDP("udp6", listenAddrIPv6)
+	if err != nil {
+		return nil, fmt.Errorf("listen udp6: %w", err)
+	}
+
+	conn := ipv6.NewPacketConn(udpConn)
+	if err := conn.SetMulticastHopLimit(multicastHops); err != nil {
+		_ = err
+	}
+
+	joined := 0
+	for i := range links {
+		if len(links[i].addrs.v6) == 0 {
+			continue
+		}
+		if err := conn.JoinGroup(&links[i].iface, &net.UDPAddr{IP: groupIPv6}); err == nil {
+			joined++
+		}
+	}
+	if joined == 0 {
+		_ = conn.Close()
+		return nil, fmt.Errorf("udp6: %w", ErrNoInterfaces)
+	}
+
+	return conn, nil
+}
+
+func joinGroups(conn4 *ipv4.PacketConn, conn6 *ipv6.PacketConn, l *link, logf func(string, ...any)) {
+	if conn4 != nil && len(l.addrs.v4) > 0 {
+		if err := conn4.JoinGroup(&l.iface, &net.UDPAddr{IP: groupIPv4}); err != nil {
+			logf("join ipv4 mDNS group on %s: %v", l.name, err)
+		}
+	}
+	if conn6 != nil && len(l.addrs.v6) > 0 {
+		if err := conn6.JoinGroup(&l.iface, &net.UDPAddr{IP: groupIPv6}); err != nil {
+			logf("join ipv6 mDNS group on %s: %v", l.name, err)
+		}
+	}
+}
+
+func leaveGroups(conn4 *ipv4.PacketConn, conn6 *ipv6.PacketConn, l *link) {
+	if conn4 != nil && len(l.addrs.v4) > 0 {
+		_ = conn4.LeaveGroup(&l.iface, &net.UDPAddr{IP: groupIPv4})
+	}
+	if conn6 != nil && len(l.addrs.v6) > 0 {
+		_ = conn6.LeaveGroup(&l.iface, &net.UDPAddr{IP: groupIPv6})
+	}
+}
+
+func closeConns(conn4 *ipv4.PacketConn, conn6 *ipv6.PacketConn) {
+	if conn4 != nil {
+		_ = conn4.Close()
+	}
+	if conn6 != nil {
+		_ = conn6.Close()
+	}
+}

--- a/pkg/service/discovery/mdns/responder.go
+++ b/pkg/service/discovery/mdns/responder.go
@@ -58,6 +58,10 @@ const (
 	// announceInterval is the gap between those announcements.
 	announceInterval = time.Second
 
+	// legacyTTL caps the TTLs sent to a legacy unicast querier.
+	// RFC 6762 section 6.7.
+	legacyTTL = 10
+
 	// maxPacketSize bounds a single read. RFC 6762 section 17 caps an mDNS
 	// message at the interface MTU, but jumbo frames and IP fragmentation
 	// make a generous buffer cheaper than a truncated parse.
@@ -125,6 +129,13 @@ func (r *Responder) Start(ifaces []net.Interface) error {
 	links := buildLinks(ifaces)
 	if len(links) == 0 {
 		return ErrNoInterfaces
+	}
+
+	r.mu.Lock()
+	stopped := r.stopped
+	r.mu.Unlock()
+	if stopped {
+		return ErrNoSockets
 	}
 
 	conn4, err4 := listenIPv4(links)
@@ -298,6 +309,8 @@ func (r *Responder) announce(links []link) {
 func (r *Responder) sendRecords(links []link, build func(link) []dns.RR) {
 	for i := range links {
 		msg := new(dns.Msg)
+		// RFC 6762 section 18.1: a multicast response carries a zero query id.
+		msg.Id = 0
 		msg.Response = true
 		msg.Authoritative = true
 		msg.Compress = true
@@ -310,9 +323,6 @@ func (r *Responder) sendRecords(links []link, build func(link) []dns.RR) {
 // makes this work on Windows, where the per-packet interface control message
 // x/net would otherwise use is unimplemented.
 func (r *Responder) writeMulticast(msg *dns.Msg, l *link) {
-	// RFC 6762 section 18.1: a multicast response carries a zero query id.
-	msg.Id = 0
-
 	buf, err := msg.Pack()
 	if err != nil {
 		r.logf("pack mDNS response for %s: %v", l.name, err)
@@ -412,52 +422,117 @@ func (r *Responder) handlePacket(packet []byte, from net.Addr) {
 	if err := msg.Unpack(packet); err != nil {
 		return
 	}
-	if msg.Response || len(msg.Question) == 0 {
-		return
-	}
-	// A query carrying an authority section is a probe for conflict
-	// detection. This responder does not participate in probing.
-	if len(msg.Ns) > 0 {
-		return
-	}
 
 	r.mu.Lock()
 	links := r.links
 	stopped := r.stopped
 	r.mu.Unlock()
-	if stopped || len(links) == 0 {
+	if stopped {
 		return
 	}
 
-	for _, question := range msg.Question {
-		r.answerQuestion(question, msg, links, from)
+	for _, planned := range r.svc.planReplies(msg, links, from) {
+		if planned.unicast != nil {
+			r.writeUnicast(planned.msg, planned.unicast)
+			continue
+		}
+		r.writeMulticast(planned.msg, planned.link)
 	}
 }
 
-func (r *Responder) answerQuestion(q dns.Question, query *dns.Msg, links []link, from net.Addr) {
-	if q.Qclass&^cacheFlush != dns.ClassINET && q.Qclass&^cacheFlush != dns.ClassANY {
-		return
+// plannedReply is one response the responder decided to send: either multicast
+// out a single interface, or unicast back to whoever asked.
+type plannedReply struct {
+	msg     *dns.Msg
+	link    *link
+	unicast net.Addr
+}
+
+// planReplies decides what to answer for one received message. Keeping the
+// decisions separate from the sending means the parts worth getting right -
+// which questions are ours, which interface answers with which addresses, and
+// which of the reply shapes in RFC 6762 applies - can be exercised without
+// opening a socket.
+func (s *Service) planReplies(query *dns.Msg, links []link, from net.Addr) []plannedReply {
+	if query.Response || len(query.Question) == 0 || len(links) == 0 {
+		return nil
+	}
+	// A query carrying an authority section is a probe for conflict
+	// detection. This responder does not participate in probing.
+	if len(query.Ns) > 0 {
+		return nil
 	}
 
-	if wantsUnicast(q) {
-		l := linkFor(links, from)
-		answer, extra := r.svc.answersFor(q, query, l.addrs)
-		if len(answer) == 0 {
-			return
-		}
-		reply := newReply(query.Id, answer, extra)
-		r.writeUnicast(reply, from)
-		return
-	}
+	legacy := isLegacyQuery(from)
 
-	for i := range links {
-		answer, extra := r.svc.answersFor(q, query, links[i].addrs)
-		if len(answer) == 0 {
+	var replies []plannedReply
+	for _, q := range query.Question {
+		if !supportedClass(q.Qclass) {
 			continue
 		}
-		reply := newReply(0, answer, extra)
-		r.writeMulticast(reply, &links[i])
+
+		if legacy || wantsUnicast(q) {
+			l := linkFor(links, from)
+			answer, extra := s.answersFor(q, query, l.addrs)
+			if len(answer) == 0 {
+				continue
+			}
+			msg := newReply(query.Id, answer, extra)
+			if legacy {
+				makeLegacy(msg, q)
+			}
+			replies = append(replies, plannedReply{msg: msg, unicast: from})
+			continue
+		}
+
+		for i := range links {
+			answer, extra := s.answersFor(q, query, links[i].addrs)
+			if len(answer) == 0 {
+				continue
+			}
+			// RFC 6762 section 18.1: a multicast response carries a zero
+			// query id.
+			replies = append(replies, plannedReply{msg: newReply(0, answer, extra), link: &links[i]})
+		}
 	}
+
+	return replies
+}
+
+// isLegacyQuery reports whether the query came from a resolver that is not
+// itself listening on the mDNS port. RFC 6762 section 6.7 calls these legacy
+// unicast queries: the sender is an ordinary DNS client that happened to ask
+// the multicast group, and it will only recognise an ordinary DNS answer.
+func isLegacyQuery(from net.Addr) bool {
+	udpAddr, ok := from.(*net.UDPAddr)
+	return ok && udpAddr.Port != Port
+}
+
+// makeLegacy reshapes a response for a legacy unicast querier. It repeats the
+// question so the client can match the answer to its query, and caps every TTL
+// at ten seconds, because a legacy client caches the records without watching
+// for the goodbye that would otherwise retire them. RFC 6762 section 6.7.
+func makeLegacy(msg *dns.Msg, q dns.Question) {
+	msg.Question = []dns.Question{q}
+	capLegacyTTLs(msg.Answer)
+	capLegacyTTLs(msg.Extra)
+}
+
+func capLegacyTTLs(records []dns.RR) {
+	for _, record := range records {
+		header := record.Header()
+		// A legacy client keeps no mDNS cache, so there is nothing for the
+		// cache-flush bit to flush and its rrclass must be a plain class.
+		header.Class &^= cacheFlush
+		if header.Ttl > legacyTTL {
+			header.Ttl = legacyTTL
+		}
+	}
+}
+
+func supportedClass(qclass uint16) bool {
+	class := qclass &^ cacheFlush
+	return class == dns.ClassINET || class == dns.ClassANY
 }
 
 // answersFor returns the answer and additional sections for one question, or

--- a/pkg/service/discovery/watch_test.go
+++ b/pkg/service/discovery/watch_test.go
@@ -1,0 +1,278 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/discovery/mdns"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// waitTimeout bounds how long a test waits for the watch loop to react. It is
+// only reached when something is wrong; the happy path returns immediately.
+const waitTimeout = 5 * time.Second
+
+// fakeResponder stands in for mdns.Responder so the watch loop can be driven
+// without opening a socket or putting traffic on the tester's network.
+type fakeResponder struct {
+	startErr   error
+	startCalls chan []net.Interface
+	setCalls   chan []net.Interface
+	stopCalls  chan struct{}
+	names      []string
+	mu         syncutil.Mutex
+	changed    bool
+}
+
+func newFakeResponder() *fakeResponder {
+	return &fakeResponder{
+		startCalls: make(chan []net.Interface, 8),
+		setCalls:   make(chan []net.Interface, 8),
+		stopCalls:  make(chan struct{}, 4),
+		changed:    true,
+	}
+}
+
+func (f *fakeResponder) Start(ifaces []net.Interface) error {
+	f.mu.Lock()
+	err := f.startErr
+	f.mu.Unlock()
+
+	f.startCalls <- ifaces
+	return err
+}
+
+func (f *fakeResponder) SetInterfaces(ifaces []net.Interface) (bool, error) {
+	f.mu.Lock()
+	changed := f.changed
+	f.mu.Unlock()
+
+	f.setCalls <- ifaces
+	return changed, nil
+}
+
+func (f *fakeResponder) Interfaces() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.names
+}
+
+func (f *fakeResponder) Stop() {
+	select {
+	case f.stopCalls <- struct{}{}:
+	default:
+	}
+}
+
+func (f *fakeResponder) setStartErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startErr = err
+}
+
+func iface(index int, name string) net.Interface {
+	return net.Interface{Index: index, Name: name, Flags: net.FlagUp | net.FlagMulticast}
+}
+
+// watchHarness wires a discovery service to a fake clock, a scripted interface
+// list, and a fake responder.
+type watchHarness struct {
+	svc       *Service
+	responder *fakeResponder
+	clock     *clockwork.FakeClock
+	ifaces    func() ([]net.Interface, error)
+	mu        syncutil.Mutex
+}
+
+func newWatchHarness(t *testing.T, initial []net.Interface) *watchHarness {
+	t.Helper()
+
+	cfg, err := config.NewConfig(t.TempDir(), config.BaseDefaults)
+	require.NoError(t, err)
+
+	h := &watchHarness{
+		responder: newFakeResponder(),
+		clock:     clockwork.NewFakeClock(),
+	}
+	h.ifaces = func() ([]net.Interface, error) { return initial, nil }
+
+	h.svc = New(cfg)
+	h.svc.clock = h.clock
+	h.svc.newResponder = func(*mdns.Service, func(string, ...any)) responder {
+		return h.responder
+	}
+	h.svc.listInterfaces = func() ([]net.Interface, error) {
+		h.mu.Lock()
+		lister := h.ifaces
+		h.mu.Unlock()
+		return lister()
+	}
+
+	return h
+}
+
+func (h *watchHarness) setInterfaces(lister func() ([]net.Interface, error)) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.ifaces = lister
+}
+
+// tick advances the fake clock by one watch interval, waiting for the loop to
+// arm its ticker first so the advance is never missed.
+func (h *watchHarness) tick(t *testing.T) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
+	defer cancel()
+	require.NoError(t, h.clock.BlockUntilContext(ctx, 1), "watch loop never armed its ticker")
+	h.clock.Advance(watchInterval)
+}
+
+func waitFor(t *testing.T, calls chan []net.Interface, what string) []net.Interface {
+	t.Helper()
+
+	select {
+	case got := <-calls:
+		return got
+	case <-time.After(waitTimeout):
+		t.Fatalf("timed out waiting for %s", what)
+		return nil
+	}
+}
+
+func TestWatchRetriesUntilTheNetworkIsReady(t *testing.T) {
+	t.Parallel()
+
+	// Core starts before the network does. The old implementation gave up
+	// five minutes in; this one keeps watching.
+	h := newWatchHarness(t, nil)
+	require.NoError(t, h.svc.Start())
+	t.Cleanup(h.svc.Stop)
+
+	assert.Empty(t, h.responder.startCalls, "nothing to advertise on yet")
+
+	wired := iface(14, "Ethernet 4")
+	h.setInterfaces(func() ([]net.Interface, error) { return []net.Interface{wired}, nil })
+	h.tick(t)
+
+	got := waitFor(t, h.responder.startCalls, "registration once an interface appeared")
+	assert.Equal(t, []net.Interface{wired}, got)
+}
+
+func TestWatchKeepsRetryingAfterAFailedRegistration(t *testing.T) {
+	t.Parallel()
+
+	wired := iface(14, "Ethernet 4")
+	h := newWatchHarness(t, []net.Interface{wired})
+	h.responder.setStartErr(errors.New("socket unavailable"))
+
+	require.NoError(t, h.svc.Start())
+	t.Cleanup(h.svc.Stop)
+	waitFor(t, h.responder.startCalls, "the first registration attempt")
+
+	h.responder.setStartErr(nil)
+	h.tick(t)
+
+	got := waitFor(t, h.responder.startCalls, "a retry after the first attempt failed")
+	assert.Equal(t, []net.Interface{wired}, got)
+}
+
+func TestWatchReconcilesWhenAnInterfaceAppears(t *testing.T) {
+	t.Parallel()
+
+	// A cable plugged in after Core started: the reported failure in #570.
+	wireless := iface(22, "Wi-Fi")
+	wired := iface(14, "Ethernet 4")
+
+	h := newWatchHarness(t, []net.Interface{wireless})
+	require.NoError(t, h.svc.Start())
+	t.Cleanup(h.svc.Stop)
+	waitFor(t, h.responder.startCalls, "the initial registration")
+
+	h.setInterfaces(func() ([]net.Interface, error) {
+		return []net.Interface{wireless, wired}, nil
+	})
+	h.tick(t)
+
+	got := waitFor(t, h.responder.setCalls, "the interface set to be reconciled")
+	assert.Equal(t, []net.Interface{wireless, wired}, got)
+	assert.Empty(t, h.responder.startCalls, "an established responder is updated, not restarted")
+}
+
+func TestWatchSurvivesAnInterfaceListingFailure(t *testing.T) {
+	t.Parallel()
+
+	wireless := iface(22, "Wi-Fi")
+	h := newWatchHarness(t, []net.Interface{wireless})
+	require.NoError(t, h.svc.Start())
+	t.Cleanup(h.svc.Stop)
+	waitFor(t, h.responder.startCalls, "the initial registration")
+
+	h.setInterfaces(func() ([]net.Interface, error) {
+		return nil, errors.New("interface table unavailable")
+	})
+	h.tick(t)
+
+	h.setInterfaces(func() ([]net.Interface, error) { return []net.Interface{wireless}, nil })
+	h.tick(t)
+
+	got := waitFor(t, h.responder.setCalls, "the watch loop to carry on after a listing error")
+	assert.Equal(t, []net.Interface{wireless}, got)
+}
+
+func TestStopEndsTheWatchLoopAndTheResponder(t *testing.T) {
+	t.Parallel()
+
+	h := newWatchHarness(t, []net.Interface{iface(22, "Wi-Fi")})
+	require.NoError(t, h.svc.Start())
+	waitFor(t, h.responder.startCalls, "the initial registration")
+
+	h.svc.Stop()
+
+	select {
+	case <-h.responder.stopCalls:
+	case <-time.After(waitTimeout):
+		t.Fatal("responder was never stopped")
+	}
+	assert.Nil(t, h.svc.responder)
+
+	// Stopping twice must stay safe; the second call has nothing left to do.
+	h.svc.Stop()
+}
+
+func TestStartAfterStopDoesNotAdvertise(t *testing.T) {
+	t.Parallel()
+
+	h := newWatchHarness(t, []net.Interface{iface(22, "Wi-Fi")})
+	h.svc.Stop()
+
+	require.NoError(t, h.svc.Start())
+	assert.Nil(t, h.svc.responder)
+	assert.Empty(t, h.responder.startCalls)
+}


### PR DESCRIPTION
- Replace `grandcat/zeroconf` with a responder in `pkg/service/discovery/mdns` that selects the outgoing interface with `IP_MULTICAST_IF`. zeroconf sets `ipv4.ControlMessage.IfIndex` per packet, and `golang.org/x/net` leaves control messages unimplemented on Windows (`ipv4/control_windows.go`, `ipv4/sys_windows.go`), so announcements and responses left by whichever interface the routing table picked and only one NIC on a multi-homed machine was ever discoverable.
- Answer on each interface with only that interface's own address records, instead of flattening every interface's addresses into one set advertised everywhere.
- Reconcile the interface set every 15s, announcing an interface that appears later and sending a goodbye for one that goes away. Registration previously happened once at startup and was never revisited, so a cable plugged in afterwards was never advertised; the retry loop only ran when the first attempt had failed, and gave up after five minutes.
- Send one zero-length string as the TXT record instead of an empty slice. An empty slice packs to rdlength 0, which RFC 1035 and RFC 6763 forbid: Apple's mDNSResponder rejects the record in `ValidateRData`, and some parsers fail the entire response, discarding the address records with it. This affected every platform, not just Windows.
- Drop IPv4 link-local addresses from advertisements. Windows leaves an APIPA address on adapters that are up but not connected, and advertising one points clients at an address that cannot answer. Add `vmware` and `virtualbox` to the virtual interface name filter.
- Add a Windows Firewall task to the installer, ticked by default, registering an inbound allow rule for the executable with `profile=any`. Without it Core relies on the Windows "allow access" popup, which scopes the rule to whichever of Private/Public is ticked, leaving Core reachable on one network profile and firewalled on another. The uninstaller removes the rule, gated on a marker written only when the step actually ran.
- Promote `github.com/miekg/dns` to a direct dependency and update it from v1.1.27 to v1.1.72.

Verified on a Windows 11 test machine with both a wired and a wireless interface live: a single PTR query for `_zaparoo._tcp.local.` is answered twice, once from each interface, each carrying only its own address. Disconnecting and reconnecting an interface is picked up within one watch interval without restarting Core.

Closes #570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Windows Firewall configuration during installation, with cleanup during uninstall.
  * Improved local network service discovery across IPv4 and IPv6 networks.
  * Discovery now adapts to network interface changes and supports additional virtual adapters, including VMware and VirtualBox.
* **Bug Fixes**
  * Improved hostname and service advertisement compatibility across supported discovery responders.
  * More reliably filters unusable network addresses while preserving IPv6 fallback behavior.
  * Improved handling of multicast and unicast discovery queries for broader compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->