### PR TITLE
perf(mediadb): serve merged system roots without reading every file

### DIFF
--- a/pkg/database/mediadb/browse_overlay_merge_test.go
+++ b/pkg/database/mediadb/browse_overlay_merge_test.go
@@ -1,0 +1,456 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mergeFixture builds a multi-route overlay over hand-placed media so each rule
+// the merge applies can be checked against a result worked out by hand.
+type mergeFixture struct {
+	mediaDB *MediaDB
+	insert  func(name, path string)
+	roots   []string
+	system  systemdefs.System
+}
+
+func setupMergeFixture(t *testing.T, routes int) (fixture *mergeFixture, cleanup func()) {
+	t.Helper()
+	mediaDB, cleanup := setupTempMediaDB(t)
+
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	roots := make([]string, routes)
+	for i := range roots {
+		roots[i] = browseTestDir(string(rune('a'+i))+"root", "NES")
+	}
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insert := func(name, path string) {
+		t.Helper()
+		title, titleErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: system.DBID,
+			Slug:       slugs.Slugify(nesSystem.GetMediaType(), name+path),
+			Name:       name,
+		})
+		require.NoError(t, titleErr)
+		_, mediaErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     system.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           path,
+			ParentDir:      filepath.ToSlash(filepath.Dir(path)) + "/",
+			SortName:       name,
+		})
+		require.NoError(t, mediaErr)
+	}
+	return &mergeFixture{mediaDB: mediaDB, insert: insert, roots: roots, system: *nesSystem}, cleanup
+}
+
+// commit closes the fixture's transaction and, when cached is set, builds the
+// browse cache. The two-route count is answered from the cache when it can be
+// and by the statement otherwise, so every rule is checked through both.
+func (f *mergeFixture) commit(t *testing.T, cached bool) {
+	t.Helper()
+	require.NoError(t, f.mediaDB.CommitTransaction())
+	if cached {
+		require.NoError(t, sqlPopulateBrowseCache(context.Background(), f.mediaDB.sql.Load()))
+	}
+}
+
+func (f *mergeFixture) overlay() *database.BrowseOverlay {
+	sources := make([]database.BrowseSource, len(f.roots))
+	for i, r := range f.roots {
+		sources[i] = database.BrowseSource{PathPrefix: r, IncludeDirs: true}
+	}
+	return &database.BrowseOverlay{Sources: sources}
+}
+
+// mergeResult is what the two merge statements say about the same overlay: the
+// paths the listing returns and the total the count reports. They are read
+// together because the API shows both at once, so a rule applied by one and not
+// the other is a user-visible inconsistency, not an internal detail.
+func (f *mergeFixture) mergeResult(t *testing.T) (paths []string, total int) {
+	t.Helper()
+	ctx := context.Background()
+	files, err := f.mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		Overlay: f.overlay(),
+		Systems: []systemdefs.System{f.system},
+		Limit:   100,
+	})
+	require.NoError(t, err)
+	for i := range files {
+		paths = append(paths, files[i].Path)
+	}
+	total, err = f.mediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+		Overlay: f.overlay(),
+		Systems: []systemdefs.System{f.system},
+	})
+	require.NoError(t, err)
+	assert.Len(t, paths, total, "the count must agree with the rows the listing returns")
+	return paths, total
+}
+
+// TestBrowseOverlayMerge_Rules pins every rule the merge applies, now that the
+// ROW_NUMBER ranking that used to apply them has been replaced by predicates
+// (#1398). Each case states the answer worked out by hand rather than comparing
+// two implementations, so the test still means something if both change.
+func TestBrowseOverlayMerge_Rules(t *testing.T) {
+	t.Parallel()
+	for _, cached := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cache=%t", cached), func(t *testing.T) {
+			t.Parallel()
+			testBrowseOverlayMergeRules(t, cached)
+		})
+	}
+}
+
+func testBrowseOverlayMergeRules(t *testing.T, cached bool) {
+	t.Helper()
+
+	t.Run("higher priority route wins a duplicate name", func(t *testing.T) {
+		t.Parallel()
+		f, cleanup := setupMergeFixture(t, 2)
+		defer cleanup()
+		f.insert("Winner", f.roots[0]+"Dup.nes")
+		f.insert("Loser", f.roots[1]+"Dup.nes")
+		f.insert("Only Second", f.roots[1]+"Unique.nes")
+		f.commit(t, cached)
+
+		paths, total := f.mergeResult(t)
+		assert.Equal(t, 2, total)
+		assert.Contains(t, paths, f.roots[0]+"Dup.nes")
+		assert.NotContains(t, paths, f.roots[1]+"Dup.nes")
+		assert.Contains(t, paths, f.roots[1]+"Unique.nes")
+	})
+
+	t.Run("a name in three routes survives once from the first", func(t *testing.T) {
+		t.Parallel()
+		f, cleanup := setupMergeFixture(t, 3)
+		defer cleanup()
+		f.insert("First", f.roots[0]+"Triple.nes")
+		f.insert("Second", f.roots[1]+"Triple.nes")
+		f.insert("Third", f.roots[2]+"Triple.nes")
+		f.commit(t, cached)
+
+		paths, total := f.mergeResult(t)
+		assert.Equal(t, 1, total)
+		assert.Equal(t, []string{f.roots[0] + "Triple.nes"}, paths)
+	})
+
+	t.Run("a higher priority directory shadows a lower priority file", func(t *testing.T) {
+		t.Parallel()
+		f, cleanup := setupMergeFixture(t, 2)
+		defer cleanup()
+		f.insert("Inside", f.roots[0]+"Shadow.nes/inside.nes")
+		f.insert("Shadowed", f.roots[1]+"Shadow.nes")
+		f.insert("Survivor", f.roots[1]+"Kept.nes")
+		f.commit(t, cached)
+
+		paths, total := f.mergeResult(t)
+		assert.Equal(t, 1, total, "only the unshadowed file counts as a file")
+		assert.Equal(t, []string{f.roots[1] + "Kept.nes"}, paths)
+	})
+
+	t.Run("a lower priority directory shadows nothing", func(t *testing.T) {
+		t.Parallel()
+		f, cleanup := setupMergeFixture(t, 2)
+		defer cleanup()
+		f.insert("Kept", f.roots[0]+"Name.nes")
+		f.insert("Inside", f.roots[1]+"Name.nes/inside.nes")
+		f.commit(t, cached)
+
+		paths, total := f.mergeResult(t)
+		assert.Equal(t, 1, total)
+		assert.Equal(t, []string{f.roots[0] + "Name.nes"}, paths)
+	})
+
+	// The interesting one. Ranking by anything other than priority gets this
+	// wrong: route 2's file would win the name and then be shadowed away by
+	// route 1's directory, losing route 0's file with it.
+	t.Run("a shadowed middle route does not take the name from the first", func(t *testing.T) {
+		t.Parallel()
+		f, cleanup := setupMergeFixture(t, 3)
+		defer cleanup()
+		f.insert("Kept", f.roots[0]+"Name.nes")
+		f.insert("Inside", f.roots[1]+"Name.nes/inside.nes")
+		f.insert("Shadowed", f.roots[2]+"Name.nes")
+		f.commit(t, cached)
+
+		paths, total := f.mergeResult(t)
+		assert.Equal(t, 1, total)
+		assert.Equal(t, []string{f.roots[0] + "Name.nes"}, paths,
+			"the first route's file is neither deduped nor shadowed")
+	})
+
+	t.Run("a missing row neither survives nor shadows", func(t *testing.T) {
+		t.Parallel()
+		f, cleanup := setupMergeFixture(t, 2)
+		defer cleanup()
+		f.insert("Present", f.roots[1]+"Dup.nes")
+		f.insert("Gone", f.roots[0]+"Dup.nes")
+		// Marked missing before the cache is built: a cache built from rows that
+		// have since gone missing is stale by construction, which is a property
+		// of the browse cache and not of the merge rule under test here.
+		f.commit(t, false)
+		ctx := context.Background()
+		_, err := f.mediaDB.sql.Load().ExecContext(ctx,
+			"UPDATE Media SET IsMissing = 1 WHERE Path = ?", f.roots[0]+"Dup.nes")
+		require.NoError(t, err)
+		if cached {
+			require.NoError(t, sqlPopulateBrowseCache(ctx, f.mediaDB.sql.Load()))
+		}
+
+		paths, total := f.mergeResult(t)
+		assert.Equal(t, 1, total)
+		assert.Equal(t, []string{f.roots[1] + "Dup.nes"}, paths,
+			"the surviving copy is the present one, not the higher-priority missing one")
+	})
+
+	t.Run("a same-named file in another system does not dedupe", func(t *testing.T) {
+		t.Parallel()
+		f, cleanup := setupMergeFixture(t, 2)
+		defer cleanup()
+		f.insert("Kept", f.roots[1]+"Shared.nes")
+		f.commit(t, cached)
+
+		ctx := context.Background()
+		other, err := f.mediaDB.FindOrInsertSystem(database.System{SystemID: "SNES", Name: "SNES"})
+		require.NoError(t, err)
+		require.NoError(t, f.mediaDB.BeginTransaction(false))
+		title, err := f.mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: other.DBID, Slug: "shared-other", Name: "Other System",
+		})
+		require.NoError(t, err)
+		_, err = f.mediaDB.InsertMedia(database.Media{
+			SystemDBID:     other.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           f.roots[0] + "Shared.nes",
+			ParentDir:      f.roots[0],
+			SortName:       "Other System",
+		})
+		require.NoError(t, err)
+		require.NoError(t, f.mediaDB.CommitTransaction())
+
+		paths, total := f.mergeResult(t)
+		assert.Equal(t, 1, total, "the other system's row is outside the filter, so it cannot win the name")
+		assert.Equal(t, []string{f.roots[1] + "Shared.nes"}, paths)
+		_ = ctx
+	})
+}
+
+// TestBrowseOverlayMerge_TwoRouteCountMatchesStatement pins the cached two-route
+// total against the statement that reads both routes, which is the only other
+// thing that can produce it. They are separate implementations of one rule, so a
+// corpus exercising every part of the correction is what keeps them equal.
+func TestBrowseOverlayMerge_TwoRouteCountMatchesStatement(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	f, cleanup := setupMergeFixture(t, 2)
+	defer cleanup()
+
+	// Names only in one route, names in both, a directory in the first route
+	// shadowing a file in the second, and a directory in the second shadowing
+	// nothing.
+	for i := range 30 {
+		name := fmt.Sprintf("Both%02d", i)
+		f.insert("First "+name, f.roots[0]+name+".nes")
+		f.insert("Second "+name, f.roots[1]+name+".nes")
+	}
+	for i := range 10 {
+		f.insert("First only", f.roots[0]+fmt.Sprintf("FirstOnly%02d.nes", i))
+		f.insert("Second only", f.roots[1]+fmt.Sprintf("SecondOnly%02d.nes", i))
+	}
+	f.insert("Inside", f.roots[0]+"Shadowing.nes/inside.nes")
+	f.insert("Shadowed", f.roots[1]+"Shadowing.nes")
+	f.insert("Inside lower", f.roots[1]+"NotShadowing.nes/inside.nes")
+	f.insert("Not shadowed", f.roots[0]+"NotShadowing.nes")
+	f.commit(t, true)
+
+	opts := database.BrowseFileCountOptions{
+		Overlay: f.overlay(),
+		Systems: []systemdefs.System{f.system},
+	}
+
+	cached, served, err := sqlBrowseTwoRouteFileCountFromCache(ctx, f.mediaDB.sql.Load(), opts)
+	require.NoError(t, err)
+	require.True(t, served, "the fixture must leave the cache able to answer the total")
+
+	query, args := browseOverlayFileCountQuery(opts)
+	var fromStatement int
+	require.NoError(t, f.mediaDB.sql.Load().QueryRowContext(ctx, query, args...).Scan(&fromStatement))
+
+	// 30 shared names counted once, 10 in each route alone, and NotShadowing.nes
+	// which only the first route holds as a file. Shadowing.nes is a directory in
+	// the first route, so the second route's file of that name is dropped.
+	assert.Equal(t, 51, fromStatement, "the statement's total")
+	assert.Equal(t, fromStatement, cached, "the cached total must match the statement's")
+
+	paths, total := f.mergeResult(t)
+	assert.Equal(t, fromStatement, total)
+	assert.Len(t, paths, total)
+}
+
+// TestBrowseOverlayMerge_FilenameSortPaging covers the sort whose branches seek
+// by m.Path rather than by the filename they order on, so a cursor issued in
+// filename terms has to be translated per route. Paging is where that would go
+// wrong: a mistranslated seek repeats or skips rows rather than erroring.
+func TestBrowseOverlayMerge_FilenameSortPaging(t *testing.T) {
+	t.Parallel()
+
+	for _, sortOrder := range []string{"filename-asc", "filename-desc"} {
+		t.Run(sortOrder, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			f, cleanup := setupMergeFixture(t, 2)
+			defer cleanup()
+			for i := range 25 {
+				f.insert(fmt.Sprintf("First %02d", i), f.roots[0]+fmt.Sprintf("game-%02d.nes", i))
+			}
+			for i := 20; i < 40; i++ {
+				f.insert(fmt.Sprintf("Second %02d", i), f.roots[1]+fmt.Sprintf("game-%02d.nes", i))
+			}
+			f.commit(t, true)
+
+			total, err := f.mediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+				Overlay: f.overlay(),
+				Systems: []systemdefs.System{f.system},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 40, total, "game-20..24 are in both routes and count once")
+
+			var (
+				cursor *database.BrowseCursor
+				order  []string
+			)
+			seen := make(map[string]struct{})
+			for range 30 {
+				page, pageErr := f.mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+					Overlay: f.overlay(),
+					Systems: []systemdefs.System{f.system},
+					Cursor:  cursor,
+					Sort:    sortOrder,
+					Limit:   6,
+				})
+				require.NoError(t, pageErr)
+				if len(page) == 0 {
+					break
+				}
+				for i := range page {
+					_, dup := seen[page[i].Path]
+					require.False(t, dup, "paged twice: %s", page[i].Path)
+					seen[page[i].Path] = struct{}{}
+					order = append(order, filepath.Base(page[i].Path))
+				}
+				last := page[len(page)-1]
+				cursor = &database.BrowseCursor{SortValue: last.SortValue, LastID: last.MediaID}
+			}
+			assert.Len(t, seen, total, "paging must enumerate exactly the counted rows")
+
+			sorted := slices.Clone(order)
+			if sortOrder == "filename-desc" {
+				slices.Sort(sorted)
+				slices.Reverse(sorted)
+			} else {
+				slices.Sort(sorted)
+			}
+			assert.Equal(t, sorted, order, "pages must come back in filename order")
+			// The duplicated names resolve to the first route, so the second
+			// route only contributes the names it alone holds.
+			assert.Contains(t, seen, f.roots[0]+"game-20.nes")
+			assert.NotContains(t, seen, f.roots[1]+"game-20.nes")
+		})
+	}
+}
+
+// TestBrowseOverlayMerge_CountMatchesEnumeration is the invariant that catches a
+// merge rule applied by one statement and not the other: media.browse shows the
+// count as the total beside the rows it pages through, so they have to agree on
+// a corpus with every rule in play at once.
+func TestBrowseOverlayMerge_CountMatchesEnumeration(t *testing.T) {
+	t.Parallel()
+
+	f, cleanup := setupMergeFixture(t, 3)
+	defer cleanup()
+	for i := range 40 {
+		name := string(rune('A'+i%26)) + string(rune('a'+i/26))
+		f.insert("First "+name, f.roots[0]+name+".nes")
+		if i%2 == 0 {
+			f.insert("Second "+name, f.roots[1]+name+".nes")
+		}
+		if i%3 == 0 {
+			f.insert("Third "+name, f.roots[2]+name+".nes")
+		}
+	}
+	f.insert("Second only", f.roots[1]+"SecondOnly.nes")
+	f.insert("Third only", f.roots[2]+"ThirdOnly.nes")
+	f.insert("Inside", f.roots[0]+"Shadowed.nes/inside.nes")
+	f.insert("Shadowed second", f.roots[1]+"Shadowed.nes")
+	f.insert("Shadowed third", f.roots[2]+"Shadowed.nes")
+	f.commit(t, true)
+
+	ctx := context.Background()
+	total, err := f.mediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+		Overlay: f.overlay(),
+		Systems: []systemdefs.System{f.system},
+	})
+	require.NoError(t, err)
+	// 40 names from the first route, plus the two names only later routes hold.
+	// Shadowed.nes is a directory in the first route, so neither later route's
+	// file of that name survives.
+	assert.Equal(t, 42, total)
+
+	seen := make(map[string]struct{})
+	var cursor *database.BrowseCursor
+	for range 20 {
+		page, pageErr := f.mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+			Overlay: f.overlay(),
+			Systems: []systemdefs.System{f.system},
+			Cursor:  cursor,
+			Limit:   7,
+		})
+		require.NoError(t, pageErr)
+		if len(page) == 0 {
+			break
+		}
+		for i := range page {
+			_, dup := seen[page[i].Path]
+			require.False(t, dup, "paged twice: %s", page[i].Path)
+			seen[page[i].Path] = struct{}{}
+		}
+		last := page[len(page)-1]
+		cursor = &database.BrowseCursor{SortValue: last.SortValue, LastID: last.MediaID}
+	}
+	assert.Len(t, seen, total, "paging must enumerate exactly the counted rows")
+}

