### PR TITLE
fix(launchers): make custom media_dirs work for an existing system

### DIFF
--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -317,10 +317,7 @@ func browseMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // si
 func browseRoots(env *requests.RequestEnv) (any, error) {
 	ctx := env.Context
 
-	var rootDirs []string
-	if env.Platform != nil {
-		rootDirs = env.Platform.RootDirs(env.Config)
-	}
+	rootDirs := browseRootDirs(env)
 
 	// Get filesystem root counts
 	rootCounts, err := env.Database.MediaDB.BrowseRootCounts(ctx, rootDirs)
@@ -467,10 +464,7 @@ func systemRootContentsSources(
 		physical = append(physical, entries[i])
 	}
 
-	var rootDirs []string
-	if env.Platform != nil {
-		rootDirs = env.Platform.RootDirs(env.Config)
-	}
+	rootDirs := browseRootDirs(env)
 	rootPriority := func(path string) int {
 		for i, root := range rootDirs {
 			if helpers.PathHasPrefix(path, root) {
@@ -787,9 +781,12 @@ func isStrictFilesystemDescendant(childPath, parentPath string) bool {
 }
 
 func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []systemdefs.System) ([]string, error) {
-	var rootDirs []string
+	rootDirs := browseRootDirs(env)
+	// A launcher's own absolute folder is a destination, not a place to look
+	// for other launchers' relative folders, so those joins use scan roots only.
+	var scanRoots []string
 	if env.Platform != nil {
-		rootDirs = env.Platform.RootDirs(env.Config)
+		scanRoots = env.Platform.RootDirs(env.Config)
 	}
 
 	routes := make([]string, 0)
@@ -826,7 +823,7 @@ func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []system
 						addFilesystemRoute(folder)
 						continue
 					}
-					for _, root := range rootDirs {
+					for _, root := range scanRoots {
 						addFilesystemRoute(filepath.Join(root, folder))
 					}
 				}
@@ -963,11 +960,7 @@ func browseFilesystem(
 	}
 
 	// Security: verify path is within an allowed root
-	var rootDirs []string
-	if env.Platform != nil {
-		rootDirs = env.Platform.RootDirs(env.Config)
-	}
-	if !isPathUnderRoots(cleaned, rootDirs) {
+	if !isPathUnderRoots(cleaned, browseRootDirs(env)) {
 		return nil, models.ClientErrf("path is not within an allowed root directory")
 	}
 
@@ -1519,6 +1512,32 @@ func isPathUnderRoots(path string, rootDirs []string) bool {
 		}
 	}
 	return false
+}
+
+// browseRootDirs returns the directories a client may browse: the platform's
+// scan roots plus the absolute folders launchers declare for themselves. A
+// custom launcher's media_dirs need not sit under a scan root, and without this
+// its media indexes and launches while the directory holding it cannot be
+// listed or opened.
+func browseRootDirs(env *requests.RequestEnv) []string {
+	var roots []string
+	if env.Platform != nil {
+		roots = env.Platform.RootDirs(env.Config)
+	}
+	if env.LauncherCache == nil {
+		return roots
+	}
+
+	launchers := env.LauncherCache.GetAllLaunchers()
+	for i := range launchers {
+		for _, folder := range launchers[i].Folders {
+			if !filepath.IsAbs(folder) || isPathUnderRoots(folder, roots) {
+				continue
+			}
+			roots = append(roots, folder)
+		}
+	}
+	return roots
 }
 
 // isKnownVirtualScheme checks if the given scheme path matches a launcher's scheme.

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -474,6 +474,8 @@ func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 	sharedPath := filepath.Join(romsRoot, "shared")
 	snesAPIPath := filepath.ToSlash(snesPath)
 	sharedAPIPath := filepath.ToSlash(sharedPath)
+	outsidePath := browseTestAbsPath("tmp", "outside")
+	outsideAPIPath := filepath.ToSlash(outsidePath)
 	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
 	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
 		Return([]string{romsRoot})
@@ -481,26 +483,32 @@ func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 		Return([]platforms.Launcher{
 			{ID: "SNES", SystemID: "SNES", Folders: []string{"SNES"}},
 			{ID: "SharedSNES", SystemID: "SNES", Folders: []string{"shared"}},
-			{ID: "OutsideSNES", SystemID: "SNES", Folders: []string{browseTestAbsPath("tmp", "outside")}},
+			{ID: "OutsideSNES", SystemID: "SNES", Folders: []string{outsidePath}},
 			{ID: "Steam", SystemID: "pc", Schemes: []string{"steam"}},
 		})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockSystemRootCandidatesNotReady(mockMediaDB)
 	romsPrefix := filepath.ToSlash(romsRoot) + "/"
+	outsidePrefix := outsideAPIPath + "/"
 	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(romsPrefix, "SNES")).
 		Return(0, nil)
 	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts(romsPrefix, "SNES")).
+		Return([]database.BrowseDirectoryResult{}, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(outsidePrefix, "SNES")).
+		Return(3, nil)
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts(outsidePrefix, "SNES")).
 		Return([]database.BrowseDirectoryResult{}, nil)
 	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "SNES")).
 		Return([]database.BrowseVirtualScheme{}, nil)
 	mockMediaDB.On("BrowseRouteCounts", mock.Anything,
 		mock.MatchedBy(func(opts database.BrowseRouteCountsOptions) bool {
 			return len(opts.Systems) == 1 && opts.Systems[0].ID == "SNES" &&
-				assert.ElementsMatch(t, []string{snesAPIPath, sharedAPIPath}, opts.Routes)
+				assert.ElementsMatch(t, []string{snesAPIPath, sharedAPIPath, outsideAPIPath}, opts.Routes)
 		}),
 	).Return(map[string]database.BrowseRouteCount{
-		snesAPIPath: {Path: snesAPIPath, FileCount: 12, SystemIDs: []string{"SNES"}},
+		snesAPIPath:    {Path: snesAPIPath, FileCount: 12, SystemIDs: []string{"SNES"}},
+		outsideAPIPath: {Path: outsideAPIPath, FileCount: 3, SystemIDs: []string{"SNES"}},
 	}, nil)
 
 	systems := []string{"SNES"}
@@ -510,16 +518,30 @@ func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
-	require.Len(t, browseResults.Entries, 1)
-	entry := browseResults.Entries[0]
+	require.Len(t, browseResults.Entries, 2)
+
+	byPath := make(map[string]models.BrowseEntry, len(browseResults.Entries))
+	for _, e := range browseResults.Entries {
+		byPath[e.Path] = e
+	}
+
+	entry, ok := byPath[snesAPIPath]
+	require.True(t, ok)
 	assert.Equal(t, "root", entry.Type)
 	assert.Equal(t, "SNES", entry.Name)
-	assert.Equal(t, snesAPIPath, entry.Path)
 	assert.Equal(t, []string{"SNES"}, entry.SystemIDs)
 	require.NotNil(t, entry.SystemID)
 	assert.Equal(t, "SNES", *entry.SystemID)
 	require.NotNil(t, entry.FileCount)
 	assert.Equal(t, 12, *entry.FileCount)
+
+	// A launcher's own media dir is browsable even though it sits outside
+	// every platform root: the user authorised the path by configuring it.
+	outside, ok := byPath[outsideAPIPath]
+	require.True(t, ok)
+	assert.Equal(t, "root", outside.Type)
+	require.NotNil(t, outside.FileCount)
+	assert.Equal(t, 3, *outside.FileCount)
 
 	mockMediaDB.AssertExpectations(t)
 }