--- a/pkg/database/mediadb/browse_overlay_merge_test.go
+++ b/pkg/database/mediadb/browse_overlay_merge_test.go
@@ -322,6 +322,74 @@ func TestBrowseOverlayMerge_TwoRouteCountMatchesStatement(t *testing.T) {
 	assert.Len(t, paths, total)
 }
 
+// TestBrowseOverlayMerge_IndexMatchesTheListing covers media.browse.index, which
+// resolves the same merged root through a statement of its own. Its buckets have
+// to describe the rows media.browse returns, so it has to apply the merge and
+// the system filter exactly as the listing does.
+func TestBrowseOverlayMerge_IndexMatchesTheListing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	f, cleanup := setupMergeFixture(t, 2)
+	defer cleanup()
+
+	f.insert("Alpha", f.roots[0]+"Alpha.nes")
+	f.insert("Beta first", f.roots[0]+"Beta.nes")
+	f.insert("Beta second", f.roots[1]+"Beta.nes")
+	f.insert("Gamma", f.roots[1]+"Gamma.nes")
+	f.insert("Inside", f.roots[0]+"Delta.nes/inside.nes")
+	f.insert("Delta shadowed", f.roots[1]+"Delta.nes")
+	f.commit(t, true)
+
+	// A same-named file under another system must not reach the buckets. The
+	// merge used to carry the system filter in a CTE the index no longer has.
+	other, err := f.mediaDB.FindOrInsertSystem(database.System{SystemID: "SNES", Name: "SNES"})
+	require.NoError(t, err)
+	require.NoError(t, f.mediaDB.BeginTransaction(false))
+	title, err := f.mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: other.DBID, Slug: "other-zulu", Name: "Zulu Other System",
+	})
+	require.NoError(t, err)
+	_, err = f.mediaDB.InsertMedia(database.Media{
+		SystemDBID:     other.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           f.roots[0] + "Zulu.nes",
+		ParentDir:      f.roots[0],
+		SortName:       "Zulu Other System",
+	})
+	require.NoError(t, err)
+	require.NoError(t, f.mediaDB.CommitTransaction())
+
+	paths, total := f.mergeResult(t)
+	require.Equal(t, 3, total, "Alpha, one Beta and Gamma survive; Delta is shadowed by a directory")
+	assert.NotContains(t, paths, f.roots[0]+"Zulu.nes")
+
+	index, err := f.mediaDB.BrowseIndex(ctx, database.BrowseIndexOptions{
+		Overlay: f.overlay(),
+		Systems: []systemdefs.System{f.system},
+	})
+	require.NoError(t, err)
+
+	bucketed := 0
+	keys := make([]string, 0, len(index.Buckets))
+	for _, bucket := range index.Buckets {
+		bucketed += bucket.Count
+		keys = append(keys, bucket.Key)
+	}
+	assert.Equal(t, total, bucketed, "the buckets must account for every row the listing returns")
+	assert.NotContains(t, keys, "Z", "another system's file must not open a bucket")
+
+	// The filename sort reports a total only, and takes the same routing as any
+	// other merged total.
+	filenameIndex, err := f.mediaDB.BrowseIndex(ctx, database.BrowseIndexOptions{
+		Overlay: f.overlay(),
+		Systems: []systemdefs.System{f.system},
+		Sort:    "filename-asc",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, total, filenameIndex.TotalFiles)
+}
+
 // TestBrowseOverlayMerge_FilenameSortPaging covers the sort whose branches seek
 // by m.Path rather than by the filename they order on, so a cursor issued in
 // filename terms has to be translated per route. Paging is where that would go

--- a/pkg/database/mediadb/browse_overlay_merge_test.go
+++ b/pkg/database/mediadb/browse_overlay_merge_test.go
@@ -307,7 +307,7 @@ func TestBrowseOverlayMerge_TwoRouteCountMatchesStatement(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, served, "the fixture must leave the cache able to answer the total")
 
-	query, args := browseOverlayFileCountQuery(opts)
+	query, args := browseOverlayFileCountQuery(opts, browseTagPlan{})
 	var fromStatement int
 	require.NoError(t, f.mediaDB.sql.Load().QueryRowContext(ctx, query, args...).Scan(&fromStatement))
 

--- a/pkg/database/mediadb/browse_overlay_plan_test.go
+++ b/pkg/database/mediadb/browse_overlay_plan_test.go
@@ -82,6 +82,158 @@ func TestBrowseOverlayPlan_HigherPriorityCheckUsesParentDirRange(t *testing.T) {
 			"row scan the whole Media table (see #1279); got %q", descendant)
 }
 
+// TestBrowseOverlayPlan_SingleRouteCountReadsTheCache is the regression guard for
+// the browse timeouts in #1398.
+//
+// A system whose media sits under one route still went through the merge
+// statement, which cannot use the browse cache: it counts by scanning every
+// direct file in the route, ranking them, and probing higher-priority routes
+// that do not exist. On the reporter's device that took 29.8 s against a 30 s
+// API timeout, so media.browse failed and the frontend showed "failed to load"
+// for N64 and PSX while smaller systems opened.
+//
+// Asserting the plan rather than a duration, for the same reason the
+// higher-priority guard above does: at fixture scale either shape finishes
+// instantly, but reading Media instead of BrowseDirCounts shows up immediately.
+func TestBrowseOverlayPlan_SingleRouteCountReadsTheCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	defer cleanup()
+
+	parentDir := seedBrowsePlanTestDB(t, mediaDB, 200)
+	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+	seedAnalysisLimitedStats(ctx, t, mediaDB)
+
+	opts := database.BrowseFileCountOptions{
+		Overlay: &database.BrowseOverlay{Sources: []database.BrowseSource{
+			{PathPrefix: parentDir, IncludeDirs: true},
+		}},
+	}
+
+	// The merge statement is what the route used to take, and pinning its shape
+	// first is what gives the assertion below its meaning: "ParentDir=?" is the
+	// read of every file sitting in the route, and asserting its absence only
+	// says something because it is present here.
+	mergePlan := browseOverlayCountPlan(ctx, t, mediaDB, &database.BrowseOverlay{
+		Sources: []database.BrowseSource{
+			{PathPrefix: parentDir, IncludeDirs: true},
+			{PathPrefix: parentDir, IncludeDirs: true},
+		},
+	})
+	t.Logf("merge EXPLAIN QUERY PLAN:\n%s", mergePlan)
+	require.Contains(t, mergePlan, "ParentDir=?",
+		"the merge statement is expected to read the route's files out of Media; plan:\n%s", mergePlan)
+
+	count, err := sqlBrowseFileCount(ctx, mediaDB.sql.Load(), opts)
+	require.NoError(t, err)
+	require.Equal(t, 200, count, "the collapsed count must still be the route's direct files")
+
+	plan := browseSingleRouteCountPlan(ctx, t, mediaDB, opts)
+	t.Logf("single-route EXPLAIN QUERY PLAN:\n%s", plan)
+
+	assert.Contains(t, plan, "BrowseDirCounts",
+		"a one-route overlay must count from the browse cache; plan:\n%s", plan)
+	assert.NotContains(t, plan, "ParentDir=?",
+		"reading Media by ParentDir means the count is still going through the route's "+
+			"files, which is the cost that timed out in #1398; plan:\n%s", plan)
+}
+
+// browseSingleRouteCountPlan returns the plan of the statement sqlBrowseFileCount
+// actually reaches for a one-route overlay, resolved the same way production
+// resolves it.
+func browseSingleRouteCountPlan(
+	ctx context.Context, t *testing.T, mediaDB *MediaDB,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // mirrors the production call
+) string {
+	t.Helper()
+
+	sole, single := browseOverlaySoleSource(opts.Overlay)
+	require.True(t, single, "the fixture must build a one-route overlay")
+	opts.Overlay = nil
+	opts.PathPrefix = sole.PathPrefix
+
+	count, usable, err := sqlBrowseDirectFileCountFromCache(ctx, mediaDB.sql.Load(), opts)
+	require.NoError(t, err)
+	require.True(t, usable, "the fixture must leave the cache serving this count")
+	require.Equal(t, 200, count)
+
+	// sqlBrowseDirectFileCountFromCache resolves the parent id first and then
+	// runs the count, so plan the statement it builds with that id bound.
+	parentID, ok, err := sqlBrowseDirID(ctx, mediaDB.sql.Load(), opts.PathPrefix)
+	require.NoError(t, err)
+	require.True(t, ok)
+	query := `SELECT COALESCE(SUM(c.FileCount), 0)
+		FROM BrowseDirCounts c
+		INNER JOIN Systems s ON c.SystemDBID = s.DBID
+		WHERE c.ParentDirDBID = ? AND c.ChildDirDBID = c.ParentDirDBID`
+	args := []any{parentID}
+	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
+		query += ` AND ` + systemClause
+		args = append(args, systemArgs...)
+	}
+	return browseQueryPlan(ctx, t, mediaDB, query, args)
+}
+
+// TestBrowseOverlayPlan_MergeRanksWithoutSorting is the regression guard for the
+// multi-route half of #1398.
+//
+// The merge used to pick one row per filename with
+// ROW_NUMBER() OVER (PARTITION BY <filename>), which makes SQLite sort every
+// direct file in every route through a temp B-tree before it can emit a row. On
+// the device corpus (two routes over 20,000 files) that was 8.7 s to count and
+// 11.0 s to list, and the listing paid for two sorts because the output ORDER BY
+// sorted the winners again.
+//
+// Ranking is now the equivalent predicate "no higher-priority route supplies
+// this name", so the count sorts nothing at all and the listing sorts once. The
+// rival lookup has to resolve through media_path_idx: it is an equality on a
+// path concatenated from the outer row, and the same misleading media_missing_idx
+// stat that caused #1279 is in play here.
+func TestBrowseOverlayPlan_MergeRanksWithoutSorting(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	defer cleanup()
+
+	parentDir := seedBrowsePlanTestDB(t, mediaDB, 200)
+	seedAnalysisLimitedStats(ctx, t, mediaDB)
+
+	overlay := &database.BrowseOverlay{Sources: []database.BrowseSource{
+		{PathPrefix: parentDir, IncludeDirs: true},
+		{PathPrefix: parentDir, IncludeDirs: true},
+	}}
+
+	countPlan := browseOverlayCountPlan(ctx, t, mediaDB, overlay)
+	t.Logf("count EXPLAIN QUERY PLAN:\n%s", countPlan)
+	assert.NotContains(t, countPlan, "TEMP B-TREE",
+		"counting must not sort the routes' files; that sort is what made a merged "+
+			"root time out in #1398. plan:\n%s", countPlan)
+	assert.Contains(t, countPlan, "media_path_idx",
+		"the rival lookup must resolve by path, not by scanning Media. plan:\n%s", countPlan)
+	assert.NotContains(t, countPlan, "media_missing_idx",
+		"media_missing_idx matches every present row, so using it here makes each "+
+			"candidate scan the whole Media table (see #1279). plan:\n%s", countPlan)
+
+	filesQuery, filesArgs := browseOverlayFilesQuery(&database.BrowseFilesOptions{
+		Overlay: overlay,
+		Limit:   26,
+	})
+	filesPlan := browseQueryPlan(ctx, t, mediaDB, filesQuery, filesArgs)
+	t.Logf("files EXPLAIN QUERY PLAN:\n%s", filesPlan)
+	assert.Equal(t, 1, strings.Count(filesPlan, "TEMP B-TREE"),
+		"only the merged handful of candidates may be sorted. A sort inside a route's "+
+			"branch means that route is being read in full before the page is cut, "+
+			"which is the 11 s the merged listing used to cost. plan:\n%s", filesPlan)
+	assert.Equal(t, len(overlay.Sources), strings.Count(filesPlan, "idx_media_browse_sort (ParentDir=?"),
+		"each route must be read in sort order straight off idx_media_browse_sort, so "+
+			"its branch can stop at the page size. plan:\n%s", filesPlan)
+	assert.Contains(t, filesPlan, "media_path_idx",
+		"the rival lookup must resolve by path here too. plan:\n%s", filesPlan)
+}
+
 // browseOverlayCountPlan returns the joined EXPLAIN QUERY PLAN lines for the
 // overlay file-count statement, built exactly as production builds it.
 func browseOverlayCountPlan(

--- a/pkg/database/mediadb/browse_overlay_plan_test.go
+++ b/pkg/database/mediadb/browse_overlay_plan_test.go
@@ -220,7 +220,7 @@ func TestBrowseOverlayPlan_MergeRanksWithoutSorting(t *testing.T) {
 	filesQuery, filesArgs := browseOverlayFilesQuery(&database.BrowseFilesOptions{
 		Overlay: overlay,
 		Limit:   26,
-	})
+	}, browseTagPlan{})
 	filesPlan := browseQueryPlan(ctx, t, mediaDB, filesQuery, filesArgs)
 	t.Logf("files EXPLAIN QUERY PLAN:\n%s", filesPlan)
 	assert.Equal(t, 1, strings.Count(filesPlan, "TEMP B-TREE"),
@@ -241,7 +241,7 @@ func browseOverlayCountPlan(
 ) string {
 	t.Helper()
 
-	query, args := browseOverlayFileCountQuery(database.BrowseFileCountOptions{Overlay: overlay})
+	query, args := browseOverlayFileCountQuery(database.BrowseFileCountOptions{Overlay: overlay}, browseTagPlan{})
 	rows, err := mediaDB.sql.Load().QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, rows.Close()) }()