@@ -1650,6 +1672,49 @@ func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {
 	assert.Equal(t, 100, *browseResults.Entries[0].FileCount)
 
 	assert.Equal(t, "SNES", browseResults.Entries[1].Name)
+	mockMediaDB.AssertExpectations(t)
+}
+
+// TestHandleMediaBrowse_LauncherMediaDirOutsideRoots covers a custom launcher
+// pointed at a directory that is not under any scan root. Its media indexes and
+// launches, so refusing to open the directory that holds it left the library
+// half visible.
+func TestHandleMediaBrowse_LauncherMediaDirOutsideRoots(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
+	mediaDir := browseTestAbsPath("tmp", "famicom")
+	mediaAPIPath := filepath.ToSlash(mediaDir)
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{romsRoot})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{
+			{ID: "Famicom", SystemID: "NES", Folders: []string{mediaDir}, Extensions: []string{".nes"}},
+		})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts(mediaAPIPath+"/")).
+		Return([]database.BrowseDirectoryResult{{Name: "Japan", FileCount: 4}}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts(mediaAPIPath+"/")).
+		Return(1, nil)
+	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
+		Return([]database.SearchResultWithCursor{}, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts(mediaAPIPath+"/", nil)).
+		Return(0, nil)
+
+	path := mediaAPIPath
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Path: &path})
+
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	assert.Equal(t, mediaAPIPath, browseResults.Path)
+	require.Len(t, browseResults.Entries, 1)
+	assert.Equal(t, "Japan", browseResults.Entries[0].Name)
 	mockMediaDB.AssertExpectations(t)
 }
 

--- a/pkg/api/methods/settings.go
+++ b/pkg/api/methods/settings.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/permissions"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/rs/zerolog/log"
 )
@@ -339,7 +340,11 @@ func HandleSettingsUpdate(env requests.RequestEnv) (any, error) {
 
 	if params.SystemDefaults != nil {
 		log.Debug().Int("count", len(*params.SystemDefaults)).Msg("updating systems.default")
-		env.Config.SetSystemDefaults(systemDefaults)
+		// Merged after the reload above so the entries carry the values on
+		// disk for the fields no client can send.
+		env.Config.SetSystemDefaults(
+			carryUnmodelledSystemDefaults(env.Config.SystemDefaults(), systemDefaults),
+		)
 	}
 
 	err := env.Config.Save()
@@ -442,6 +447,40 @@ func buildSystemDefaults(cache *helpers.LauncherCache, in []models.SystemDefault
 		})
 	}
 	return out, nil
+}
+
+// carryUnmodelledSystemDefaults copies forward the system default fields that
+// models.SystemDefault does not carry. settings.update replaces the whole list,
+// so a client editing a launcher would otherwise delete pause_on_launch from
+// the user's config file without ever having been able to see it.
+func carryUnmodelledSystemDefaults(existing, updated []config.SystemsDefault) []config.SystemsDefault {
+	if len(existing) == 0 {
+		return updated
+	}
+
+	// Entries are matched on the resolved system, because config and client
+	// may name the same system differently, the way LookupSystemDefaults does.
+	previous := make(map[string]*config.SystemsDefault, len(existing))
+	for i := range existing {
+		system, err := systemdefs.LookupSystem(existing[i].System)
+		if err != nil {
+			continue
+		}
+		if _, seen := previous[system.ID]; !seen {
+			previous[system.ID] = &existing[i]
+		}
+	}
+
+	for i := range updated {
+		system, err := systemdefs.LookupSystem(updated[i].System)
+		if err != nil {
+			continue
+		}
+		if entry, ok := previous[system.ID]; ok {
+			updated[i].PauseOnLaunch = entry.PauseOnLaunch
+		}
+	}
+	return updated
 }
 
 // launcherRefExists reports whether ref matches a launcher ID or any of a

--- a/pkg/api/methods/settings_test.go
+++ b/pkg/api/methods/settings_test.go
@@ -1217,6 +1217,67 @@ func TestHandleSettingsUpdate_SystemDefaults(t *testing.T) {
 	assert.Equal(t, "snes9x", got[1].Launcher)
 }
 
+// TestHandleSettingsUpdate_SystemDefaultsKeepPauseOnLaunch covers a field the
+// API does not model. An update replaces the whole list, so a client editing a
+// launcher used to silently delete pause_on_launch from the user's config file.
+func TestHandleSettingsUpdate_SystemDefaultsKeepPauseOnLaunch(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{})
+	require.NoError(t, err)
+
+	pauseOnLaunch := false
+	cfg.SetSystemDefaults([]config.SystemsDefault{
+		{System: "Audio", PauseOnLaunch: &pauseOnLaunch},
+		{System: "SNES", Launcher: "snes9x"},
+	})
+	require.NoError(t, cfg.Save())
+	require.False(t, cfg.AudioPauseOnLaunch())
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
+
+	cache := &corehelpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "snes9x", SystemID: "SNES"},
+		{ID: "audioplayer", SystemID: "Audio"},
+	})
+
+	params := models.UpdateSettingsParams{
+		SystemDefaults: &[]models.SystemDefault{
+			{System: "Audio", Launcher: "audioplayer"},
+			{System: "SNES", Launcher: "snes9x"},
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		Platform:      mockPlatform,
+		Config:        cfg,
+		State:         appState,
+		LauncherCache: cache,
+		Params:        paramsJSON,
+		IsLocal:       true,
+	}
+
+	_, err = HandleSettingsUpdate(env)
+	require.NoError(t, err)
+
+	got := cfg.SystemDefaults()
+	require.Len(t, got, 2)
+	assert.Equal(t, "Audio", got[0].System)
+	assert.Equal(t, "audioplayer", got[0].Launcher, "the field the client did send is applied")
+	require.NotNil(t, got[0].PauseOnLaunch, "the field the client cannot send survives")
+	assert.False(t, *got[0].PauseOnLaunch)
+	assert.False(t, cfg.AudioPauseOnLaunch())
+}
+
 // TestHandleSettingsUpdate_SystemDefaults_AcceptsGroup verifies a launcher
 // group name is accepted as a launcher reference, mirroring config lookup.
 func TestHandleSettingsUpdate_SystemDefaults_AcceptsGroup(t *testing.T) {

--- a/pkg/config/configcustomlaunchers.go
+++ b/pkg/config/configcustomlaunchers.go
@@ -141,6 +141,12 @@ func validateCustomLauncher(entry *LaunchersCustom) error {
 			return fmt.Errorf("backend %q currently requires kind %q",
 				CustomLauncherBackendMisterCore, CustomLauncherKindVirtualSystem)
 		}
+		// Without execute there is nothing to run, so the entry is only useful
+		// as a way to add media directories to an existing system. Anything
+		// else would load without complaint and then do nothing at all.
+		if backend == "" && (entry.System == "" || len(entry.MediaDirs) == 0) {
+			return errors.New("a launcher without execute must set system and media_dirs")
+		}
 	case CustomLauncherKindVirtualSystem:
 		if backend != CustomLauncherBackendCommand && backend != CustomLauncherBackendMisterCore {
 			return errors.New("virtual_system requires a supported backend")

--- a/pkg/config/configcustomlaunchers_test.go
+++ b/pkg/config/configcustomlaunchers_test.go
@@ -68,6 +68,35 @@ func TestValidateCustomLauncher_NormalizesOmittedKind(t *testing.T) {
 	assert.Equal(t, CustomLauncherBackendCommand, entry.Backend)
 }
 
+func TestValidateCustomLauncher_MediaDirsOnlyEntry(t *testing.T) {
+	t.Run("accepted with system and media dirs", func(t *testing.T) {
+		entry := LaunchersCustom{
+			ID:        "Famicom",
+			System:    "NES",
+			MediaDirs: []string{"/media/fat/cifs/games/famicom"},
+			FileExts:  []string{".nes"},
+		}
+
+		require.NoError(t, validateCustomLauncher(&entry))
+		assert.Equal(t, CustomLauncherKindLauncher, entry.Kind)
+		assert.Empty(t, entry.Backend)
+	})
+
+	// Without media dirs it declares no folders, so it matches every path for
+	// its system and indexes nothing. Loading it would do nothing at all.
+	t.Run("rejected without media dirs", func(t *testing.T) {
+		entry := LaunchersCustom{ID: "Famicom", System: "NES", FileExts: []string{".nes"}}
+		require.ErrorContains(t, validateCustomLauncher(&entry),
+			"a launcher without execute must set system and media_dirs")
+	})
+
+	t.Run("rejected without system", func(t *testing.T) {
+		entry := LaunchersCustom{ID: "Famicom", MediaDirs: []string{"/games/famicom"}}
+		require.ErrorContains(t, validateCustomLauncher(&entry),
+			"a launcher without execute must set system and media_dirs")
+	})
+}
+
 func TestValidateCustomLauncher_RejectsInvalidCommonFields(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -1411,6 +1411,58 @@ func TestGetFiles_CustomLauncherMatchesFiles(t *testing.T) {
 	assert.False(t, foundFiles["readme.txt"], "Non-matching extension should be excluded")
 }
 
+// TestGetFiles_DuplicateLauncherIDMatchesBothFolders is the #1399 regression.
+// A custom launcher configured with a built-in launcher's ID used to lose its
+// media directory entirely: the scanner cached folder data by launcher ID, so
+// one entry answered for both, the walk found the files and matched none of
+// them, and the log said only that nothing matched.
+func TestGetFiles_DuplicateLauncherIDMatchesBothFolders(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+
+	extraDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(extraDir, "Rockman 4.nes"), []byte("test"), 0o600))
+
+	duplicateID := systemdefs.SystemNES
+	custom := platforms.Launcher{
+		ID:         duplicateID,
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{extraDir},
+		Extensions: []string{".nes"},
+	}
+	builtIn := platforms.Launcher{
+		ID:         duplicateID,
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{"NES"},
+		Extensions: []string{".nes"},
+	}
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Settings").Return(platforms.Settings{})
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{custom, builtIn})
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.Initialize(platform, cfg)
+	helpers.GlobalLauncherCache = testCache
+	defer func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	files, err := GetFiles(context.Background(), cfg, platform, systemdefs.SystemNES, extraDir, nil)
+	require.NoError(t, err)
+	require.Len(t, files, 1, "the extra media directory must still be indexed")
+	assert.Equal(t, "Rockman 4.nes", filepath.Base(files[0]))
+}
+
 // TestGetFiles_CustomLauncherNestedDirectories verifies that GetFiles walks
 // subdirectories within a custom launcher's absolute path.
 func TestGetFiles_CustomLauncherNestedDirectories(t *testing.T) {

--- a/pkg/helpers/launchers.go
+++ b/pkg/helpers/launchers.go
@@ -116,6 +116,10 @@ func ParseCustomLauncher(pl platforms.Platform, v *config.LaunchersCustom) (plat
 		AllowListOnly: v.Restricted,
 		Lifecycle:     lifecycle,
 		Controls:      parseCustomControls(v.Controls),
+		// An entry with no backend has nothing to run. Validation only lets
+		// one through when it names a system and media dirs, so it exists to
+		// widen that system's media and defers launching to a real launcher.
+		ScanOnly: executeCmd == "" && v.Backend == "" && systemID != "",
 	}
 
 	if executeCmd != "" {
@@ -218,4 +222,54 @@ func ParseCustomLaunchers(
 			Msg("some custom launchers were skipped due to errors")
 	}
 	return launchers
+}
+
+// CombineLaunchers assembles the launcher list a platform reports from its
+// built-in launchers and the user's custom ones. Every platform returns through
+// this, so the launcher cache and the code reading pl.Launchers directly never
+// see different lists.
+func CombineLaunchers(
+	cfg *config.Instance,
+	pl platforms.Platform,
+	builtIn []platforms.Launcher,
+) []platforms.Launcher {
+	return CombineParsedLaunchers(ParseCustomLaunchers(pl, cfg.CustomLaunchers()), builtIn)
+}
+
+// CombineParsedLaunchers is CombineLaunchers for platforms that already parsed
+// their custom launchers, because they feed them to the emulator integrations
+// as the set of IDs those must not redefine.
+func CombineParsedLaunchers(custom, builtIn []platforms.Launcher) []platforms.Launcher {
+	custom = FilterConflictingLaunchers(custom, builtIn)
+	combined := make([]platforms.Launcher, 0, len(custom)+len(builtIn))
+	combined = append(combined, custom...)
+	combined = append(combined, builtIn...)
+	return combined
+}
+
+// FilterConflictingLaunchers drops custom launchers whose ID matches a built-in
+// one. Launcher IDs are the handle for launch overrides, controls and the
+// launcher advanced argument, so a duplicate makes those resolve to whichever
+// entry happens to come first, and shadows a launcher that can actually launch
+// with one that usually cannot.
+func FilterConflictingLaunchers(custom, builtIn []platforms.Launcher) []platforms.Launcher {
+	if len(custom) == 0 || len(builtIn) == 0 {
+		return custom
+	}
+
+	taken := make(map[string]string, len(builtIn))
+	for i := range builtIn {
+		taken[strings.ToLower(builtIn[i].ID)] = builtIn[i].ID
+	}
+
+	kept := make([]platforms.Launcher, 0, len(custom))
+	for i := range custom {
+		if existing, conflict := taken[strings.ToLower(custom[i].ID)]; conflict {
+			log.Error().Str("id", custom[i].ID).Str("existingLauncher", existing).
+				Msg("ignoring custom launcher: id is already used by a built-in launcher")
+			continue
+		}
+		kept = append(kept, custom[i])
+	}
+	return kept
 }

--- a/pkg/helpers/launchers_test.go
+++ b/pkg/helpers/launchers_test.go
@@ -311,6 +311,42 @@ func TestParseCustomLaunchers_EmptyExecuteLeavesLaunchNil(t *testing.T) {
 	assert.Equal(t, []string{filepath.Join(ExeDir(), "movies")}, l.Folders)
 	assert.Equal(t, []string{".mp4", ".mkv"}, l.Extensions)
 	assert.Nil(t, l.Launch, "Launch should be nil when Execute is empty")
+	assert.True(t, l.ScanOnly, "an entry with no execute only widens its system's media")
+}
+
+func TestFilterConflictingLaunchers(t *testing.T) {
+	t.Parallel()
+
+	builtIn := []platforms.Launcher{
+		{ID: "NES", SystemID: "NES", Folders: []string{"NES"}, Extensions: []string{".nes"}},
+		{ID: "SNES", SystemID: "SNES", Folders: []string{"SNES"}, Extensions: []string{".sfc"}},
+	}
+	custom := []platforms.Launcher{
+		{ID: "nes", SystemID: "NES", Folders: []string{"/games/famicom"}},
+		{ID: "Famicom", SystemID: "NES", Folders: []string{"/games/famicom"}},
+	}
+
+	kept := FilterConflictingLaunchers(custom, builtIn)
+
+	require.Len(t, kept, 1, "the entry colliding with a built-in ID is dropped")
+	assert.Equal(t, "Famicom", kept[0].ID)
+}
+
+func TestCombineParsedLaunchers_KeepsBuiltInOnConflict(t *testing.T) {
+	t.Parallel()
+
+	builtIn := []platforms.Launcher{
+		{ID: "NES", SystemID: "NES", Folders: []string{"NES"}, Extensions: []string{".nes"}},
+	}
+	custom := []platforms.Launcher{
+		{ID: "NES", SystemID: "NES", Folders: []string{"/games/famicom"}},
+	}
+
+	combined := CombineParsedLaunchers(custom, builtIn)
+
+	require.Len(t, combined, 1)
+	assert.Equal(t, []string{"NES"}, combined[0].Folders,
+		"the built-in launcher survives, not the custom entry shadowing it")
 }
 
 func TestParseCustomLaunchers_LaunchLogsArgvAndFailsOnMissingBinary(t *testing.T) {

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -249,8 +249,76 @@ type LauncherMatcher struct {
 	normFolderCache map[string]string
 	precomp         map[string]*launcherPrecomp
 	normDataDir     string
+	normMediaPrefix string
 	normRootDirs    []string
 	rawRootDirs     []string
+}
+
+// launcherPaths returns a launcher's normalized paths, computing them when a
+// duplicate ID left the cache entry blank. Skipping such a launcher instead
+// would drop it from the scan-exclude agreements, which are decided by what
+// every launcher sharing a root asks for.
+func (m *LauncherMatcher) launcherPaths(l *platforms.Launcher) *launcherPrecomp {
+	if lc := m.precomp[l.ID]; lc != nil {
+		return lc
+	}
+	return newLauncherPrecomp(l, m.normRootDirs, m.normFolderCache, m.normMediaPrefix)
+}
+
+// newLauncherPrecomp normalizes everything path matching needs from a single
+// launcher. folderCache only saves repeated work; a folder it does not hold is
+// normalized on the spot.
+func newLauncherPrecomp(
+	l *platforms.Launcher,
+	normRoots []string,
+	folderCache map[string]string,
+	normMediaPrefix string,
+) *launcherPrecomp {
+	lp := &launcherPrecomp{}
+
+	normFolder := func(folder string) string {
+		if cached, ok := folderCache[folder]; ok {
+			return cached
+		}
+		return NormalizePathForComparison(folder)
+	}
+
+	if l.SystemID != "" && normMediaPrefix != "" {
+		lp.normMediaPath = NormalizePathForComparison(filepath.Join(normMediaPrefix, strings.ToLower(l.SystemID)))
+	}
+
+	for _, normRoot := range normRoots {
+		for _, folder := range l.Folders {
+			if !filepath.IsAbs(folder) {
+				lp.rootPairs = append(
+					lp.rootPairs,
+					NormalizePathForComparison(filepath.Join(normRoot, normFolder(folder))),
+				)
+			}
+		}
+	}
+
+	for _, folder := range l.Folders {
+		if filepath.IsAbs(folder) {
+			lp.absFolders = append(lp.absFolders, normFolder(folder))
+		}
+	}
+
+	for _, e := range l.Extensions {
+		lp.extensions = append(lp.extensions, strings.ToLower(e))
+	}
+	for _, exclude := range l.ScanExcludes {
+		lp.scanExcludes = append(lp.scanExcludes, NormalizePathForComparison(exclude))
+	}
+	for _, exclude := range l.ScanDirectoryExcludes {
+		lp.scanDirectoryExcludes = append(
+			lp.scanDirectoryExcludes,
+			NormalizePathForComparison(exclude),
+		)
+	}
+	lp.skipInternalSymlinks = l.ScanSkipInternalSymlinks
+
+	return lp
 }
 
 // NewLauncherMatcher creates a matcher with pre-normalized root dirs and folder paths.
@@ -301,52 +369,18 @@ func NewLauncherMatcher(cfg *config.Instance, pl platforms.Platform) *LauncherMa
 	precomp := make(map[string]*launcherPrecomp, len(allLaunchers))
 	for i := range allLaunchers {
 		l := &allLaunchers[i]
-		lp := &launcherPrecomp{}
-
-		if l.SystemID != "" && normMediaPrefix != "" {
-			lp.normMediaPath = NormalizePathForComparison(filepath.Join(normMediaPrefix, strings.ToLower(l.SystemID)))
-		}
-
-		for _, normRoot := range normRoots {
-			for _, folder := range l.Folders {
-				if !filepath.IsAbs(folder) {
-					normFolder := folderCache[folder]
-					lp.rootPairs = append(lp.rootPairs, NormalizePathForComparison(filepath.Join(normRoot, normFolder)))
-				}
-			}
-		}
-
-		for _, folder := range l.Folders {
-			if filepath.IsAbs(folder) {
-				lp.absFolders = append(lp.absFolders, folderCache[folder])
-			}
-		}
-
-		for _, e := range l.Extensions {
-			lp.extensions = append(lp.extensions, strings.ToLower(e))
-		}
-		for _, exclude := range l.ScanExcludes {
-			lp.scanExcludes = append(lp.scanExcludes, NormalizePathForComparison(exclude))
-		}
-		for _, exclude := range l.ScanDirectoryExcludes {
-			lp.scanDirectoryExcludes = append(
-				lp.scanDirectoryExcludes,
-				NormalizePathForComparison(exclude),
-			)
-		}
-		lp.skipInternalSymlinks = l.ScanSkipInternalSymlinks
 
 		// Two launchers sharing an ID cannot share one cache entry: whichever
 		// was precomputed last would answer for both and silently match the
-		// wrong folders. Blank the entry instead so every lookup for that ID
-		// falls back to computing from the launcher in hand.
+		// wrong folders. Blank the entry instead, so every lookup for that ID
+		// computes from the launcher in hand.
 		if _, duplicate := precomp[l.ID]; duplicate {
 			log.Error().Str("launcherID", l.ID).
 				Msg("duplicate launcher ID, matching without precomputed paths")
 			precomp[l.ID] = nil
 			continue
 		}
-		precomp[l.ID] = lp
+		precomp[l.ID] = newLauncherPrecomp(l, normRoots, folderCache, normMediaPrefix)
 	}
 
 	return &LauncherMatcher{
@@ -354,6 +388,7 @@ func NewLauncherMatcher(cfg *config.Instance, pl platforms.Platform) *LauncherMa
 		normRootDirs:    normRoots,
 		rawRootDirs:     rawRoots,
 		normDataDir:     normDataDir,
+		normMediaPrefix: normMediaPrefix,
 		normFolderCache: folderCache,
 		precomp:         precomp,
 	}
@@ -431,10 +466,7 @@ func (m *LauncherMatcher) ShouldSkipScanDirectory(systemID, path string) bool {
 		if launcher.SkipFilesystemScan {
 			continue
 		}
-		lc := m.precomp[launcher.ID]
-		if lc == nil {
-			continue
-		}
+		lc := m.launcherPaths(launcher)
 
 		for _, roots := range [][]string{lc.rootPairs, lc.absFolders} {
 			for _, root := range roots {
@@ -478,10 +510,7 @@ func (m *LauncherMatcher) ShouldSkipScanSymlink(
 		if launcher.SkipFilesystemScan {
 			continue
 		}
-		lc := m.precomp[launcher.ID]
-		if lc == nil {
-			continue
-		}
+		lc := m.launcherPaths(launcher)
 
 		contains := false
 		for _, roots := range [][]string{lc.rootPairs, lc.absFolders} {
@@ -546,15 +575,7 @@ func scanDirectoryExcludeMatches(relPath string, patterns []string) bool {
 }
 
 func (m *LauncherMatcher) pathIsExcludedFromScan(l *platforms.Launcher, normPath string) bool {
-	var excludes []string
-	if lc := m.precomp[l.ID]; lc != nil {
-		excludes = lc.scanExcludes
-	} else {
-		for _, exclude := range l.ScanExcludes {
-			excludes = append(excludes, NormalizePathForComparison(exclude))
-		}
-	}
-
+	excludes := m.launcherPaths(l).scanExcludes
 	if len(excludes) == 0 {
 		return false
 	}
@@ -617,64 +638,25 @@ func (m *LauncherMatcher) pathIsLauncher(
 		}
 	}
 
-	lc := m.precomp[l.ID]
+	lc := m.launcherPaths(l)
 
-	inDataDir := false
-	if lc != nil && lc.normMediaPath != "" {
-		if pathHasPrefixNormalized(normPath, lc.normMediaPath) {
-			inDataDir = true
-		}
-	} else if l.SystemID != "" && m.normDataDir != "" {
-		normZaparooMedia := NormalizePathForComparison(
-			filepath.Join(m.normDataDir, config.MediaDir, strings.ToLower(l.SystemID)),
-		)
-		if pathHasPrefixNormalized(normPath, normZaparooMedia) {
-			inDataDir = true
-		}
-	}
+	inDataDir := lc.normMediaPath != "" && pathHasPrefixNormalized(normPath, lc.normMediaPath)
 
 	if !inDataDir && len(l.Folders) > 0 {
 		inRoot := false
 		isAbs := false
 
-		if lc != nil {
-			for _, normFull := range lc.rootPairs {
-				if pathHasPrefixNormalized(normPath, normFull) {
-					inRoot = true
+		for _, normFull := range lc.rootPairs {
+			if pathHasPrefixNormalized(normPath, normFull) {
+				inRoot = true
+				break
+			}
+		}
+		if !inRoot {
+			for _, normFolder := range lc.absFolders {
+				if pathHasPrefixNormalized(normPath, normFolder) {
+					isAbs = true
 					break
-				}
-			}
-			if !inRoot {
-				for _, normFolder := range lc.absFolders {
-					if pathHasPrefixNormalized(normPath, normFolder) {
-						isAbs = true
-						break
-					}
-				}
-			}
-		} else {
-			for _, normRoot := range m.normRootDirs {
-				if inRoot {
-					break
-				}
-				for _, folder := range l.Folders {
-					normFolder := m.normFolderCache[folder]
-					normFull := NormalizePathForComparison(filepath.Join(normRoot, normFolder))
-					if pathHasPrefixNormalized(normPath, normFull) {
-						inRoot = true
-						break
-					}
-				}
-			}
-			if !inRoot {
-				for _, folder := range l.Folders {
-					if filepath.IsAbs(folder) {
-						normFolder := m.normFolderCache[folder]
-						if pathHasPrefixNormalized(normPath, normFolder) {
-							isAbs = true
-							break
-						}
-					}
 				}
 			}
 		}
@@ -690,24 +672,9 @@ func (m *LauncherMatcher) pathIsLauncher(
 		}
 	}
 
-	if lc != nil && len(lc.extensions) > 0 {
+	if len(lc.extensions) > 0 {
 		for _, e := range lc.extensions {
 			if strings.HasSuffix(lp, e) {
-				return true
-			}
-		}
-		if l.Test != nil {
-			return l.Test(m.cfg, path)
-		}
-		log.Trace().
-			Str("launcher", l.ID).
-			Str("path", path).
-			Strs("extensions", l.Extensions).
-			Msg("path extension did not match any launcher extension")
-		return false
-	} else if len(l.Extensions) > 0 {
-		for _, e := range l.Extensions {
-			if strings.HasSuffix(lp, strings.ToLower(e)) {
 				return true
 			}
 		}

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -336,6 +336,16 @@ func NewLauncherMatcher(cfg *config.Instance, pl platforms.Platform) *LauncherMa
 		}
 		lp.skipInternalSymlinks = l.ScanSkipInternalSymlinks
 
+		// Two launchers sharing an ID cannot share one cache entry: whichever
+		// was precomputed last would answer for both and silently match the
+		// wrong folders. Blank the entry instead so every lookup for that ID
+		// falls back to computing from the launcher in hand.
+		if _, duplicate := precomp[l.ID]; duplicate {
+			log.Error().Str("launcherID", l.ID).
+				Msg("duplicate launcher ID, matching without precomputed paths")
+			precomp[l.ID] = nil
+			continue
+		}
 		precomp[l.ID] = lp
 	}
 
@@ -777,6 +787,11 @@ func (m *LauncherMatcher) FindLauncher(path string) (platforms.Launcher, error) 
 		Int("candidates", len(launchers)).
 		Msg("selected launcher by specificity")
 
+	launcher, err := ResolveLaunchableLauncher(&launcher, path)
+	if err != nil {
+		return platforms.Launcher{}, err
+	}
+
 	if launcher.AllowListOnly && !m.cfg.IsLauncherFileAllowed(path) {
 		return platforms.Launcher{}, errors.New("file not allowed: " + path)
 	}
@@ -1040,6 +1055,58 @@ func GuessLauncherForPath(path string) (platforms.Launcher, bool) {
 	return launcher, ok
 }
 
+// LauncherCanLaunch reports whether a launcher is able to start media itself.
+func LauncherCanLaunch(l *platforms.Launcher) bool {
+	return l.Launch != nil || l.BuildLaunchCommand != nil
+}
+
+// ResolveLaunchableLauncher returns a launcher able to start path. A scan-only
+// launcher only widens the media its system indexes, so the system's real
+// launcher takes over, keeping any allow list the scan-only entry asked for.
+// Every other launcher is returned unchanged.
+func ResolveLaunchableLauncher(
+	launcher *platforms.Launcher,
+	path string,
+) (platforms.Launcher, error) {
+	if !launcher.ScanOnly {
+		return *launcher, nil
+	}
+
+	ext := filepath.Ext(path)
+	candidates := GlobalLauncherCache.GetAvailableLaunchersBySystem(launcher.SystemID)
+	best := -1
+	bestScore := -1
+	for i := range candidates {
+		candidate := &candidates[i]
+		if candidate.ScanOnly || !LauncherCanLaunch(candidate) {
+			continue
+		}
+		// An extension match beats every structural signal: it is the only
+		// evidence that this launcher handles this kind of file, rather than
+		// merely belonging to the same system.
+		score := launcherSpecificity(candidate)
+		if ext != "" && launcherHasExtension(candidate, ext) {
+			score += 10000
+		}
+		if score > bestScore {
+			best = i
+			bestScore = score
+		}
+	}
+
+	if best == -1 {
+		log.Debug().Str("launcher", launcher.ID).Str("system", launcher.SystemID).
+			Str("path", path).Msg("no launchable launcher for scan-only launcher's system")
+		return platforms.Launcher{}, fmt.Errorf("%w for: %s", ErrNoLauncher, path)
+	}
+
+	resolved := candidates[best]
+	resolved.AllowListOnly = resolved.AllowListOnly || launcher.AllowListOnly
+	log.Debug().Str("scanOnlyLauncher", launcher.ID).Str("launcher", resolved.ID).
+		Str("path", path).Msg("resolved scan-only launcher to system launcher")
+	return resolved, nil
+}
+
 // FindLauncher takes a path and tries to find the best possible match for a
 // launcher, taking into account specificity and allowlist restrictions.
 func FindLauncher(
@@ -1075,6 +1142,11 @@ func FindLauncher(
 			Int("specificity", bestScore).
 			Int("candidates", len(launchers)).
 			Msg("selected launcher by specificity")
+	}
+
+	launcher, resolveErr := ResolveLaunchableLauncher(&launcher, path)
+	if resolveErr != nil {
+		return platforms.Launcher{}, resolveErr
 	}
 
 	if launcher.AllowListOnly && !cfg.IsLauncherFileAllowed(path) {

--- a/pkg/helpers/paths_launcher_test.go
+++ b/pkg/helpers/paths_launcher_test.go
@@ -769,3 +769,172 @@ func TestFindLauncher_TieBreaksToFirstMatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "First", launcher.ID, "on tie, first match should win")
 }
+
+// TestMatchSystemFile_DuplicateLauncherIDs covers a custom launcher configured
+// with the same ID as a built-in one. The matcher precomputes folder data into
+// a map keyed by ID, so before the fix one entry answered for both and the
+// other's directory silently matched nothing.
+func TestMatchSystemFile_DuplicateLauncherIDs(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	tmpDir := t.TempDir()
+
+	duplicateID := "PS2"
+	customLauncher := platforms.Launcher{
+		ID:         duplicateID,
+		SystemID:   "PS2",
+		Folders:    []string{tmpDir},
+		Extensions: []string{".chd"},
+	}
+	builtinLauncher := platforms.Launcher{
+		ID:         duplicateID,
+		SystemID:   "PS2",
+		Folders:    []string{"PS2"},
+		Extensions: []string{".iso"},
+	}
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return(
+		[]platforms.Launcher{customLauncher, builtinLauncher})
+
+	cfg := &config.Instance{}
+
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	// The scanner matches through LauncherMatcher, which is where the
+	// per-launcher folder data is cached by ID.
+	matcher := NewLauncherMatcher(cfg, mockPlatform)
+	assert.True(t, matcher.MatchSystemFileForScan("PS2", filepath.Join(tmpDir, "game.chd")),
+		"the absolute folder must still match when another launcher shares its ID")
+	assert.True(t, matcher.MatchSystemFileForScan("PS2", "/roms/PS2/game.iso"),
+		"the relative folder must still match when another launcher shares its ID")
+	assert.False(t, matcher.MatchSystemFileForScan("PS2", filepath.Join(tmpDir, "readme.txt")),
+		"an unrelated extension must not match either launcher")
+}
+
+func TestResolveLaunchableLauncher(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	tmpDir := t.TempDir()
+
+	launched := false
+	realLauncher := platforms.Launcher{
+		ID:         "NES",
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{"NES"},
+		Extensions: []string{".nes"},
+		Launch: func(_ *config.Instance, _ string, _ *platforms.LaunchOptions) (*os.Process, error) {
+			launched = true
+			return nil, nil //nolint:nilnil // test stub
+		},
+	}
+	musicLauncher := platforms.Launcher{
+		ID:         "NESMusic",
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{"NES"},
+		Extensions: []string{".nsf"},
+		Launch: func(_ *config.Instance, _ string, _ *platforms.LaunchOptions) (*os.Process, error) {
+			return nil, nil //nolint:nilnil // test stub
+		},
+	}
+	scanOnly := platforms.Launcher{
+		ID:         "Famicom",
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{tmpDir},
+		Extensions: []string{".nes"},
+		ScanOnly:   true,
+	}
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return(
+		[]platforms.Launcher{scanOnly, realLauncher, musicLauncher})
+
+	cfg := &config.Instance{}
+
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	mediaPath := filepath.Join(tmpDir, "Rockman 4.nes")
+
+	t.Run("scan-only launcher resolves to the system launcher", func(t *testing.T) {
+		resolved, err := ResolveLaunchableLauncher(&scanOnly, mediaPath)
+		require.NoError(t, err)
+		assert.Equal(t, "NES", resolved.ID)
+		require.NotNil(t, resolved.Launch)
+		_, launchErr := resolved.Launch(cfg, mediaPath, nil)
+		require.NoError(t, launchErr)
+		assert.True(t, launched, "the resolved launcher is the one that runs")
+	})
+
+	t.Run("a launchable launcher is returned unchanged", func(t *testing.T) {
+		resolved, err := ResolveLaunchableLauncher(&realLauncher, mediaPath)
+		require.NoError(t, err)
+		assert.Equal(t, realLauncher.ID, resolved.ID)
+	})
+
+	t.Run("allow list restriction survives the swap", func(t *testing.T) {
+		restricted := scanOnly
+		restricted.AllowListOnly = true
+		resolved, err := ResolveLaunchableLauncher(&restricted, mediaPath)
+		require.NoError(t, err)
+		assert.Equal(t, "NES", resolved.ID)
+		assert.True(t, resolved.AllowListOnly)
+	})
+
+	t.Run("FindLauncher delegates for a path only the scan-only launcher matches", func(t *testing.T) {
+		found, err := FindLauncher(cfg, mockPlatform, mediaPath)
+		require.NoError(t, err)
+		assert.Equal(t, "NES", found.ID)
+	})
+}
+
+func TestResolveLaunchableLauncher_NoLaunchableLauncher(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	tmpDir := t.TempDir()
+
+	scanOnly := platforms.Launcher{
+		ID:         "Famicom",
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{tmpDir},
+		Extensions: []string{".nes"},
+		ScanOnly:   true,
+	}
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return(
+		[]platforms.Launcher{scanOnly})
+
+	cfg := &config.Instance{}
+
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	_, err := ResolveLaunchableLauncher(&scanOnly, filepath.Join(tmpDir, "Rockman 4.nes"))
+	require.ErrorIs(t, err, ErrNoLauncher)
+}

--- a/pkg/helpers/paths_launcher_test.go
+++ b/pkg/helpers/paths_launcher_test.go
@@ -938,3 +938,52 @@ func TestResolveLaunchableLauncher_NoLaunchableLauncher(t *testing.T) {
 	_, err := ResolveLaunchableLauncher(&scanOnly, filepath.Join(tmpDir, "Rockman 4.nes"))
 	require.ErrorIs(t, err, ErrNoLauncher)
 }
+
+// TestShouldSkipScanDirectory_DuplicateLauncherIDs covers the scan-exclude
+// agreement when two launchers share an ID. The agreement is decided by what
+// every launcher sharing a root asks for, so a launcher dropped from it because
+// its cache entry was blanked would let an excluded directory be walked.
+func TestShouldSkipScanDirectory_DuplicateLauncherIDs(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	tmpDir := t.TempDir()
+
+	duplicateID := "PS2"
+	excluding := platforms.Launcher{
+		ID:                    duplicateID,
+		SystemID:              "PS2",
+		Folders:               []string{tmpDir},
+		Extensions:            []string{".iso"},
+		ScanDirectoryExcludes: []string{"updates"},
+	}
+	other := platforms.Launcher{
+		ID:                    duplicateID,
+		SystemID:              "PS2",
+		Folders:               []string{tmpDir},
+		Extensions:            []string{".chd"},
+		ScanDirectoryExcludes: []string{"updates"},
+	}
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return(
+		[]platforms.Launcher{excluding, other})
+
+	cfg := &config.Instance{}
+
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	matcher := NewLauncherMatcher(cfg, mockPlatform)
+	assert.True(t, matcher.ShouldSkipScanDirectory("PS2", filepath.Join(tmpDir, "updates")),
+		"an excluded directory must still be skipped when another launcher shares the ID")
+	assert.False(t, matcher.ShouldSkipScanDirectory("PS2", filepath.Join(tmpDir, "games")),
+		"a directory nothing excludes must still be scanned")
+}

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -816,11 +816,14 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 				}
 				return nil, nil //nolint:nilnil // API launches don't return a process handle
 			}
+			// It can launch now, so it is no longer a scan-only entry that
+			// has to defer to another launcher for its system.
+			cl.ScanOnly = false
 			log.Debug().Str("launcherID", cl.ID).Msg("custom launcher using ES API launch")
 		}
 	}
 
-	return append(customLaunchers, launchers...)
+	return helpers.CombineParsedLaunchers(customLaunchers, launchers)
 }
 
 func (*Platform) PresentUI(

--- a/pkg/platforms/bazzite/platform.go
+++ b/pkg/platforms/bazzite/platform.go
@@ -187,9 +187,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	emuOpts := p.emulationOptions()
 	ls = append(ls, linuxemu.Launchers(cfg, emuOpts, existing)...)
 	linuxemu.AttachPlainESDEScanners(cfg, emuOpts, ls)
-	allLaunchers := make([]platforms.Launcher, 0, len(custom)+len(ls))
-	allLaunchers = append(allLaunchers, custom...)
-	allLaunchers = append(allLaunchers, ls...)
+	allLaunchers := helpers.CombineParsedLaunchers(custom, ls)
 	p.gameMode.WrapLaunchers(allLaunchers)
 	return allLaunchers
 }

--- a/pkg/platforms/chimeraos/platform.go
+++ b/pkg/platforms/chimeraos/platform.go
@@ -177,9 +177,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	emuOpts := p.emulationOptions()
 	ls = append(ls, linuxemu.Launchers(cfg, emuOpts, existing)...)
 	linuxemu.AttachPlainESDEScanners(cfg, emuOpts, ls)
-	allLaunchers := make([]platforms.Launcher, 0, len(custom)+len(ls))
-	allLaunchers = append(allLaunchers, custom...)
-	allLaunchers = append(allLaunchers, ls...)
+	allLaunchers := helpers.CombineParsedLaunchers(custom, ls)
 	p.gameMode.WrapLaunchers(allLaunchers)
 	return allLaunchers
 }

--- a/pkg/platforms/libreelec/platform.go
+++ b/pkg/platforms/libreelec/platform.go
@@ -250,7 +250,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 		},
 	}
 
-	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+	return helpers.CombineLaunchers(cfg, p, launchers)
 }
 
 func (*Platform) ConsoleManager() platforms.ConsoleManager {

--- a/pkg/platforms/linux/platform.go
+++ b/pkg/platforms/linux/platform.go
@@ -185,7 +185,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	emuOpts := p.emulationOptions()
 	ls = append(ls, linuxemu.Launchers(cfg, emuOpts, existing)...)
 	linuxemu.AttachPlainESDEScanners(cfg, emuOpts, ls)
-	return append(custom, ls...)
+	return helpers.CombineParsedLaunchers(custom, ls)
 }
 
 func (p *Platform) emulationOptions() linuxemu.Options {

--- a/pkg/platforms/mac/platform.go
+++ b/pkg/platforms/mac/platform.go
@@ -255,7 +255,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 		},
 	}
 