--- a/pkg/database/mediadb/browse_overlay_single_route_test.go
+++ b/pkg/database/mediadb/browse_overlay_single_route_test.go
@@ -1,0 +1,380 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	zapscript "github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// singleRouteFixture is one system with media under the route the overlay
+// browses and under an unrelated directory that must never leak into a result,
+// plus an empty route used only as the merge oracle's second source.
+type singleRouteFixture struct {
+	mediaDB *MediaDB
+	route   string
+	empty   string
+	system  systemdefs.System
+}
+
+// The empty second route is the oracle for every collapse assertion below. It
+// holds no media, so it can neither shadow nor dedupe anything, which makes a
+// two-route overlay over it exactly the one-route overlay - except that it goes
+// through the merge statement rather than the collapsed one. Comparing the two
+// runs the production merge against the collapsed shape on the same data.
+func (f *singleRouteFixture) sole() *database.BrowseOverlay {
+	return &database.BrowseOverlay{Sources: []database.BrowseSource{
+		{PathPrefix: f.route, IncludeDirs: true},
+	}}
+}
+
+func (f *singleRouteFixture) merged() *database.BrowseOverlay {
+	return &database.BrowseOverlay{Sources: []database.BrowseSource{
+		{PathPrefix: f.route, IncludeDirs: true},
+		{PathPrefix: f.empty, IncludeDirs: true},
+	}}
+}
+
+func (f *singleRouteFixture) systems() []systemdefs.System {
+	return []systemdefs.System{f.system}
+}
+
+func setupSingleRouteFixture(t *testing.T) (fixture *singleRouteFixture, cleanup func()) {
+	t.Helper()
+	mediaDB, cleanup := setupTempMediaDB(t)
+
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	route := browseTestDir("games", "NES")
+	empty := browseTestDir("empty", "NES")
+	elsewhere := browseTestDir("elsewhere", "NES")
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	regionType, err := mediaDB.FindOrInsertTagType(database.TagType{Type: "region"})
+	require.NoError(t, err)
+	usa, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: regionType.DBID, Tag: "usa"})
+	require.NoError(t, err)
+
+	insert := func(name, path string, tagged bool) {
+		t.Helper()
+		title, titleErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: system.DBID,
+			Slug:       slugs.Slugify(nesSystem.GetMediaType(), name+path),
+			Name:       name,
+		})
+		require.NoError(t, titleErr)
+		row, mediaErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     system.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           path,
+			ParentDir:      filepath.ToSlash(filepath.Dir(path)) + "/",
+			SortName:       name,
+		})
+		require.NoError(t, mediaErr)
+		if !tagged {
+			return
+		}
+		_, tagErr := mediaDB.InsertMediaTag(database.MediaTag{MediaDBID: row.DBID, TagDBID: usa.DBID})
+		require.NoError(t, tagErr)
+	}
+
+	// Direct files, spread across letters so the letter filter has something to
+	// exclude, and one of them tagged so the tag filter does too.
+	insert("Astro Blaster", route+"Astro Blaster.nes", true)
+	insert("Aqua Jet", route+"Aqua Jet.nes", false)
+	insert("Bubble Racer", route+"Bubble Racer.nes", false)
+	insert("Comet Chase", route+"Comet Chase.nes", true)
+	// A subdirectory, and a directory whose name is also a direct file. With one
+	// route nothing can shadow either, and both must survive the collapse.
+	insert("Inside Collection", route+"Collection/Inside Collection.nes", false)
+	insert("Shadow", route+"Shadow", false)
+	insert("Inside Shadow", route+"Shadow/Inside Shadow.nes", false)
+	insert("Unrelated", elsewhere+"Unrelated.nes", false)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	return &singleRouteFixture{
+		mediaDB: mediaDB,
+		system:  *nesSystem,
+		route:   route,
+		empty:   empty,
+	}, cleanup
+}
+
+// TestBrowseOverlaySingleRoute_MatchesTheMergeStatement is the correctness guard
+// for the #1398 collapse: a one-route overlay skips the merge machinery, so the
+// results have to be the ones the merge would have produced.
+func TestBrowseOverlaySingleRoute_MatchesTheMergeStatement(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	letter := "A"
+	tags := []zapscript.TagFilter{{Type: "region", Value: "usa"}}
+
+	for _, cached := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cache=%t", cached), func(t *testing.T) {
+			t.Parallel()
+			fixture, cleanup := setupSingleRouteFixture(t)
+			defer cleanup()
+			if cached {
+				require.NoError(t, sqlPopulateBrowseCache(ctx, fixture.mediaDB.sql.Load()))
+			}
+			db := fixture.mediaDB
+
+			t.Run("file count", func(t *testing.T) {
+				for _, tc := range []struct {
+					letter *string
+					name   string
+					tags   []zapscript.TagFilter
+				}{
+					{name: "unfiltered"},
+					{name: "letter", letter: &letter},
+					{name: "tags", tags: tags},
+				} {
+					opts := func(overlay *database.BrowseOverlay) database.BrowseFileCountOptions {
+						return database.BrowseFileCountOptions{
+							Overlay: overlay,
+							Letter:  tc.letter,
+							Tags:    tc.tags,
+							Systems: fixture.systems(),
+						}
+					}
+					merged, err := db.BrowseFileCount(ctx, opts(fixture.merged()))
+					require.NoError(t, err)
+					sole, err := db.BrowseFileCount(ctx, opts(fixture.sole()))
+					require.NoError(t, err)
+					assert.Equal(t, merged, sole, "%s file count", tc.name)
+
+					plain, err := db.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+						PathPrefix: fixture.route,
+						Letter:     tc.letter,
+						Tags:       tc.tags,
+						Systems:    fixture.systems(),
+					})
+					require.NoError(t, err)
+					assert.Equal(t, plain, sole, "%s file count against the plain browse", tc.name)
+				}
+			})
+
+			t.Run("dir count", func(t *testing.T) {
+				merged, err := db.BrowseDirCount(ctx, database.BrowseDirCountOptions{
+					Overlay: fixture.merged(),
+					Systems: fixture.systems(),
+				})
+				require.NoError(t, err)
+				sole, err := db.BrowseDirCount(ctx, database.BrowseDirCountOptions{
+					Overlay: fixture.sole(),
+					Systems: fixture.systems(),
+				})
+				require.NoError(t, err)
+				assert.Equal(t, merged, sole)
+				assert.Equal(t, 2, sole, "Collection and Shadow are both directories under the route")
+			})
+
+			t.Run("directories", func(t *testing.T) {
+				merged, err := db.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+					Overlay: fixture.merged(),
+					Systems: fixture.systems(),
+				})
+				require.NoError(t, err)
+				sole, err := db.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+					Overlay: fixture.sole(),
+					Systems: fixture.systems(),
+				})
+				require.NoError(t, err)
+				assert.Equal(t, merged, sole)
+				require.Len(t, sole, 2)
+				assert.Equal(t, fixture.route+"Collection", sole[0].Path,
+					"the collapsed statement still returns the route-qualified path")
+			})
+
+			t.Run("directories paged", func(t *testing.T) {
+				opts := func(overlay *database.BrowseOverlay) database.BrowseDirectoriesOptions {
+					return database.BrowseDirectoriesOptions{
+						Overlay:   overlay,
+						AfterName: "Collection",
+						Systems:   fixture.systems(),
+						Limit:     1,
+					}
+				}
+				merged, err := db.BrowseDirectories(ctx, opts(fixture.merged()))
+				require.NoError(t, err)
+				sole, err := db.BrowseDirectories(ctx, opts(fixture.sole()))
+				require.NoError(t, err)
+				assert.Equal(t, merged, sole)
+				require.Len(t, sole, 1)
+				assert.Equal(t, "Shadow", sole[0].Name)
+			})
+
+			t.Run("directories excluded route", func(t *testing.T) {
+				excluded := &database.BrowseOverlay{Sources: []database.BrowseSource{
+					{PathPrefix: fixture.route, IncludeDirs: false},
+				}}
+				dirs, err := db.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+					Overlay: excluded,
+					Systems: fixture.systems(),
+				})
+				require.NoError(t, err)
+				assert.Empty(t, dirs, "a route excluded from the listing contributes no directories")
+
+				count, err := db.BrowseDirCount(ctx, database.BrowseDirCountOptions{
+					Overlay: excluded,
+					Systems: fixture.systems(),
+				})
+				require.NoError(t, err)
+				assert.Equal(t, 0, count)
+			})
+
+			t.Run("files", func(t *testing.T) {
+				for _, tc := range []struct {
+					letter *string
+					name   string
+					sort   string
+					tags   []zapscript.TagFilter
+				}{
+					{name: "unfiltered"},
+					{name: "filename order", sort: "filename-asc"},
+					{name: "descending", sort: "name-desc"},
+					{name: "letter", letter: &letter},
+					{name: "tags", tags: tags},
+				} {
+					opts := func(overlay *database.BrowseOverlay) *database.BrowseFilesOptions {
+						return &database.BrowseFilesOptions{
+							Overlay: overlay,
+							Letter:  tc.letter,
+							Tags:    tc.tags,
+							Sort:    tc.sort,
+							Systems: fixture.systems(),
+							Limit:   10,
+						}
+					}
+					merged, err := db.BrowseFiles(ctx, opts(fixture.merged()))
+					require.NoError(t, err)
+					sole, err := db.BrowseFiles(ctx, opts(fixture.sole()))
+					require.NoError(t, err)
+					assert.Equal(t, merged, sole, "%s files", tc.name)
+					assert.NotEmpty(t, sole, "%s files", tc.name)
+				}
+			})
+
+			t.Run("files paged", func(t *testing.T) {
+				first, err := db.BrowseFiles(ctx, &database.BrowseFilesOptions{
+					Overlay: fixture.sole(),
+					Systems: fixture.systems(),
+					Limit:   2,
+				})
+				require.NoError(t, err)
+				require.Len(t, first, 2)
+
+				opts := func(overlay *database.BrowseOverlay) *database.BrowseFilesOptions {
+					return &database.BrowseFilesOptions{
+						Overlay: overlay,
+						Cursor: &database.BrowseCursor{
+							SortValue: first[1].SortValue,
+							LastID:    first[1].MediaID,
+						},
+						Systems: fixture.systems(),
+						Limit:   10,
+					}
+				}
+				merged, err := db.BrowseFiles(ctx, opts(fixture.merged()))
+				require.NoError(t, err)
+				sole, err := db.BrowseFiles(ctx, opts(fixture.sole()))
+				require.NoError(t, err)
+				assert.Equal(t, merged, sole)
+				assert.NotEmpty(t, sole)
+			})
+		})
+	}
+}
+
+// TestBrowseOverlayMultiRoute_StillMerges is the other half of the collapse: the
+// merge only becomes optional because one route has nothing to merge with, so a
+// real two-route overlay must still resolve names by priority.
+func TestBrowseOverlayMultiRoute_StillMerges(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	first := browseTestDir("first", "NES")
+	second := browseTestDir("second", "NES")
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insert := func(name, path string) {
+		t.Helper()
+		title, titleErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: system.DBID,
+			Slug:       slugs.Slugify(nesSystem.GetMediaType(), name+path),
+			Name:       name,
+		})
+		require.NoError(t, titleErr)
+		_, mediaErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     system.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           path,
+			ParentDir:      filepath.ToSlash(filepath.Dir(path)) + "/",
+			SortName:       name,
+		})
+		require.NoError(t, mediaErr)
+	}
+	insert("Winner", first+"Duplicate.nes")
+	insert("Loser", second+"Duplicate.nes")
+	insert("Only Second", second+"Unique.nes")
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	overlay := &database.BrowseOverlay{Sources: []database.BrowseSource{
+		{PathPrefix: first, IncludeDirs: true},
+		{PathPrefix: second, IncludeDirs: true},
+	}}
+	count, err := mediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+		Overlay: overlay,
+		Systems: []systemdefs.System{*nesSystem},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "the duplicate filename counts once across the two routes")
+
+	files, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		Overlay: overlay,
+		Systems: []systemdefs.System{*nesSystem},
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	paths := []string{files[0].Path, files[1].Path}
+	assert.Contains(t, paths, first+"Duplicate.nes", "the higher-priority route wins the name")
+	assert.NotContains(t, paths, second+"Duplicate.nes")
+}