-	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+	return helpers.CombineLaunchers(cfg, p, launchers)
 }
 
 func (*Platform) ConsoleManager() platforms.ConsoleManager {

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -1745,8 +1745,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	)
 	setCoreAvailability(ls)
 
-	custom := helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers())
-	return append(custom, ls...)
+	return helpers.CombineLaunchers(cfg, p, ls)
 }
 
 func (*Platform) MinimumUIDisplay(kind models.UIEventKind) time.Duration {

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -382,7 +382,7 @@ func (*Platform) LookupMapping(_ *tokens.Token) (string, bool) {
 
 func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	ls := mister.CreateLaunchers(p)
-	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), ls...)
+	return helpers.CombineLaunchers(cfg, p, ls)
 }
 
 func (*Platform) ConsoleManager() platforms.ConsoleManager {

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -387,6 +387,11 @@ type Launcher struct {
 	// own path, so the alias would only duplicate it. Applies to symlinked files
 	// and directories. Direct path launches remain unaffected.
 	ScanSkipInternalSymlinks bool
+	// ScanOnly marks a launcher that contributes media directories to its
+	// system but cannot launch anything itself. Launch selection resolves it
+	// to a launchable launcher for the same system, so media found only in a
+	// user-configured directory still starts on the system's real launcher.
+	ScanOnly bool
 	// Available is populated by LauncherCache.
 	Available bool
 }

--- a/pkg/platforms/recalbox/platform.go
+++ b/pkg/platforms/recalbox/platform.go
@@ -235,7 +235,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 		},
 	}
 