--- a/pkg/database/mediadb/browse_tag_plan_test.go
+++ b/pkg/database/mediadb/browse_tag_plan_test.go
@@ -1,0 +1,253 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	zapscript "github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	tagPlanBigFiles   = 200
+	tagPlanSmallFiles = 5
+	tagPlanRareFiles  = 3
+)
+
+// tagPlanFixture is one big directory and one small one under the same system,
+// with a tag on nearly every file and a tag on a handful, which is the pair the
+// plan has to choose between.
+type tagPlanFixture struct {
+	mediaDB  *MediaDB
+	bigDir   string
+	smallDir string
+	system   systemdefs.System
+}
+
+func setupTagPlanFixture(t *testing.T) (fixture *tagPlanFixture, cleanup func()) {
+	t.Helper()
+	mediaDB, cleanup := setupTempMediaDB(t)
+
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	bigDir := browseTestDir("big", "NES")
+	smallDir := browseTestDir("small", "NES")
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	regionType, err := mediaDB.FindOrInsertTagType(database.TagType{Type: "region"})
+	require.NoError(t, err)
+	common, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: regionType.DBID, Tag: "common"})
+	require.NoError(t, err)
+	rare, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: regionType.DBID, Tag: "rare"})
+	require.NoError(t, err)
+
+	insert := func(dir, name, file string, tagDBIDs ...int64) {
+		t.Helper()
+		title, titleErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: system.DBID,
+			Slug:       slugs.Slugify(nesSystem.GetMediaType(), name+dir+file),
+			Name:       name,
+		})
+		require.NoError(t, titleErr)
+		row, mediaErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     system.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           dir + file,
+			ParentDir:      dir,
+			SortName:       name,
+		})
+		require.NoError(t, mediaErr)
+		for _, tagDBID := range tagDBIDs {
+			_, tagErr := mediaDB.InsertMediaTag(database.MediaTag{MediaDBID: row.DBID, TagDBID: tagDBID})
+			require.NoError(t, tagErr)
+		}
+	}
+
+	for i := range tagPlanBigFiles {
+		name := fmt.Sprintf("Big %03d", i)
+		tagIDs := []int64{common.DBID}
+		if i < tagPlanRareFiles {
+			tagIDs = append(tagIDs, rare.DBID)
+		}
+		insert(bigDir, name, fmt.Sprintf("big-%03d.nes", i), tagIDs...)
+	}
+	for i := range tagPlanSmallFiles {
+		insert(smallDir, fmt.Sprintf("Small %02d", i), fmt.Sprintf("small-%02d.nes", i), common.DBID)
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+	require.NoError(t, sqlPopulateBrowseCache(context.Background(), mediaDB.sql.Load()))
+
+	return &tagPlanFixture{
+		mediaDB: mediaDB, system: *nesSystem, bigDir: bigDir, smallDir: smallDir,
+	}, cleanup
+}
+
+// TestBrowseTagPlan_PicksTheSmallerSide pins the rule: resolve a tag from the
+// tag side only when it carries fewer rows than the browse would read.
+func TestBrowseTagPlan_PicksTheSmallerSide(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	f, cleanup := setupTagPlanFixture(t)
+	defer cleanup()
+	db := f.mediaDB.sql.Load()
+	systems := []systemdefs.System{f.system}
+	rare := []zapscript.TagFilter{{Type: "region", Value: "rare"}}
+	common := []zapscript.TagFilter{{Type: "region", Value: "common"}}
+
+	bigScope, known, err := sqlBrowseScopeRows(ctx, db, []string{f.bigDir}, systems)
+	require.NoError(t, err)
+	require.True(t, known)
+	assert.Equal(t, tagPlanBigFiles, bigScope)
+
+	plan := sqlBrowseTagPlan(ctx, db, rare, bigScope, true)
+	require.NotNil(t, plan.driveFromTag, "3 rows against a 200-file directory must drive from the tag")
+	assert.Equal(t, "rare", plan.driveFromTag.Value)
+
+	plan = sqlBrowseTagPlan(ctx, db, common, bigScope, true)
+	assert.Nil(t, plan.driveFromTag,
+		"a tag on every row of the directory is not the smaller side")
+
+	smallScope, known, err := sqlBrowseScopeRows(ctx, db, []string{f.smallDir}, systems)
+	require.NoError(t, err)
+	require.True(t, known)
+	plan = sqlBrowseTagPlan(ctx, db, common, smallScope, true)
+	assert.Nil(t, plan.driveFromTag,
+		"a common tag against a small directory must stay on candidate probes, which is "+
+			"the case that gets slower when driven from the tag side")
+
+	// Without a scope there is nothing to compare against, so the browse keeps
+	// the behaviour it had.
+	plan = sqlBrowseTagPlan(ctx, db, rare, 0, false)
+	assert.Nil(t, plan.driveFromTag)
+}
+
+// TestBrowseTagPlan_ShapesAgree is the correctness guard. The plan only changes
+// which side a filter is resolved from, so both shapes have to return the same
+// rows and the same total for every filter, whichever side the plan picks.
+func TestBrowseTagPlan_ShapesAgree(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	f, cleanup := setupTagPlanFixture(t)
+	t.Cleanup(cleanup)
+	db := f.mediaDB.sql.Load()
+	systems := []systemdefs.System{f.system}
+
+	for _, testCase := range []struct {
+		name string
+		tags []zapscript.TagFilter
+		want int
+	}{
+		{name: "rare", tags: []zapscript.TagFilter{{Type: "region", Value: "rare"}}, want: tagPlanRareFiles},
+		{name: "common", tags: []zapscript.TagFilter{{Type: "region", Value: "common"}}, want: tagPlanBigFiles},
+		{name: "absent", tags: []zapscript.TagFilter{{Type: "region", Value: "nosuch"}}, want: 0},
+		{name: "both", tags: []zapscript.TagFilter{
+			{Type: "region", Value: "rare"}, {Type: "region", Value: "common"},
+		}, want: tagPlanRareFiles},
+		{name: "not", tags: []zapscript.TagFilter{
+			{Type: "region", Value: "rare", Operator: zapscript.TagOperatorNOT},
+		}, want: tagPlanBigFiles - tagPlanRareFiles},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			countOpts := database.BrowseFileCountOptions{
+				PathPrefix: f.bigDir,
+				Systems:    systems,
+				Tags:       testCase.tags,
+			}
+			filesOpts := &database.BrowseFilesOptions{
+				PathPrefix: f.bigDir,
+				Systems:    systems,
+				Tags:       testCase.tags,
+				Limit:      1000,
+			}
+
+			probed := browseTagCountWithPlan(ctx, t, db, countOpts, browseTagPlan{})
+			assert.Equal(t, testCase.want, probed, "candidate-probe total")
+
+			for _, filter := range browseTagDriverCandidates(testCase.tags) {
+				driven := browseTagCountWithPlan(ctx, t, db, countOpts,
+					browseTagPlan{driveFromTag: &filter})
+				assert.Equal(t, probed, driven,
+					"driving from %s:%s must not change the total", filter.Type, filter.Value)
+
+				probedRows := browseTagPathsWithPlan(ctx, t, db, filesOpts, browseTagPlan{})
+				drivenRows := browseTagPathsWithPlan(ctx, t, db, filesOpts,
+					browseTagPlan{driveFromTag: &filter})
+				assert.Equal(t, probedRows, drivenRows,
+					"driving from %s:%s must not change the rows", filter.Type, filter.Value)
+				assert.Len(t, probedRows, probed, "the total must match the rows returned")
+			}
+		})
+	}
+}
+
+func browseTagCountWithPlan(
+	ctx context.Context, t *testing.T, db sqlQueryable,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // mirrors the production call
+	plan browseTagPlan,
+) int {
+	t.Helper()
+	where, args := browseFilesBaseCondition(&database.BrowseFilesOptions{
+		PathPrefix: opts.PathPrefix,
+		Letter:     opts.Letter,
+		Systems:    opts.Systems,
+		Tags:       opts.Tags,
+	}, plan)
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM Media m
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		WHERE `+where, args...).Scan(&count))
+	return count
+}
+
+func browseTagPathsWithPlan(
+	ctx context.Context, t *testing.T, db sqlQueryable,
+	opts *database.BrowseFilesOptions, plan browseTagPlan,
+) []string {
+	t.Helper()
+	where, args := browseFilesBaseCondition(opts, plan)
+	rows, err := db.QueryContext(ctx, `SELECT m.Path
+		FROM Media m
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		WHERE `+where+` ORDER BY m.Path`, args...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var paths []string
+	for rows.Next() {
+		var path string
+		require.NoError(t, rows.Scan(&path))
+		paths = append(paths, path)
+	}
+	require.NoError(t, rows.Err())
+	return paths
+}

--- a/pkg/database/mediadb/frontend_prereq_plan_test.go
+++ b/pkg/database/mediadb/frontend_prereq_plan_test.go
@@ -103,7 +103,7 @@ func TestFrontendPrerequisiteQueryPlansUseExistingIndexes(t *testing.T) {
 			Tags:       favorite,
 			Limit:      100,
 		}
-		whereClause, args := browseFilesBaseCondition(opts)
+		whereClause, args := browseFilesBaseCondition(opts, browseTagPlan{})
 		args = append(args, opts.Limit)
 		plan := randomQueryPlan(t, mediaDB.sql.Load(), `
 			SELECT m.DBID

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -3033,13 +3033,23 @@ func (db *MediaDB) BrowseFileCount(
 }
 
 // BrowseDirCount returns the total number of immediate child directories under a path prefix.
+//
+// Goes through beginBrowse like every other browse entry point. It used to read
+// the pool directly, which left the one browse statement that can list a whole
+// route's directories with no timing line of its own: in #1398 its cost showed
+// only as an unexplained gap between two logged calls.
 func (db *MediaDB) BrowseDirCount(
 	ctx context.Context, opts database.BrowseDirCountOptions,
 ) (int, error) {
 	if db.sql.Load() == nil {
 		return 0, ErrNullSQL
 	}
-	count, err := sqlBrowseDirCount(ctx, db.sql.Load(), opts)
+	call, err := db.beginBrowse(ctx, "browse dir count", len(browseOverlaySources(opts.Overlay)))
+	if err != nil {
+		return 0, err
+	}
+	defer call.finish(db)
+	count, err := sqlBrowseDirCount(ctx, call.conn, opts)
 	db.NoteCorruption(err)
 	return count, err
 }

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -553,6 +553,28 @@ func browseOverlaySources(overlay *database.BrowseOverlay) []database.BrowseSour
 	return overlay.Sources
 }
 