-	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+	return helpers.CombineLaunchers(cfg, p, launchers)
 }
 
 func (*Platform) ConsoleManager() platforms.ConsoleManager {

--- a/pkg/platforms/replayos/platform.go
+++ b/pkg/platforms/replayos/platform.go
@@ -313,7 +313,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 		},
 	})
 
-	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+	return helpers.CombineLaunchers(cfg, p, launchers)
 }
 
 func (*Platform) ConsoleManager() platforms.ConsoleManager {

--- a/pkg/platforms/retropie/platform.go
+++ b/pkg/platforms/retropie/platform.go
@@ -235,7 +235,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 		},
 	}
 
-	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+	return helpers.CombineLaunchers(cfg, p, launchers)
 }
 
 func (*Platform) ConsoleManager() platforms.ConsoleManager {

--- a/pkg/platforms/shared/linuxemu/integration.go
+++ b/pkg/platforms/shared/linuxemu/integration.go
@@ -101,9 +101,16 @@ func newFlatpakChecker() func(string) bool {
 func Launchers(cfg *config.Instance, options Options, existing []platforms.Launcher) []platforms.Launcher {
 	options.normalize()
 	result := make([]platforms.Launcher, 0, 64)
-	seenIDs := make([]string, len(existing), len(existing)+64)
+	seenIDs := make([]string, 0, len(existing)+64)
 	for i := range existing {
-		seenIDs[i] = existing[i].ID
+		// A launcher that cannot start anything must not displace one that
+		// can. A scan-only custom launcher only widens a system's media
+		// directories, so suppressing the real launcher for its ID would
+		// leave that system indexed and unlaunchable.
+		if existing[i].ScanOnly {
+			continue
+		}
+		seenIDs = append(seenIDs, existing[i].ID)
 	}
 	appendUnique := func(items ...platforms.Launcher) {
 		for i := range items {

--- a/pkg/platforms/shared/linuxemu/integration_test.go
+++ b/pkg/platforms/shared/linuxemu/integration_test.go
@@ -231,6 +231,29 @@ func TestLaunchersSuppressesCaseInsensitiveExistingID(t *testing.T) {
 	assert.NotContains(t, launcherIDs(launchers), "ScummVMStandalone")
 }
 
+// TestLaunchersScanOnlyDoesNotSuppressExistingID covers a custom launcher that
+// only widens a system's media directories. Letting it claim an emulator
+// launcher's ID would remove the only thing able to start that system's media.
+func TestLaunchersScanOnlyDoesNotSuppressExistingID(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions(t.TempDir(), sharedretroarch.Options{})
+	options.IncludeRetroArch = false
+	options.IncludeProviderDecks = false
+	options.LookPath = func(name string) (string, error) {
+		if name == "scummvm" {
+			return filepath.Join(string(filepath.Separator), "usr", "bin", "scummvm"), nil
+		}
+		return "", errors.New("missing")
+	}
+	options.IsFlatpakInstalled = func(string) bool { return false }
+
+	launchers := Launchers(nil, options, []platforms.Launcher{
+		{ID: "scummvmstandalone", ScanOnly: true},
+	})
+	assert.Contains(t, launcherIDs(launchers), "ScummVMStandalone")
+}
+
 func TestLauncherIDInSliceUsesEqualFold(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/steamos/platform.go
+++ b/pkg/platforms/steamos/platform.go
@@ -429,9 +429,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	integrationOpts := p.emulationOptions(&retroArchOpts)
 	ls = append(ls, linuxemu.Launchers(cfg, integrationOpts, existing)...)
 
-	allLaunchers := make([]platforms.Launcher, 0, len(custom)+len(ls))
-	allLaunchers = append(allLaunchers, custom...)
-	allLaunchers = append(allLaunchers, ls...)
+	allLaunchers := helpers.CombineParsedLaunchers(custom, ls)
 	if p.steamRuntime != nil && p.steamRuntime.Available() && steamOSGameMode.IsGamingMode() {
 		for i := range allLaunchers {
 			p.wrapSteamRuntime(&allLaunchers[i])

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -505,7 +505,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 
 	launchers = append(launchers, deverr.GetDevErrLaunchers()...)
 
-	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+	return helpers.CombineLaunchers(cfg, p, launchers)
 }
 
 func (*Platform) ConsoleManager() platforms.ConsoleManager {

--- a/pkg/platforms/zapos/platform.go
+++ b/pkg/platforms/zapos/platform.go
@@ -79,7 +79,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	existing := append(append(make([]platforms.Launcher, 0, len(custom)+len(builtIn)), custom...), builtIn...)
 	builtIn = append(builtIn, linuxemu.Launchers(cfg, p.emulationOptions(), existing)...)
 	linuxemu.AttachPlainESDEScanners(cfg, p.emulationOptions(), builtIn)
-	return append(custom, builtIn...)
+	return helpers.CombineParsedLaunchers(custom, builtIn)
 }
 
 func (p *Platform) emulationOptions() linuxemu.Options {

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -313,6 +313,9 @@ func inferLauncherForSystemPath(
 	launchers := pl.Launchers(env.Cfg)
 	match := -1
 	for i := range launchers {
+		if launchers[i].ScanOnly {
+			continue
+		}
 		if !strings.EqualFold(launchers[i].SystemID, systemID) {
 			continue
 		}
@@ -828,7 +831,15 @@ func getLaunchClosure(
 			if launcher == nil {
 				return fmt.Errorf("launcher not found: %s", launcherID)
 			}
-			log.Info().Msgf("launching with launcher: %s", launcherID)
+			// Naming a scan-only launcher is asking for the media it
+			// contributes, so honour it with the launcher that can start it
+			// rather than refusing a launcher the user configured themselves.
+			resolved, resolveErr := helpers.ResolveLaunchableLauncher(launcher, target.path)
+			if resolveErr != nil {
+				return fmt.Errorf("resolving launcher %s: %w", launcherID, resolveErr)
+			}
+			launcher = &resolved
+			log.Info().Msgf("launching with launcher: %s", launcher.ID)
 		} else if target.guideLauncherBySystem {
 			inferred, found := inferLauncherForSystemPath(pl, env, target.path, target.systemID)
 			if found {

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1173,6 +1173,92 @@ func TestInferLauncherForSystemPath_RejectsSameSystemAmbiguity(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
+// TestInferLauncherForSystemPath_SkipsScanOnly covers a custom launcher that
+// only widens a system's media directories. It shares the stock launcher's
+// extension, so counting it as a candidate would make every launch for that
+// system ambiguous.
+func TestInferLauncherForSystemPath_SkipsScanOnly(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{
+		{
+			ID: "Famicom", SystemID: systemdefs.SystemNES,
+			Folders:    []string{filepath.Join("games", "famicom")},
+			Extensions: []string{".nes"}, ScanOnly: true,
+		},
+		{
+			ID: systemdefs.SystemNES, SystemID: systemdefs.SystemNES,
+			Folders: []string{"NES"}, Extensions: []string{".nes"},
+		},
+	})
+
+	launcher, found := inferLauncherForSystemPath(
+		mockPlatform,
+		&platforms.CmdEnv{Cfg: cfg},
+		filepath.Join("games", "famicom", "Rockman 4.nes"),
+		systemdefs.SystemNES,
+	)
+
+	assert.True(t, found)
+	assert.Equal(t, systemdefs.SystemNES, launcher.ID)
+	mockPlatform.AssertExpectations(t)
+}
+
+// TestCmdLaunch_ExplicitScanOnlyLauncherDelegates covers naming a scan-only
+// launcher in the launcher argument. It cannot start anything itself, so the
+// launch has to go to the system's real launcher rather than being refused.
+func TestCmdLaunch_ExplicitScanOnlyLauncherDelegates(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	tmpDir := t.TempDir()
+	mediaPath := filepath.Join(tmpDir, "Rockman 4.nes")
+	require.NoError(t, os.WriteFile(mediaPath, []byte("test"), 0o600))
+
+	cfg := &config.Instance{}
+	scanOnly := platforms.Launcher{
+		ID: "Famicom", SystemID: systemdefs.SystemNES,
+		Folders: []string{tmpDir}, Extensions: []string{".nes"}, ScanOnly: true,
+	}
+	systemLauncher := platforms.Launcher{
+		ID: systemdefs.SystemNES, SystemID: systemdefs.SystemNES,
+		Folders: []string{"NES"}, Extensions: []string{".nes"},
+		Launch: func(_ *config.Instance, _ string, _ *platforms.LaunchOptions) (*os.Process, error) {
+			return nil, nil //nolint:nilnil // test stub
+		},
+	}
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Maybe()
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{scanOnly, systemLauncher})
+	mockPlatform.On("RootDirs", cfg).Return([]string{}).Maybe()
+	mockPlatform.On(
+		"LaunchMedia", cfg, mediaPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == systemdefs.SystemNES
+		}),
+		(*database.Database)(nil), (*platforms.LaunchOptions)(nil),
+	).Return(nil).Once()
+
+	originalCache := pathhelpers.GlobalLauncherCache
+	testCache := &pathhelpers.LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	pathhelpers.GlobalLauncherCache = testCache
+	defer func() { pathhelpers.GlobalLauncherCache = originalCache }()
+
+	reader := zapscript.NewParser(mediaPath + "?launcher=Famicom")
+	script, err := reader.ParseScript()
+	require.NoError(t, err)
+	require.Len(t, script.Cmds, 1)
+
+	env := platforms.CmdEnv{Cmd: script.Cmds[0], Cfg: cfg}
+	result, err := cmdLaunchWithFS(afero.NewMemMapFs(), mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCmdLaunch_SystemDefaultDoesNotBypassLauncherAllowlist(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #1399.

A user keeps NES ROMs in two directories, `nes` and `famicom`. Only `nes` is
indexed, because folder discovery probes literal launcher folder names. The
documented answer is a custom launcher reusing an existing system, and it did
nothing at all for them.

Three separate defects were responsible, plus two found while testing.

**A duplicate launcher ID silently broke folder matching.** `LauncherMatcher`
cached per-launcher folder data in a map keyed by launcher ID, so their
`id = "NES"` shared the built-in NES launcher's entry and their `famicom`
directory matched nothing. The scan walked it and rejected every file, logging
only that nothing matched. A custom launcher whose ID collides with a built-in
is now rejected with a message naming both, since the ID is also the handle for
launch overrides, controls and the `launcher=` argument, and the matcher no
longer lets one launcher answer for another.

Custom launchers were merged into the platform list in fourteen places, none of
which could see the built-in set, so the conflict check needed a single place
to live. `CombineLaunchers` is now that place, which also means the launcher
cache and the ~14 call sites reading `pl.Launchers` directly — including the
indexer — can no longer disagree about what exists.

**An entry with `media_dirs` and no `execute` could not launch.** It produced a
launcher with no launch function, so it indexed correctly and then failed with
`launcher has no launch function configured`. There is no usable `execute` for
this on MiSTer: the correct behaviour is to boot the NES core, which only the
built-in launcher can do. Such an entry is now marked scan-only and resolves to
a launchable launcher for the same system, keeping any allow list it asked for.
It has to name both a system and media dirs, because without both it matches
every path for its system and indexes nothing.

**Media directories outside every scan root could not be browsed.** Both browse
gates keyed off `Platform.RootDirs` — one deciding whether a launcher folder was
listed as a route, the other whether a client could open a path at all — so
media configured there indexed and launched while the directory holding it was
invisible and unopenable. A path the user wrote into their own config now counts
alongside the scan roots. Relative folders still compose only against scan roots,
and a path under no root and no media directory is still refused.

Two more surfaced during device testing. Naming a scan-only launcher explicitly
in the `launcher=` argument failed opaquely rather than delegating, and on the
desktop Linux platforms a scan-only launcher could suppress an emulator
integration launcher sharing its ID, leaving that system indexed and completely
unlaunchable.

Also included: `settings.update` replaces the whole `systemDefaults` list from a
model with no `pause_on_launch`, so a client editing a launcher deleted a
setting it could neither see nor send. Entries now carry that value forward from
disk.

Verified on the MiSTer test device and against a real Linux build. The
reporter's exact config now names the conflict instead of indexing nothing; with
a unique id, a reader-sourced scan of `@NES/Rockman 4` boots the NES core from
the `famicom` directory. A full rebuild indexed 6,590 media with no errors or
warnings, returning to its 6,587 baseline after teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom scan-only launchers can expand a system’s media directories while launching through the appropriate playable launcher.
  * Media folders outside configured platform scan roots can now be browsed.
  * Conflicting custom launcher IDs no longer replace built-in launchers.
* **Bug Fixes**
  * Preserved system default audio-pause settings when updating configuration.
  * Improved media discovery when launchers share IDs or use external directories.
* **Validation**
  * Invalid scan-only launcher configurations are now rejected with clear validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->