+// browseOverlaySoleSource returns the only route of a one-route overlay.
+//
+// A one-route overlay has nothing to merge, so every part of the merge costs
+// without changing the answer. Priorities are the slice index, so the only route
+// is priority 0 and no route can outrank it: the higher-priority checks
+// (overlayHigherPriorityDirectoryCondition and the direct_files shadow) are
+// constant-false. Media.Path is unique and ParentDir is fixed by the join, so
+// the filename the merge partitions by is unique per row and every row is its
+// own winner. What is left is a plain browse of that one prefix, which is the
+// shape the browse cache can answer.
+//
+// This is what #1398 hit: a system with one route spent 30 s counting the files
+// in its root through the merge query while the cache held the same number, and
+// media.browse died on the 30 s API timeout.
+func browseOverlaySoleSource(overlay *database.BrowseOverlay) (source database.BrowseSource, ok bool) {
+	sources := browseOverlaySources(overlay)
+	if len(sources) != 1 {
+		return database.BrowseSource{}, false
+	}
+	return sources[0], true
+}
+
 func sqlBrowseDirectories(
 	ctx context.Context,
 	db sqlQueryable,
@@ -624,6 +646,16 @@ const browseOverlayDirectoryTail = `ranked AS (
 		SELECT name, file_count, system_ids, parent_dir || name
 		FROM ranked
 		WHERE source_rank = 1`
+
+// browseOverlaySingleRouteDirectoryTail replaces browseOverlayDirectoryTail for
+// a one-route overlay. Both merge steps are inert there: nothing outranks
+// priority 0, so no candidate can be shadowed, and one route cannot list the
+// same name twice, so every candidate is its own winner. Dropping them also
+// drops the direct_files CTE, which reads every file sitting directly in the
+// route just to compare names. See browseOverlaySoleSource.
+const browseOverlaySingleRouteDirectoryTail = ` SELECT name, file_count, system_ids, parent_dir || name
+		FROM directory_candidates
+		WHERE TRUE`
 
 // sqlBrowseOverlayDirectories lists the merged immediate subdirectories of an
 // overlay's routes, preferring the browse cache and falling back to Media.
@@ -741,7 +773,11 @@ func browseOverlayDirectoriesCacheQuery(
 	}
 	query += `
 			GROUP BY sources.parent_dir, sources.priority, child.DBID, child.Name
-		), ` + browseOverlayDirectFilesCTE(systemClause)
+		)`
+	if len(sources) == 1 {
+		return query + browseOverlaySingleRouteDirectoryTail, args
+	}
+	query += `, ` + browseOverlayDirectFilesCTE(systemClause)
 	if systemClause != "" {
 		args = append(args, systemArgs...)
 	}
@@ -799,7 +835,11 @@ func browseOverlayDirectoriesMediaQuery(
 			FROM matched_dirs
 			WHERE instr(rest, '/') > 0
 			GROUP BY parent_dir, priority, name
-		), ` + browseOverlayDirectFilesCTE(systemClause)
+		)`
+	if len(sources) == 1 {
+		return query + browseOverlaySingleRouteDirectoryTail, args
+	}
+	query += `, ` + browseOverlayDirectFilesCTE(systemClause)
 	if systemClause != "" {
 		args = append(args, systemArgs...)
 	}
@@ -1337,67 +1377,277 @@ const overlayHigherPriorityDirectoryCondition = `NOT EXISTS (
 		AND descendant.ParentDir < higher.parent_dir || substr(m.Path, length(m.ParentDir) + 1) || '/' || char(1114111)
 )`
 
+// browseOverlayPreferredRouteCondition drops a candidate whose filename a
+// higher-priority route already supplies as a file.
+//
+// This is exactly what ROW_NUMBER() OVER (PARTITION BY <filename> ORDER BY
+// priority) used to decide. A row ranked first precisely when no higher-priority
+// route held its name: one route cannot hold a name twice, because Path is
+// unique under a fixed ParentDir, and no two routes share a priority, because
+// priority is the slice index. So the rank test and this predicate select the
+// same rows.
+//
+// Ranking cost a temp B-tree sort of every direct file in every route before a
+// single row could be emitted. Measured on the #1398 MiSTer corpus, two routes
+// over 20,000 files: 8.7 s to count and 11.0 s to list. As a predicate the
+// highest-priority route short-circuits on priority = 0 without probing at all,
+// and every other route pays one equality lookup on media_path_idx per row.
+//
+// The rival must pass the same system filter as the candidate, because ranking
+// partitioned only over rows that had already passed it.
+func browseOverlayPreferredRouteCondition(systems []systemdefs.System) (condition string, args []any) {
+	condition = `(sources.priority = 0 OR NOT EXISTS (
+		SELECT 1
+		FROM sources preferred
+		INNER JOIN Media rival
+			ON rival.Path = preferred.parent_dir || substr(m.Path, length(m.ParentDir) + 1)
+		WHERE preferred.priority < sources.priority
+			AND rival.IsMissing = 0`
+	if clause, systemArgs := browseSystemFilterClause("rs.SystemID", systems); clause != "" {
+		condition += `
+			AND rival.SystemDBID IN (SELECT rs.DBID FROM Systems rs WHERE ` + clause + `)`
+		args = systemArgs
+	}
+	return condition + `
+	))`, args
+}
+
+// browseOverlayShadowedByDirectoryCondition is the directory shadow rule under
+// the same short-circuit: nothing outranks priority 0, so the first route never
+// runs the correlated probe.
+func browseOverlayShadowedByDirectoryCondition() string {
+	return `(sources.priority = 0 OR ` + overlayHigherPriorityDirectoryCondition + `)`
+}
+
+// browseOverlayMergeSource is the FROM clause both merge statements read
+// candidates through, and browseOverlaySourcesCTE the routes it joins against.
+const (
+	browseOverlaySourcesCTE  = `WITH sources(parent_dir, priority, include_dirs) AS (VALUES `
+	browseOverlayMergeSource = `FROM sources
+		INNER JOIN Media m ON m.ParentDir = sources.parent_dir
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID`
+)
+
+// browseOverlaySourceValues renders the routes as the sources CTE's VALUES rows.
+func browseOverlaySourceValues(sources []database.BrowseSource) (values string, args []any) {
+	rows := make([]string, len(sources))
+	args = make([]any, 0, len(sources)*3+16)
+	for i := range sources {
+		rows[i] = "(?, ?, ?)"
+		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
+	}
+	return strings.Join(rows, ","), args
+}
+
+// browseOverlayRouteDedupeCondition drops a candidate whose filename one
+// specific higher-priority route already supplies as a file. Takes the route's
+// prefix as an argument so it can sit inside a per-route branch, where the
+// candidate's own route is fixed and there is no sources CTE to join against.
+const browseOverlayRouteDedupeCondition = `NOT EXISTS (
+			SELECT 1 FROM Media rival
+			WHERE rival.Path = ? || substr(m.Path, length(m.ParentDir) + 1)
+				AND rival.IsMissing = 0`
+
+// browseOverlayRouteShadowCondition is overlayHigherPriorityDirectoryCondition
+// for one specific higher-priority route. Same reasoning, same load-bearing
+// INDEXED BY: the ParentDir bounds are built by concatenation from the outer
+// row, so without the hint the planner takes media_missing_idx and each
+// candidate scans the whole of Media (#1279).
+const browseOverlayRouteShadowCondition = `NOT EXISTS (
+			SELECT 1 FROM Media descendant INDEXED BY idx_media_browse_sort
+			WHERE descendant.IsMissing = 0
+				AND descendant.ParentDir >= ? || substr(m.Path, length(m.ParentDir) + 1) || '/'
+				AND descendant.ParentDir < ? || substr(m.Path, length(m.ParentDir) + 1) || '/' || char(1114111)
+		)`
+
+// browseOverlayRouteMergeConditions returns the merge predicates route i must
+// pass, one pair per route the merge prefers, along with their arguments.
+func browseOverlayRouteMergeConditions(
+	sources []database.BrowseSource, index int, systems []systemdefs.System,
+) (conditions []string, args []any) {
+	systemClause, systemArgs := browseSystemFilterClause("rs.SystemID", systems)
+	for j := range index {
+		dedupe := browseOverlayRouteDedupeCondition
+		args = append(args, sources[j].PathPrefix)
+		if systemClause != "" {
+			dedupe += `
+				AND rival.SystemDBID IN (SELECT rs.DBID FROM Systems rs WHERE ` + systemClause + `)`
+			args = append(args, systemArgs...)
+		}
+		conditions = append(conditions, dedupe+`
+		)`)
+		if !sources[j].IncludeDirs {
+			continue
+		}
+		conditions = append(conditions, browseOverlayRouteShadowCondition)
+		args = append(args, sources[j].PathPrefix, sources[j].PathPrefix)
+	}
+	return conditions, args
+}
+
+// browseOverlayRouteSort returns how one route's rows should be ordered and
+// seeked, given the sort the caller asked for and the route's prefix.
+//
+// A filename sort orders by substr(m.Path, length(m.ParentDir) + 1), which no
+// index can serve, so a route sorted that way has to be read in full. Within one
+// route the prefix is constant, so that suffix and m.Path put the rows in the
+// same order, and ordering by m.Path rides media_path_idx instead. The redundant
+// range is what lets the planner see it: m.ParentDir = ? already implies it, but
+// only as a fact about the data, not as bounds on the ordered column.
+//
+// The emitted SortValue stays the suffix either way, so cursors issued before
+// this and the merge across routes both keep working on the same values.
+func browseOverlayRouteSort(
+	sortExpr, prefix string, cursor *database.BrowseCursor,
+) browseRouteSort {
+	route := browseRouteSort{orderExpr: sortExpr}
+	if cursor != nil {
+		route.cursorValue = cursor.SortValue
+	}
+	if sortExpr != browseFilenameExpr() {
+		return route
+	}
+	route.orderExpr = "m.Path"
+	route.rangeClause = ` AND m.Path >= ? AND m.Path < ? || char(1114111)`
+	route.rangeArgs = []any{prefix, prefix}
+	if cursor != nil {
+		route.cursorValue = prefix + cursor.SortValue
+	}
+	return route
+}
+
+// browseRouteSort is how one route is ordered and seeked within the merge.
+type browseRouteSort struct {
+	cursorValue any
+	orderExpr   string
+	rangeClause string
+	rangeArgs   []any
+}
+
+// browseOverlayMergedFilesQuery reads each route's own best rows and merges
+// those, rather than reading every route in full and sorting the result.
+//
+// A merged root cannot ride one index the way a single directory can, so the
+// flat statement had to read every direct file in every route and sort them for
+// one page. On the #1398 device corpus, two routes over 20,000 files, that was
+// 11.0 s a page. Each route on its own is an ordered range of
+// idx_media_browse_sort, so a per-route branch stops as soon as it has Limit
+// rows, and the outer query merges at most one page per route.
+//
+// Taking each route's top rows is safe because the merge predicates are applied
+// inside the branch, before its LIMIT: a branch yields that route's best
+// surviving rows, and the best surviving rows overall are among them, which is
+// the ordinary k-way merge argument. Filtering after the LIMIT instead would
+// not be safe, because a route whose leading rows are all dropped would hide
+// the surviving rows behind them.
+func browseOverlayMergedFilesQuery(
+	opts *database.BrowseFilesOptions, sortExpr, direction, cursorOp string,
+) (query string, args []any) {
+	sources := browseOverlaySources(opts.Overlay)
+	branches := make([]string, len(sources))
+	for i := range sources {
+		routeOpts := *opts
+		routeOpts.PathPrefix = sources[i].PathPrefix
+		where, whereArgs := browseFilesFilterCondition(&routeOpts, true)
+		args = append(args, whereArgs...)
+
+		route := browseOverlayRouteSort(sortExpr, sources[i].PathPrefix, opts.Cursor)
+		where += route.rangeClause
+		args = append(args, route.rangeArgs...)
+
+		mergeConditions, mergeArgs := browseOverlayRouteMergeConditions(sources, i, opts.Systems)
+		if len(mergeConditions) > 0 {
+			where += `
+			AND ` + strings.Join(mergeConditions, `
+			AND `)
+		}
+		args = append(args, mergeArgs...)
+
+		if opts.Cursor != nil {
+			where += `
+			AND (` + route.orderExpr + `, m.DBID) ` + cursorOp + ` (?, ?)`
+			args = append(args, route.cursorValue, opts.Cursor.LastID)
+		}
+		branches[i] = `SELECT * FROM (
+			SELECT m.DBID AS dbid, ` + sortExpr + ` AS sortval
+			FROM Media m
+			INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			WHERE ` + where + `
+			ORDER BY ` + route.orderExpr + ` ` + direction + `, m.DBID ` + direction + `
+			LIMIT ?
+		)`
+		args = append(args, opts.Limit)
+	}
+
+	// A subquery column carries no explicit collation, so the merge has to name
+	// the same one again or it would order the branches by BINARY.
+	mergeOrder := "candidates.sortval"
+	if sortExpr == browseTitleSortExpr() {
+		mergeOrder += " COLLATE " + browseTitleCollationName
+	}
+	return `WITH candidates AS (
+		` + strings.Join(branches, `
+		UNION ALL
+		`) + `
+	)
+	SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID,
+		mt.DisambiguationTypes, candidates.sortval AS SortValue
+	FROM candidates
+	INNER JOIN Media m ON m.DBID = candidates.dbid
+	INNER JOIN Systems s ON m.SystemDBID = s.DBID
+	INNER JOIN MediaTitles mt ON mt.DBID = m.MediaTitleDBID
+	ORDER BY ` + mergeOrder + ` ` + direction + `, m.DBID ` + direction + `
+	LIMIT ?`, append(args, opts.Limit)
+}
+
+// browseOverlayFilesQuery builds the overlay file-listing statement and its
+// arguments. Separate from the exec so the query-plan regression test can
+// measure the statement production actually runs, matching
+// browseOverlayFileCountQuery.
+func browseOverlayFilesQuery(opts *database.BrowseFilesOptions) (query string, args []any) {
+	sortExpr := browseTitleSortExpr()
+	if opts.Sort == "filename-asc" || opts.Sort == "filename-desc" {
+		sortExpr = browseFilenameExpr()
+	}
+	direction, cursorOp := "ASC", ">"
+	if opts.Sort == "name-desc" || opts.Sort == "filename-desc" {
+		direction, cursorOp = "DESC", "<"
+	}
+
+	sole, single := browseOverlaySoleSource(opts.Overlay)
+	if !single {
+		return browseOverlayMergedFilesQuery(opts, sortExpr, direction, cursorOp)
+	}
+
+	// One route has nothing to merge, so it reads Media directly and the route
+	// prefix is just the parent filter. See browseOverlaySoleSource.
+	routeOpts := *opts
+	routeOpts.PathPrefix = sole.PathPrefix
+	where, args := browseFilesFilterCondition(&routeOpts, true)
+	route := browseOverlayRouteSort(sortExpr, sole.PathPrefix, opts.Cursor)
+	where += route.rangeClause
+	args = append(args, route.rangeArgs...)
+	query = ` SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID,
+		mt.DisambiguationTypes, ` + sortExpr + ` AS SortValue
+		FROM Media m
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		INNER JOIN MediaTitles mt ON mt.DBID = m.MediaTitleDBID
+		WHERE ` + where
+	if opts.Cursor != nil {
+		query += ` AND (` + route.orderExpr + `, m.DBID) ` + cursorOp + ` (?, ?)`
+		args = append(args, route.cursorValue, opts.Cursor.LastID)
+	}
+	query += ` ORDER BY ` + route.orderExpr + ` ` + direction + `, m.DBID ` + direction + ` LIMIT ?`
+	return query, append(args, opts.Limit)
+}
+
 func sqlBrowseOverlayFilesFromMedia(
 	ctx context.Context,
 	db sqlQueryable,
 	opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {
-	sources := browseOverlaySources(opts.Overlay)
-	values := make([]string, len(sources))
-	args := make([]any, 0, len(sources)+16)
-	for i := range sources {
-		values[i] = "(?, ?, ?)"
-		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
-	}
-
-	winnerConditions := []string{"m.IsMissing = 0", overlayHigherPriorityDirectoryCondition}
-	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
-		winnerConditions = append(winnerConditions, systemClause)
-		args = append(args, systemArgs...)
-	}
-	query := `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
-		 ranked AS (
-			SELECT m.DBID,
-				ROW_NUMBER() OVER (
-					PARTITION BY substr(m.Path, length(m.ParentDir) + 1)
-					ORDER BY sources.priority ASC, m.DBID ASC
-				) AS source_rank
-			FROM sources
-			INNER JOIN Media m ON m.ParentDir = sources.parent_dir
-			INNER JOIN Systems s ON m.SystemDBID = s.DBID
-			WHERE ` + strings.Join(winnerConditions, " AND ") + `
-		)`
-
-	filterOpts := *opts
-	filterOpts.Systems = nil
-	where, filterArgs := browseFilesFilterCondition(&filterOpts, false)
-	args = append(args, filterArgs...)
+	query, args := browseOverlayFilesQuery(opts)
 	sortMode := opts.Sort
-	sortExpr := browseTitleSortExpr()
-	if opts.Sort == "filename-asc" || opts.Sort == "filename-desc" {
-		sortExpr = browseFilenameExpr()
-	}
-	query += ` SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID,
-		mt.DisambiguationTypes, ` + sortExpr + ` AS SortValue
-		FROM ranked
-		INNER JOIN Media m ON m.DBID = ranked.DBID
-		INNER JOIN Systems s ON m.SystemDBID = s.DBID
-		INNER JOIN MediaTitles mt ON mt.DBID = m.MediaTitleDBID
-		WHERE ranked.source_rank = 1 AND ` + where
-	if opts.Cursor != nil {
-		op := ">"
-		if opts.Sort == "name-desc" || opts.Sort == "filename-desc" {
-			op = "<"
-		}
-		query += ` AND (` + sortExpr + `, m.DBID) ` + op + ` (?, ?)`
-		args = append(args, opts.Cursor.SortValue, opts.Cursor.LastID)
-	}
-	direction := "ASC"
-	if opts.Sort == "name-desc" || opts.Sort == "filename-desc" {
-		direction = "DESC"
-	}
-	query += ` ORDER BY ` + sortExpr + ` ` + direction + `, m.DBID ` + direction + ` LIMIT ?`
-	args = append(args, opts.Limit)
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -1971,7 +2221,14 @@ func sqlBrowseFileCount(
 	opts database.BrowseFileCountOptions, //nolint:gocritic // internal call mirrors MediaDBI value options
 ) (int, error) {
 	if len(browseOverlaySources(opts.Overlay)) > 0 {
-		return sqlBrowseOverlayFileCount(ctx, db, opts)
+		sole, single := browseOverlaySoleSource(opts.Overlay)
+		if !single {
+			return sqlBrowseOverlayFileCount(ctx, db, opts)
+		}
+		// One route merges with nothing, so counting its direct files is a plain
+		// count under that prefix. See browseOverlaySoleSource.
+		opts.Overlay = nil
+		opts.PathPrefix = sole.PathPrefix
 	}
 
 	// Letter and tag scopes need row-level predicates absent from compact cache.
@@ -1997,40 +2254,26 @@ func sqlBrowseFileCount(
 func browseOverlayFileCountQuery(
 	opts database.BrowseFileCountOptions, //nolint:gocritic // mirrors the caller's value options
 ) (query string, args []any) {
-	sources := browseOverlaySources(opts.Overlay)
-	values := make([]string, len(sources))
-	args = make([]any, 0, len(sources)+16)
-	for i := range sources {
-		values[i] = "(?, ?, ?)"
-		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
-	}
-	winnerConditions := []string{"m.IsMissing = 0", overlayHigherPriorityDirectoryCondition}
-	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
-		winnerConditions = append(winnerConditions, systemClause)
-		args = append(args, systemArgs...)
-	}
-	filterOpts := &database.BrowseFilesOptions{
-		Letter: opts.Letter,
-		Tags:   opts.Tags,
-	}
-	where, filterArgs := browseFilesFilterCondition(filterOpts, false)
+	values, args := browseOverlaySourceValues(browseOverlaySources(opts.Overlay))
+
+	// One flat statement: the merge is two predicates now, so there is no ranked
+	// CTE to materialise and no second pass over Media to re-read the winners.
+	where, filterArgs := browseFilesFilterCondition(&database.BrowseFilesOptions{
+		Letter:  opts.Letter,
+		Systems: opts.Systems,
+		Tags:    opts.Tags,
+	}, false)
 	args = append(args, filterArgs...)
-	return `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
-		ranked AS (
-			SELECT m.DBID,
-				ROW_NUMBER() OVER (
-					PARTITION BY substr(m.Path, length(m.ParentDir) + 1)
-					ORDER BY sources.priority ASC, m.DBID ASC
-				) AS source_rank
-			FROM sources
-			INNER JOIN Media m ON m.ParentDir = sources.parent_dir
-			INNER JOIN Systems s ON m.SystemDBID = s.DBID
-			WHERE ` + strings.Join(winnerConditions, " AND ") + `
-		)
+
+	preferred, preferredArgs := browseOverlayPreferredRouteCondition(opts.Systems)
+	args = append(args, preferredArgs...)
+
+	return browseOverlaySourcesCTE + values + `)
 		SELECT COUNT(*)
-		FROM ranked
-		INNER JOIN Media m ON m.DBID = ranked.DBID
-		WHERE ranked.source_rank = 1 AND ` + where, args
+		` + browseOverlayMergeSource + `
+		WHERE ` + where + `
+			AND ` + preferred + `
+			AND ` + browseOverlayShadowedByDirectoryCondition(), args
 }
 
 func sqlBrowseOverlayFileCount(
@@ -2038,12 +2281,187 @@ func sqlBrowseOverlayFileCount(
 	db sqlQueryable,
 	opts database.BrowseFileCountOptions, //nolint:gocritic // internal call mirrors MediaDBI value options
 ) (int, error) {
+	count, served, err := sqlBrowseTwoRouteFileCountFromCache(ctx, db, opts)
+	if err != nil || served {
+		return count, err
+	}
 	query, args := browseOverlayFileCountQuery(opts)
-	var count int
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("browse overlay file count: %w", err)
 	}
 	return count, nil
+}
+
+// sqlBrowseTwoRouteFileCountFromCache totals a two-route merged root without
+// reading either route's files.
+//
+// The statement below has to touch every direct file in every route, because
+// each one has to be checked against the routes the merge prefers. On the #1398
+// device corpus that was 7.8 s for two routes over 20,000 files, and the count
+// runs on the merged root's first page, so it lands in every request.
+//
+// The cache already holds each route's direct-file total. What it cannot hold is
+// which names the routes share, but that correction is bounded by the smaller
+// route rather than by the larger:
+//
+//	total = |route 0| + |route 1| - |names in both| - |route 1 names shadowed by a route 0 directory|
+//
+// Both corrections are driven from the small side — the smaller route's files
+// for the first, route 0's child directories for the second — so a big route
+// paired with a small one costs a handful of lookups rather than 20,000.
+//
+// Only two routes: three or more needs inclusion-exclusion over every subset,
+// and a system resolving to three roots is rare enough not to be worth that.
+// Anything this cannot answer falls back to the statement.
+func sqlBrowseTwoRouteFileCountFromCache(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // internal call mirrors MediaDBI value options
+) (count int, served bool, err error) {
+	sources := browseOverlaySources(opts.Overlay)
+	// A letter or tag filter is a row-level predicate the cached totals know
+	// nothing about.
+	if len(sources) != 2 || opts.Letter != nil || len(opts.Tags) > 0 {
+		return 0, false, nil
+	}
+	covered, err := sqlBrowseCacheCoversSystems(ctx, db, opts.Systems)
+	if err != nil || !covered {
+		return 0, false, err
+	}
+	ready, err := sqlBrowseCacheReady(ctx, db)
+	if err != nil || !ready {
+		return 0, false, err
+	}
+
+	totals := make([]int, len(sources))
+	for i := range sources {
+		routeOpts := opts
+		routeOpts.Overlay = nil
+		routeOpts.PathPrefix = sources[i].PathPrefix
+		routeTotal, usable, cacheErr := sqlBrowseDirectFileCountFromCache(ctx, db, routeOpts)
+		if cacheErr != nil || !usable {
+			return 0, false, cacheErr
+		}
+		totals[i] = routeTotal
+	}
+
+	// Shared names are symmetric, so drive the scan from whichever route holds
+	// fewer files and probe the other by path.
+	driver, probed := 0, 1
+	if totals[1] < totals[0] {
+		driver, probed = 1, 0
+	}
+	shared, err := sqlBrowseRouteSharedNameCount(
+		ctx, db, sources[driver].PathPrefix, sources[probed].PathPrefix, opts.Systems)
+	if err != nil {
+		return 0, false, err
+	}
+
+	shadowed := 0
+	if sources[0].IncludeDirs {
+		shadowed, served, err = sqlBrowseRouteShadowedNameCount(
+			ctx, db, sources[0].PathPrefix, sources[1].PathPrefix, opts.Systems)
+		if err != nil || !served {
+			return 0, false, err
+		}
+	}
+	return totals[0] + totals[1] - shared - shadowed, true, nil
+}
+
+// sqlBrowseRouteSharedNameCount counts the filenames both routes hold, scanning
+// driverPrefix and probing probedPrefix by path.
+func sqlBrowseRouteSharedNameCount(
+	ctx context.Context,
+	db sqlQueryable,
+	driverPrefix, probedPrefix string,
+	systems []systemdefs.System,
+) (int, error) {
+	args := []any{driverPrefix}
+	query := `SELECT COUNT(*)
+		FROM Media a
+		INNER JOIN Systems sa ON a.SystemDBID = sa.DBID
+		WHERE a.ParentDir = ? AND a.IsMissing = 0`
+	systemClause, systemArgs := browseSystemFilterClause("sa.SystemID", systems)
+	if systemClause != "" {
+		query += ` AND ` + systemClause
+		args = append(args, systemArgs...)
+	}
+	query += `
+		AND EXISTS (
+			SELECT 1 FROM Media b
+			INNER JOIN Systems sb ON b.SystemDBID = sb.DBID
+			WHERE b.Path = ? || substr(a.Path, length(a.ParentDir) + 1)
+				AND b.IsMissing = 0`
+	args = append(args, probedPrefix)
+	if clause, clauseArgs := browseSystemFilterClause("sb.SystemID", systems); clause != "" {
+		query += ` AND ` + clause
+		args = append(args, clauseArgs...)
+	}
+	query += `
+		)`
+
+	var count int
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("browse route shared name count: %w", err)
+	}
+	return count, nil
+}
+
+// sqlBrowseRouteShadowedNameCount counts the files in lowerPrefix whose name the
+// higher-priority route supplies as a directory, which the merge drops.
+//
+// The names come from the cache's child directories, which is why this is cheap:
+// a route has a handful of directories and tens of thousands of files. They are
+// deliberately not filtered by system, matching the statement's shadow rule,
+// where any media beneath the directory makes it shadow. Names the higher route
+// also holds as a file are excluded so they are not subtracted twice, once here
+// and once as a shared name.
+func sqlBrowseRouteShadowedNameCount(
+	ctx context.Context,
+	db sqlQueryable,
+	higherPrefix, lowerPrefix string,
+	systems []systemdefs.System,
+) (count int, served bool, err error) {
+	higherID, ok, err := sqlBrowseDirID(ctx, db, browseRouteCacheKey(higherPrefix))
+	if err != nil || !ok {
+		return 0, false, err
+	}
+
+	args := []any{higherID, lowerPrefix}
+	query := `SELECT COUNT(*)
+		FROM (
+			SELECT DISTINCT d.Name AS name
+			FROM BrowseDirCounts c
+			INNER JOIN BrowseDirs d ON c.ChildDirDBID = d.DBID
+			WHERE c.ParentDirDBID = ? AND c.ChildDirDBID != c.ParentDirDBID AND d.IsVirtual = 0
+		) dirs
+		WHERE EXISTS (
+			SELECT 1 FROM Media m
+			INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			WHERE m.Path = ? || dirs.name AND m.IsMissing = 0`
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", systems)
+	if systemClause != "" {
+		query += ` AND ` + systemClause
+		args = append(args, systemArgs...)
+	}
+	query += `
+		)
+		AND NOT EXISTS (
+			SELECT 1 FROM Media hm
+			INNER JOIN Systems hs ON hm.SystemDBID = hs.DBID
+			WHERE hm.Path = ? || dirs.name AND hm.IsMissing = 0`
+	args = append(args, higherPrefix)
+	if systemClause != "" {
+		query += ` AND ` + strings.ReplaceAll(systemClause, "s.SystemID", "hs.SystemID")
+		args = append(args, systemArgs...)
+	}
+	query += `
+		)`
+
+	if scanErr := db.QueryRowContext(ctx, query, args...).Scan(&count); scanErr != nil {
+		return 0, false, fmt.Errorf("browse route shadowed name count: %w", scanErr)
+	}
+	return count, true, nil
 }
 
 func sqlBrowseDirectFileCountFromCache(
@@ -2145,11 +2563,24 @@ func sqlBrowseDirCount(
 	opts database.BrowseDirCountOptions,
 ) (int, error) {
 	if len(browseOverlaySources(opts.Overlay)) > 0 {
-		dirs, overlayErr := sqlBrowseOverlayDirectories(ctx, db, database.BrowseDirectoriesOptions{
-			Overlay: opts.Overlay,
-			Systems: opts.Systems,
-		})
-		return len(dirs), overlayErr
+		sole, single := browseOverlaySoleSource(opts.Overlay)
+		if !single {
+			dirs, overlayErr := sqlBrowseOverlayDirectories(ctx, db, database.BrowseDirectoriesOptions{
+				Overlay: opts.Overlay,
+				Systems: opts.Systems,
+			})
+			return len(dirs), overlayErr
+		}
+		// A route excluded from the directory listing contributes no directories
+		// to count, matching the include_dirs = 1 filter the merge applies.
+		if !sole.IncludeDirs {
+			return 0, nil
+		}
+		// One route merges with nothing, so this is a plain child-directory count
+		// under that prefix, and the cache can answer it without listing every
+		// directory first. See browseOverlaySoleSource.
+		opts.Overlay = nil
+		opts.PathPrefix = sole.PathPrefix
 	}
 
 	ready, err := sqlBrowseCacheReady(ctx, db)

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	zapscript "github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/browseprefix"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
@@ -1132,15 +1133,177 @@ func browsePathPrefixCondition(column, pathPrefix string) (condition string, arg
 	return column + ` LIKE ? || '%'`, []any{pathPrefix}
 }
 
+// sqlBrowseScopeRows reports how many files a browse can read at most, summed
+// over its routes from the cache, so a tag filter has something to be compared
+// against. Reports ok=false when the cache cannot answer for every route.
+func sqlBrowseScopeRows(
+	ctx context.Context,
+	db sqlQueryable,
+	prefixes []string,
+	systems []systemdefs.System,
+) (rows int, ok bool, err error) {
+	if len(prefixes) == 0 {
+		return 0, false, nil
+	}
+	ready, err := sqlBrowseCacheReady(ctx, db)
+	if err != nil || !ready {
+		return 0, false, err
+	}
+	for _, prefix := range prefixes {
+		count, usable, countErr := sqlBrowseDirectFileCountFromCache(ctx, db, database.BrowseFileCountOptions{
+			PathPrefix: prefix,
+			Systems:    systems,
+		})
+		if countErr != nil || !usable {
+			return 0, false, countErr
+		}
+		rows += count
+	}
+	return rows, true, nil
+}
+
+// browseTagDriverCandidates returns the filters that could be resolved from the
+// tag side. Only required filters qualify: NOT filters already resolve to a
+// forward anti-set, OR filters are one grouped clause, and credit filters match
+// across three tag types, which the bounded count below does not model.
+func browseTagDriverCandidates(filters []zapscript.TagFilter) []zapscript.TagFilter {
+	candidates := make([]zapscript.TagFilter, 0, len(filters))
+	for _, filter := range filters {
+		if filter.Operator == zapscript.TagOperatorNOT || filter.Operator == zapscript.TagOperatorOR {
+			continue
+		}
+		if filter.Type == string(tags.TagTypeCredit) {
+			continue
+		}
+		candidates = append(candidates, filter)
+	}
+	return candidates
+}
+
+// sqlBrowseTagPlan picks the side a tag-filtered browse drives from, by finding
+// the required filter carrying fewer rows than the browse will read.
+//
+// The count stops at the scope, so the worst case reads scopeRows entries of
+// mediatags_tag_media_idx — one sequential pass over a covering index, to decide
+// whether to avoid that many random probes into two tag tables. Title tags are
+// counted as rows too, which overstates the media a tag covers and so errs
+// toward the probing the browse would have done anyway.
+func sqlBrowseTagPlan(
+	ctx context.Context,
+	db sqlQueryable,
+	filters []zapscript.TagFilter,
+	scopeRows int,
+	scopeKnown bool,
+) browseTagPlan {
+	if !scopeKnown || scopeRows <= 0 || len(filters) == 0 {
+		return browseTagPlan{}
+	}
+
+	var (
+		best      zapscript.TagFilter
+		bestRows  int
+		bestFound bool
+	)
+	for _, filter := range browseTagDriverCandidates(filters) {
+		tagType, tagValue := resolveFilter(filter.Type, filter.Value)
+		var rows int
+		err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM (
+			SELECT 1 FROM MediaTags
+				INNER JOIN Tags ON MediaTags.TagDBID = Tags.DBID
+				INNER JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+				WHERE TagTypes.Type = ? AND Tags.Tag = ?
+			UNION ALL
+			SELECT 1 FROM MediaTitleTags
+				INNER JOIN Tags ON MediaTitleTags.TagDBID = Tags.DBID
+				INNER JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+				WHERE TagTypes.Type = ? AND Tags.Tag = ?
+			LIMIT ?
+		)`, tagType, tagValue, tagType, tagValue, scopeRows).Scan(&rows)
+		if err != nil {
+			// A browse that still works is worth more than the faster shape.
+			log.Debug().Err(err).Str("tag", tagType+":"+tagValue).
+				Msg("browse tag cardinality probe failed; probing candidates instead")
+			return browseTagPlan{}
+		}
+		if rows >= scopeRows {
+			continue
+		}
+		if !bestFound || rows < bestRows {
+			best, bestRows, bestFound = filter, rows, true
+		}
+	}
+	if !bestFound {
+		return browseTagPlan{}
+	}
+	return browseTagPlan{driveFromTag: &best}
+}
+
+// browsePrefixTagPlan plans a tag filter over one directory.
+func browsePrefixTagPlan(
+	ctx context.Context,
+	db sqlQueryable,
+	prefix string,
+	systems []systemdefs.System,
+	filters []zapscript.TagFilter,
+) browseTagPlan {
+	if len(filters) == 0 {
+		return browseTagPlan{}
+	}
+	scope, known, err := sqlBrowseScopeRows(ctx, db, []string{prefix}, systems)
+	if err != nil {
+		log.Debug().Err(err).Str("pathPrefix", prefix).Msg("browse tag scope lookup failed")
+		return browseTagPlan{}
+	}
+	return sqlBrowseTagPlan(ctx, db, filters, scope, known)
+}
+
+// browseOverlayTagPlan plans a tag filter over a merged root's routes.
+func browseOverlayTagPlan(
+	ctx context.Context, db sqlQueryable, opts *database.BrowseFilesOptions,
+) browseTagPlan {
+	return browseOverlayRoutesTagPlan(ctx, db, opts.Overlay, opts.Systems, opts.Tags)
+}
+
+func browseOverlayCountTagPlan(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // mirrors the caller's value options
+) browseTagPlan {
+	return browseOverlayRoutesTagPlan(ctx, db, opts.Overlay, opts.Systems, opts.Tags)
+}
+
+func browseOverlayRoutesTagPlan(
+	ctx context.Context,
+	db sqlQueryable,
+	overlay *database.BrowseOverlay,
+	systems []systemdefs.System,
+	filters []zapscript.TagFilter,
+) browseTagPlan {
+	if len(filters) == 0 {
+		return browseTagPlan{}
+	}
+	sources := browseOverlaySources(overlay)
+	prefixes := make([]string, len(sources))
+	for i := range sources {
+		prefixes[i] = sources[i].PathPrefix
+	}
+	scope, known, err := sqlBrowseScopeRows(ctx, db, prefixes, systems)
+	if err != nil {
+		log.Debug().Err(err).Msg("browse overlay tag scope lookup failed")
+		return browseTagPlan{}
+	}
+	return sqlBrowseTagPlan(ctx, db, filters, scope, known)
+}
+
 func browseFilesFilterCondition(
 	opts *database.BrowseFilesOptions,
 	includeParent bool,
+	tagPlan browseTagPlan,
 ) (where string, args []any) {
 	letterClauses, letterArgs := BuildLetterFilterSQL(opts.Letter, "m.SortName")
-	// Most browse scopes are bounded enough for correlated candidate probes.
-	// Required favorites are exceptionally sparse in production, so drive from
-	// that reverse-index set and probe any remaining filters per candidate.
-	tagClauses, tagArgs := buildBrowseTagFilterSQL(opts.Tags, "m")
+	// Which side a tag filter drives from depends on which is smaller; see
+	// browseTagPlan.
+	tagClauses, tagArgs := buildBrowseTagFilterSQL(opts.Tags, "m", tagPlan)
 	conditions := make([]string, 0, 3+len(letterClauses)+len(tagClauses))
 	if includeParent {
 		conditions = append(conditions, `m.ParentDir = ?`)
@@ -1160,8 +1323,10 @@ func browseFilesFilterCondition(
 	return strings.Join(conditions, " AND "), args
 }
 
-func browseFilesBaseCondition(opts *database.BrowseFilesOptions) (where string, args []any) {
-	return browseFilesFilterCondition(opts, true)
+func browseFilesBaseCondition(
+	opts *database.BrowseFilesOptions, tagPlan browseTagPlan,
+) (where string, args []any) {
+	return browseFilesFilterCondition(opts, true, tagPlan)
 }
 
 func browseFilenameExpr() string {
@@ -1541,14 +1706,14 @@ type browseRouteSort struct {
 // not be safe, because a route whose leading rows are all dropped would hide
 // the surviving rows behind them.
 func browseOverlayMergedFilesQuery(
-	opts *database.BrowseFilesOptions, sortExpr, direction, cursorOp string,
+	opts *database.BrowseFilesOptions, sortExpr, direction, cursorOp string, tagPlan browseTagPlan,
 ) (query string, args []any) {
 	sources := browseOverlaySources(opts.Overlay)
 	branches := make([]string, len(sources))
 	for i := range sources {
 		routeOpts := *opts
 		routeOpts.PathPrefix = sources[i].PathPrefix
-		where, whereArgs := browseFilesFilterCondition(&routeOpts, true)
+		where, whereArgs := browseFilesFilterCondition(&routeOpts, true, tagPlan)
 		args = append(args, whereArgs...)
 
 		route := browseOverlayRouteSort(sortExpr, sources[i].PathPrefix, opts.Cursor)
@@ -1604,7 +1769,9 @@ func browseOverlayMergedFilesQuery(
 // arguments. Separate from the exec so the query-plan regression test can
 // measure the statement production actually runs, matching
 // browseOverlayFileCountQuery.
-func browseOverlayFilesQuery(opts *database.BrowseFilesOptions) (query string, args []any) {
+func browseOverlayFilesQuery(
+	opts *database.BrowseFilesOptions, tagPlan browseTagPlan,
+) (query string, args []any) {
 	sortExpr := browseTitleSortExpr()
 	if opts.Sort == "filename-asc" || opts.Sort == "filename-desc" {
 		sortExpr = browseFilenameExpr()
@@ -1616,14 +1783,14 @@ func browseOverlayFilesQuery(opts *database.BrowseFilesOptions) (query string, a
 
 	sole, single := browseOverlaySoleSource(opts.Overlay)
 	if !single {
-		return browseOverlayMergedFilesQuery(opts, sortExpr, direction, cursorOp)
+		return browseOverlayMergedFilesQuery(opts, sortExpr, direction, cursorOp, tagPlan)
 	}
 
 	// One route has nothing to merge, so it reads Media directly and the route
 	// prefix is just the parent filter. See browseOverlaySoleSource.
 	routeOpts := *opts
 	routeOpts.PathPrefix = sole.PathPrefix
-	where, args := browseFilesFilterCondition(&routeOpts, true)
+	where, args := browseFilesFilterCondition(&routeOpts, true, tagPlan)
 	route := browseOverlayRouteSort(sortExpr, sole.PathPrefix, opts.Cursor)
 	where += route.rangeClause
 	args = append(args, route.rangeArgs...)
@@ -1646,7 +1813,7 @@ func sqlBrowseOverlayFilesFromMedia(
 	db sqlQueryable,
 	opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {
-	query, args := browseOverlayFilesQuery(opts)
+	query, args := browseOverlayFilesQuery(opts, browseOverlayTagPlan(ctx, db, opts))
 	sortMode := opts.Sort
 
 	rows, err := db.QueryContext(ctx, query, args...)
@@ -1693,7 +1860,8 @@ func sqlBrowseFilesFromMedia(
 	db sqlQueryable,
 	opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {
-	where, args := browseFilesBaseCondition(opts)
+	tagPlan := browsePrefixTagPlan(ctx, db, opts.PathPrefix, opts.Systems, opts.Tags)
+	where, args := browseFilesBaseCondition(opts, tagPlan)
 	sortModeStarted := time.Now()
 	sortMode := resolveBrowseSortMode(ctx, db, opts)
 	sortModeElapsed := time.Since(sortModeStarted)
@@ -2253,6 +2421,7 @@ func sqlBrowseFileCount(
 // measure the statement production actually runs rather than a copy of it.
 func browseOverlayFileCountQuery(
 	opts database.BrowseFileCountOptions, //nolint:gocritic // mirrors the caller's value options
+	tagPlan browseTagPlan,
 ) (query string, args []any) {
 	values, args := browseOverlaySourceValues(browseOverlaySources(opts.Overlay))
 
@@ -2262,7 +2431,7 @@ func browseOverlayFileCountQuery(
 		Letter:  opts.Letter,
 		Systems: opts.Systems,
 		Tags:    opts.Tags,
-	}, false)
+	}, false, tagPlan)
 	args = append(args, filterArgs...)
 
 	preferred, preferredArgs := browseOverlayPreferredRouteCondition(opts.Systems)
@@ -2285,7 +2454,7 @@ func sqlBrowseOverlayFileCount(
 	if err != nil || served {
 		return count, err
 	}
-	query, args := browseOverlayFileCountQuery(opts)
+	query, args := browseOverlayFileCountQuery(opts, browseOverlayCountTagPlan(ctx, db, opts))
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("browse overlay file count: %w", err)
 	}
@@ -2541,7 +2710,7 @@ func sqlBrowseFileCountFromMedia(
 		Letter:     opts.Letter,
 		Systems:    opts.Systems,
 		Tags:       opts.Tags,
-	})
+	}, browsePrefixTagPlan(ctx, db, opts.PathPrefix, opts.Systems, opts.Tags))
 	query := `SELECT COUNT(*)
 		FROM Media m
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID
@@ -2727,7 +2896,8 @@ func sqlBrowseIndex(
 		}, nil
 	}
 
-	where, args := browseFilesBaseCondition(filesOpts)
+	where, args := browseFilesBaseCondition(filesOpts,
+		browsePrefixTagPlan(ctx, db, filesOpts.PathPrefix, filesOpts.Systems, filesOpts.Tags))
 	// Only join Systems when a system filter is active; browseFilesBaseCondition
 	// references s.SystemID solely for that filter, so an unfiltered facet would
 	// otherwise pay one PK lookup per row for nothing.
@@ -2833,7 +3003,8 @@ func sqlBrowseOverlayIndex(
 		args = append(args, systemArgs...)
 	}
 	filterOpts := &database.BrowseFilesOptions{Tags: opts.Tags}
-	where, filterArgs := browseFilesFilterCondition(filterOpts, false)
+	where, filterArgs := browseFilesFilterCondition(filterOpts, false,
+		browseOverlayRoutesTagPlan(ctx, db, opts.Overlay, opts.Systems, opts.Tags))
 	args = append(args, filterArgs...)
 	desc := opts.Sort == "name-desc"
 	direction := "ASC"

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -2975,7 +2975,10 @@ func sqlBrowseOverlayIndex(
 	opts *database.BrowseIndexOptions,
 ) (database.BrowseIndexResult, error) {
 	if opts.Sort == "filename-asc" || opts.Sort == "filename-desc" {
-		total, err := sqlBrowseOverlayFileCount(ctx, db, database.BrowseFileCountOptions{
+		// Through sqlBrowseFileCount, not the overlay statement directly, so the
+		// total takes the same routing every other browse total does: collapsed
+		// for one route, cached for two.
+		total, err := sqlBrowseFileCount(ctx, db, database.BrowseFileCountOptions{
 			Overlay: opts.Overlay,
 			Systems: opts.Systems,
 			Tags:    opts.Tags,
@@ -2990,48 +2993,36 @@ func sqlBrowseOverlayIndex(
 		}, nil
 	}
 
-	sources := browseOverlaySources(opts.Overlay)
-	values := make([]string, len(sources))
-	args := make([]any, 0, len(sources)+16)
-	for i := range sources {
-		values[i] = "(?, ?, ?)"
-		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
-	}
-	winnerConditions := []string{"m.IsMissing = 0", overlayHigherPriorityDirectoryCondition}
-	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
-		winnerConditions = append(winnerConditions, systemClause)
-		args = append(args, systemArgs...)
-	}
-	filterOpts := &database.BrowseFilesOptions{Tags: opts.Tags}
-	where, filterArgs := browseFilesFilterCondition(filterOpts, false,
-		browseOverlayRoutesTagPlan(ctx, db, opts.Overlay, opts.Systems, opts.Tags))
+	values, args := browseOverlaySourceValues(browseOverlaySources(opts.Overlay))
+	// The merge is the same two predicates the other overlay statements use, so
+	// a one-route overlay pays nothing for it and no route's files are sorted
+	// just to rank them. The system filter has to sit in this WHERE: it used to
+	// ride in the ranked CTE, which no longer exists.
+	where, filterArgs := browseFilesFilterCondition(&database.BrowseFilesOptions{
+		Systems: opts.Systems,
+		Tags:    opts.Tags,
+	}, false, browseOverlayRoutesTagPlan(ctx, db, opts.Overlay, opts.Systems, opts.Tags))
 	args = append(args, filterArgs...)
+	preferred, preferredArgs := browseOverlayPreferredRouteCondition(opts.Systems)
+	args = append(args, preferredArgs...)
+
 	desc := opts.Sort == "name-desc"
 	direction := "ASC"
 	if desc {
 		direction = "DESC"
 	}
 	bucketExpr := browseBucketKeyExpr("m.SortName")
-	query := `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
-		ranked AS (
-			SELECT m.DBID,
-				ROW_NUMBER() OVER (
-					PARTITION BY substr(m.Path, length(m.ParentDir) + 1)
-					ORDER BY sources.priority ASC, m.DBID ASC
-				) AS source_rank
-			FROM sources
-			INNER JOIN Media m ON m.ParentDir = sources.parent_dir
-			INNER JOIN Systems s ON m.SystemDBID = s.DBID
-			WHERE ` + strings.Join(winnerConditions, " AND ") + `
-		), ordered AS (
+	query := browseOverlaySourcesCTE + values + `),
+		ordered AS (
 			SELECT ` + bucketExpr + ` AS bucket,
 				m.SortName AS sortValue,
 				m.DBID AS dbid,
 				ROW_NUMBER() OVER (ORDER BY ` + browseTitleSortExpr() + ` ` + direction +
 		`, m.DBID ` + direction + `) AS rn
-			FROM ranked
-			INNER JOIN Media m ON m.DBID = ranked.DBID
-			WHERE ranked.source_rank = 1 AND ` + where + `
+			` + browseOverlayMergeSource + `
+			WHERE ` + where + `
+				AND ` + preferred + `
+				AND ` + browseOverlayShadowedByDirectoryCondition() + `
 		), counts AS (
 			SELECT bucket, COUNT(*) AS n, MIN(rn) AS first_rn FROM ordered GROUP BY bucket
 		)

--- a/pkg/database/mediadb/sql_browse_bench_test.go
+++ b/pkg/database/mediadb/sql_browse_bench_test.go
@@ -219,6 +219,122 @@ func seedBenchCoverFlagsDB(b *testing.B, mediaDB *MediaDB, rows int) []int64 {
 	return mediaIDs
 }
 
+// BenchmarkBrowseOverlayFileCount_LargeRoute measures what #1398 paid to count
+// the files in a system's root.
+//
+// "merge" is the statement a one-route overlay used to run: rank every direct
+// file in the route by filename, probe higher-priority routes per candidate, and
+// re-join Media to re-check IsMissing. "collapsed" is what a one-route overlay
+// runs now, a summed BrowseDirCounts self row. Both are measured against the
+// same seeded route so the difference is the statement and not the data.
+func BenchmarkBrowseOverlayFileCount_LargeRoute(b *testing.B) {
+	const rows = 20_000
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowseBenchMediaDB(b)
+	defer cleanup()
+	parentDir := seedBenchBrowseDB(b, mediaDB, rows, false)
+	require.NoError(b, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+	sqlDB := mediaDB.sql.Load()
+
+	overlay := &database.BrowseOverlay{Sources: []database.BrowseSource{
+		{PathPrefix: parentDir, IncludeDirs: true},
+	}}
+	opts := database.BrowseFileCountOptions{Overlay: overlay}
+
+	b.Run("merge", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(rows, "route_files")
+		for b.Loop() {
+			count, err := sqlBrowseOverlayFileCount(ctx, sqlDB, opts)
+			require.NoError(b, err)
+			require.Equal(b, rows, count)
+		}
+	})
+
+	b.Run("collapsed", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(rows, "route_files")
+		for b.Loop() {
+			count, err := sqlBrowseFileCount(ctx, sqlDB, opts)
+			require.NoError(b, err)
+			require.Equal(b, rows, count)
+		}
+	})
+}
+
+// BenchmarkBrowseOverlayMerge_TwoRoutes measures the merged root a one-route
+// collapse cannot help: a system whose media sits under two roots still has to
+// resolve one row per filename across them.
+//
+// The large route is second, which is the order MiSTer produces when the library
+// is on the SD card and a few games are on USB, and the order that makes the
+// merge pay a probe for every row it reads.
+func BenchmarkBrowseOverlayMerge_TwoRoutes(b *testing.B) {
+	const rows = 20_000
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowseBenchMediaDB(b)
+	defer cleanup()
+	parentDir := seedBenchBrowseDB(b, mediaDB, rows, false)
+	small := seedBenchSecondRoute(b, mediaDB, 3)
+	require.NoError(b, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+	sqlDB := mediaDB.sql.Load()
+
+	overlay := &database.BrowseOverlay{Sources: []database.BrowseSource{
+		{PathPrefix: small, IncludeDirs: true},
+		{PathPrefix: parentDir, IncludeDirs: true},
+	}}
+
+	b.Run("count", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(rows, "route_files")
+		for b.Loop() {
+			count, err := sqlBrowseFileCount(ctx, sqlDB,
+				database.BrowseFileCountOptions{Overlay: overlay})
+			require.NoError(b, err)
+			require.Equal(b, rows+3, count)
+		}
+	})
+
+	b.Run("files", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(rows, "route_files")
+		for b.Loop() {
+			files, err := sqlBrowseFiles(ctx, sqlDB,
+				&database.BrowseFilesOptions{Overlay: overlay, Limit: 26})
+			require.NoError(b, err)
+			require.Len(b, files, 26)
+		}
+	})
+}
+
+// seedBenchSecondRoute adds a small second route for the same system, so the
+// merge has something to resolve names against.
+func seedBenchSecondRoute(b *testing.B, mediaDB *MediaDB, rows int) string {
+	b.Helper()
+	ctx := context.Background()
+	parentDir := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "bench2")) + "/"
+	tx, err := mediaDB.sql.Load().BeginTx(ctx, nil)
+	require.NoError(b, err)
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO Media (MediaTitleDBID, SystemDBID, Path, ParentDir, SortName)
+		VALUES (1, 1, ?, ?, ?)
+	`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, stmt.Close()) }()
+
+	for i := range rows {
+		name := fmt.Sprintf("second-%04d", i)
+		_, err = stmt.ExecContext(ctx, parentDir+name+".rom", parentDir, name)
+		require.NoError(b, err)
+	}
+	require.NoError(b, tx.Commit())
+	return parentDir
+}
+
 func setupBrowseBenchMediaDB(b *testing.B) (mediaDB *MediaDB, cleanup func()) {
 	b.Helper()
 	tempDir, err := os.MkdirTemp("", "zaparoo-browse-bench-mediadb-*")

--- a/pkg/database/mediadb/sql_browse_tags_test.go
+++ b/pkg/database/mediadb/sql_browse_tags_test.go
@@ -132,7 +132,8 @@ func TestHasRequiredFavoriteFilter(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, testCase.want, hasRequiredFavoriteFilter([]zapscript.TagFilter{testCase.filter}))
+			_, ok := browseTagPlan{}.driver([]zapscript.TagFilter{testCase.filter})
+			assert.Equal(t, testCase.want, ok)
 		})
 	}
 }
@@ -143,7 +144,7 @@ func TestBuildBrowseTagFilterSQL(t *testing.T) {
 	clauses, args := buildBrowseTagFilterSQL([]zapscript.TagFilter{
 		{Type: "user", Value: "favorite"},
 		{Type: "genre", Value: "action"},
-	}, "m")
+	}, "m", browseTagPlan{})
 	require.Len(t, clauses, 2)
 	assert.Contains(t, clauses[0], "m.DBID IN")
 	assert.Contains(t, clauses[1], "EXISTS")
@@ -151,10 +152,18 @@ func TestBuildBrowseTagFilterSQL(t *testing.T) {
 
 	candidateClauses, _ := buildBrowseTagFilterSQL([]zapscript.TagFilter{{
 		Type: "genre", Value: "action",
-	}}, "m")
+	}}, "m", browseTagPlan{})
 	require.Len(t, candidateClauses, 1)
 	assert.Contains(t, candidateClauses[0], "EXISTS")
 	assert.NotContains(t, candidateClauses[0], "m.DBID IN")
+
+	// A measured plan drives from whichever tag it names, favorite or not.
+	genre := zapscript.TagFilter{Type: "genre", Value: "action"}
+	plannedClauses, _ := buildBrowseTagFilterSQL([]zapscript.TagFilter{genre}, "m",
+		browseTagPlan{driveFromTag: &genre})
+	require.Len(t, plannedClauses, 1)
+	assert.Contains(t, plannedClauses[0], "m.DBID IN")
+	assert.NotContains(t, plannedClauses[0], "EXISTS")
 }
 
 func TestBuildTagFilterSQL_MediaAlias(t *testing.T) {

--- a/pkg/database/mediadb/tagfilter.go
+++ b/pkg/database/mediadb/tagfilter.go
@@ -21,7 +21,6 @@ package mediadb
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/ZaparooProject/go-zapscript"
@@ -100,35 +99,63 @@ func isRequiredFavoriteFilter(filter zapscript.TagFilter) bool {
 	return tagType == string(tags.TagTypeUser) && tagValue == string(tags.TagUserFavorite)
 }
 
-func hasRequiredFavoriteFilter(filters []zapscript.TagFilter) bool {
-	return slices.ContainsFunc(filters, isRequiredFavoriteFilter)
+// browseTagPlan names the required tag filter, if any, that a browse should
+// resolve from the tag side rather than probe once per candidate row.
+//
+// Neither shape wins outright, so the choice is which side is smaller.
+// Correlated probes cost one lookup per row the browse reads; a forward set
+// costs one pass over the rows carrying the tag. Measured on the #1398 device
+// database: a tag matching nothing over a 20,000-file route is 9.4 ms probed
+// and 0.18 ms as a set, while a tag on 20,020 rows over a 120-file directory is
+// 0.5 ms probed and 3.9 ms as a set.
+//
+// The zero value means "no measurement available", and then a required
+// user:favorite is still assumed sparse, which is the rule this used before
+// there was anything to measure.
+type browseTagPlan struct {
+	driveFromTag *zapscript.TagFilter
+}
+
+// driver returns the filter to resolve from the tag side.
+func (p browseTagPlan) driver(filters []zapscript.TagFilter) (driver zapscript.TagFilter, ok bool) {
+	if p.driveFromTag != nil {
+		return *p.driveFromTag, true
+	}
+	for _, filter := range filters {
+		if isRequiredFavoriteFilter(filter) {
+			return filter, true
+		}
+	}
+	return zapscript.TagFilter{}, false
 }
 
 func buildBrowseTagFilterSQL(
 	filters []zapscript.TagFilter,
 	mediaRef string,
+	plan browseTagPlan,
 ) (clauses []string, args []any) {
-	if !hasRequiredFavoriteFilter(filters) {
+	driver, ok := plan.driver(filters)
+	if !ok {
 		return buildCandidateTagFilterSQLForRef(filters, mediaRef)
 	}
 
-	var favoriteFilter zapscript.TagFilter
-	remaining := make([]zapscript.TagFilter, 0, len(filters)-1)
+	taken := false
+	remaining := make([]zapscript.TagFilter, 0, len(filters))
 	for _, filter := range filters {
-		if favoriteFilter.Type == "" && isRequiredFavoriteFilter(filter) {
-			favoriteFilter = filter
+		if !taken && filter == driver {
+			taken = true
 			continue
 		}
 		remaining = append(remaining, filter)
 	}
 
-	favoriteClauses, favoriteArgs := buildTagFilterSQLForRef([]zapscript.TagFilter{favoriteFilter}, mediaRef)
+	driverClauses, driverArgs := buildTagFilterSQLForRef([]zapscript.TagFilter{driver}, mediaRef)
 	remainingClauses, remainingArgs := buildCandidateTagFilterSQLForRef(remaining, mediaRef)
-	clauses = make([]string, 0, len(favoriteClauses)+len(remainingClauses))
-	clauses = append(clauses, favoriteClauses...)
+	clauses = make([]string, 0, len(driverClauses)+len(remainingClauses))
+	clauses = append(clauses, driverClauses...)
 	clauses = append(clauses, remainingClauses...)
-	args = make([]any, 0, len(favoriteArgs)+len(remainingArgs))
-	args = append(args, favoriteArgs...)
+	args = make([]any, 0, len(driverArgs)+len(remainingArgs))
+	args = append(args, driverArgs...)
 	args = append(args, remainingArgs...)
 	return clauses, args
 }


### PR DESCRIPTION
Fixes #1398.

Opening a system in the frontend runs `media.browse` on a merged system root, which read every direct file in every route the system resolves to. On a MiSTer with 20,000 files in one system root that was 17.6 s for one route and 24.1 s for two, against the 30 s API timeout, so the request failed and the frontend showed "failed to load". Under the retries the frontend already makes, 1 of 8 concurrent browses survived on one route and none on two.

The reporter's log shows the two statements that ran out of budget:

```
op="browse file count" elapsed=29850ms routes=1
error="error counting system root contents files: browse overlay file count: context deadline exceeded"
op="browse files"      elapsed=11204ms routes=1
error="error browsing system root contents files: browse overlay files rows: context deadline exceeded"
```

## What was slow

`routes=1` is `len(overlay.Sources)`, so that system resolved to a single route and had nothing to merge, yet still paid the full merge: a `ROW_NUMBER() OVER (PARTITION BY <filename>)` over every direct file, a correlated higher-priority probe per candidate row, and a re-join to `Media` for a filter the CTE had already applied. `sqlBrowseFileCount` returned to the overlay statement as soon as an overlay was present, so it never reached the `BrowseDirCounts` cache the plain path uses.

A one-route overlay cannot change any answer. Priorities are the slice index, so the only route is priority 0 and nothing can outrank it; `Media.Path` is unique under a fixed `ParentDir`, so the filename the merge partitions by is unique per row. It collapses to a plain prefix browse, which the cache can serve.

Removing the ranking from the real multi-route case, however, only moved two routes 24.1 s → 20.7 s. On this hardware the sort was never the bottleneck — cost tracks how many rows a statement touches, because each one is random I/O against a 22 MB database with an 8 MB page cache on SD. A letter filter, which eliminates rows before the merge predicates run, took the same query to 1.2 s.

## What changed

- **The merge is predicates, not ranking.** `ROW_NUMBER() OVER (PARTITION BY <filename> ORDER BY priority)` becomes "no higher-priority route supplies this name", which selects the same rows and lets the first route short-circuit instead of sorting every route's files.
- **The listing reads a page, not a route.** Each route is an ordered range of `idx_media_browse_sort`, so its branch stops at the page size and the outer query merges at most one page per route. The merge predicates run inside each branch, before its `LIMIT` — filtering after would be unsound, because a route whose leading rows are all dropped would hide the rows behind them.
- **The total comes from the cache.** Two routes' direct-file counts, less the names both hold and the names a higher-priority directory shadows. Both corrections are driven from the smaller side, so a big route paired with a small one costs a handful of lookups. Three or more routes would need inclusion-exclusion over every subset and fall back to the statement.
- **Filename sorts ride an index.** They order by `m.Path` with a redundant range rather than by `substr(m.Path, length(m.ParentDir) + 1)`, which no index can serve. Within one route the prefix is constant, so it is the same order as the suffix the row reports.
- **Tag filters resolve from whichever side is smaller.** `buildBrowseTagFilterSQL` already had both shapes and already split one filter off to the forward-set form, but picked by `isRequiredFavoriteFilter` — a stand-in for "this tag is sparse". The scope now comes from the cache and each required filter's rows are counted against it, stopping at the scope, so deciding costs one sequential pass over a covering index instead of that many random probes.
- **`BrowseDirCount` goes through `beginBrowse`** like every other browse entry point. It was the one statement that could list a whole route with no timing line of its own; in this issue its cost showed only as an unexplained gap between two logged calls.

Ranking by anything other than priority is unsound, because a row can be dropped in favour of a rival that is itself shadowed away by a directory in a route between them. `TestBrowseOverlayMerge_Rules` pins that case.

## Measured on the MiSTer test device

20,000 files in one system root, binaries swapped against the same database.

| | before | after |
|---|---|---|
| one route, merged root | 17.56s | 0.34s |
| one route, 8 concurrent | 1 of 8 | 8 of 8 |
| two routes, merged root | 24.07s | 0.57s |
| two routes, filename sort | 20.80s | 0.51s |
| two routes, 8 concurrent | 0 of 8 | 8 of 8 |
| two routes, paging 6x500 | 12.5s/page | 0.90s/page |
| tag matching nothing | 6.82s | 0.62s |
| `region:us` over the route | 13.01s | 1.05s |

Benchmarks: two-route count 15.23ms → 0.12ms, files 23.22ms → 0.28ms.

Two cases are unchanged because their answer is proportional to the directory rather than to the filter: a tag covering the whole route spends 4.9 s counting 20,000 matches, and a `NOT` filter excluding everything spends 9.6 s proving zero matches.

## Behaviour

Responses are unchanged. On device, 15 single-route cases, 7 two-route cases, 16 adversarial cases in each configuration, 9 tag cases and full paged enumerations all match the previous build byte for byte after normalising volatile ids, and cursors are byte-identical and replay across the two builds.

The browse cache answering a two-route total extends an existing tradeoff rather than introducing one: `sqlBrowseDirectFileCountFromCache` already served single-route totals the same way, so a cache that is stale with respect to rows gone missing since it was built can disagree with the listing until the next refresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved browse performance for single-route overlays by using streamlined query paths.
  - Optimized tag-filtered browsing by selecting the more efficient search strategy.
  - Improved directory-count requests with more consistent connection and timing handling.

- **Bug Fixes**
  - Improved multi-route overlay result merging, including duplicate filenames, directory shadowing, missing entries, and route isolation.
  - Improved cached file counts and paging consistency for overlay browsing.
  - Preserved correct filtering, sorting, and counting across overlay configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->