### PR TITLE
fix(test): unblock Windows and macOS CI, and gate releases on it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,26 @@ jobs:
       contents: read
       packages: write
 
-  create-release:
+  # A tag builds, signs and publishes on its own; nothing here used to look at
+  # whether the commit passed its tests, and v2.17.1 shipped on a commit whose
+  # Windows job was failing. Run them here so a release cannot outrun them.
+  # Skipped for test_build, which publishes nothing: build-check.yml only asks
+  # whether every target still compiles, and main has already tested the code.
+  # Declared per job because the workflow-level block above grants contents:
+  # write, which this needs none of.
+  lint-and-test:
     if: ${{ !inputs.test_build }}
+    uses: ./.github/workflows/lint-and-test.yml
+    with:
+      release_gate: true
+    permissions:
+      contents: read
+      pull-requests: read
+      packages: read
+
+  create-release:
+    needs: lint-and-test
+    if: ${{ !cancelled() && !inputs.test_build && needs.lint-and-test.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -84,8 +102,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [create-release, ensure-zigcc]
-    if: ${{ !cancelled() && needs.ensure-zigcc.result == 'success' }}
+    needs: [create-release, ensure-zigcc, lint-and-test]
+    # 'skipped' is the test_build case, where the gate does not run at all.
+    if: >-
+      ${{ !cancelled() && needs.ensure-zigcc.result == 'success'
+      && (needs.lint-and-test.result == 'success' || needs.lint-and-test.result == 'skipped') }}
     permissions:
       contents: write # Needed for uploading release assets
       packages: read # Needed for pulling Docker images from ghcr.io

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - main
   workflow_call:
+    inputs:
+      release_gate:
+        description: "Run as a release build's test gate: the reports below belong to branches, not releases, so skip them"
+        required: false
+        type: boolean
+        default: false
 
 # Cancel in-progress runs when new commits are pushed
 concurrency:
@@ -192,7 +198,11 @@ jobs:
           exit "$status"
 
       - name: Upload govulncheck SARIF
-        if: matrix.os == 'ubuntu' && !cancelled() && github.event_name != 'workflow_call' && hashFiles('govulncheck.sarif') != ''
+        # Not on a release gate: code scanning rejects an upload for a tag ref,
+        # which would fail the job and block the release over a report nobody
+        # asked this run for. github.event_name cannot express this — inside a
+        # reusable workflow it still reads as the caller's event.
+        if: matrix.os == 'ubuntu' && !cancelled() && !inputs.release_gate && hashFiles('govulncheck.sarif') != ''
         uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           sarif_file: govulncheck.sarif
@@ -222,7 +232,9 @@ jobs:
         run: go test -tags=deadlock -race -count=1 ./...
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu' && !startsWith(github.ref, 'refs/tags/')
+        # Coverage is tracked per branch, so a release gate's run has nothing to
+        # report against.
+        if: matrix.os == 'ubuntu' && !inputs.release_gate
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pkg/database/mediadb/crash_consistency_test.go
+++ b/pkg/database/mediadb/crash_consistency_test.go
@@ -41,11 +41,11 @@ import (
 // already spilled to the WAL, a torn write at the WAL tail, and a checkpoint
 // interrupted part-way through copying frames into the main file. Each one
 // drives the production indexing write path — staging, the tag-link reconcile,
-// commit — against a real file-backed database, then copies the on-disk files
-// to a fresh directory to stand in for what storage would have preserved, and
-// damages the copy where the failure would have. Reopening the copy is the
-// recovery SQLite performs at the next boot; what these pin down is that the
-// data it recovers is exactly the committed set and the file passes an
+// commit — against a real file-backed database, then copies the database and
+// its WAL to a fresh directory to stand in for what storage would have
+// preserved, and damages the copy where the failure would have. Reopening the
+// copy is the recovery SQLite performs at the next boot; what these pin down is
+// that the data it recovers is exactly the committed set and the file passes an
 // integrity check. The one storage failure they cannot model is a drive that
 // acknowledges an fsync it did not perform, which is the case the corruption
 // marker and rebuild exist for (see TestMediaDB_ZeroedPages_DetectedAndRecovered).
@@ -108,15 +108,22 @@ func copyFileIfExists(t *testing.T, src, dst string) {
 	require.NoError(t, os.WriteFile(dst, data, 0o600)) //nolint:gosec // test-controlled temp path
 }
 
-// snapshotDatabase copies the database and whichever sidecars exist to a fresh
-// directory: the on-disk state a power loss at that instant would have left
-// for the next boot to recover from.
+// snapshotDatabase copies the database and its WAL to a fresh directory: the
+// on-disk state a power loss at that instant would have left for the next boot
+// to recover from.
+//
+// The -shm is deliberately not copied. It is the WAL index and holds nothing
+// durable: the next connection takes the exclusive dead-man-switch lock and
+// rebuilds it from the WAL, so recovery reaches the same state with or without
+// it. Copying it is also impossible while a writer is live — SQLite keeps the
+// WAL-index locks inside that file, and on Windows an os.ReadFile over an
+// exclusively locked byte range fails outright, which is what made the
+// mid-transaction snapshot below the only one of these tests to fail there.
 func snapshotDatabase(t *testing.T, dbPath string) string {
 	t.Helper()
 	target := filepath.Join(t.TempDir(), "crash.db")
 	copyFileIfExists(t, dbPath, target)
 	copyFileIfExists(t, dbPath+"-wal", target+"-wal")
-	copyFileIfExists(t, dbPath+"-shm", target+"-shm")
 	return target
 }
 

--- a/pkg/database/mediadb/forensic_set_test.go
+++ b/pkg/database/mediadb/forensic_set_test.go
@@ -21,7 +21,6 @@ package mediadb
 
 import (
 	"context"
-	"database/sql"
 	"path/filepath"
 	"testing"
 
@@ -29,6 +28,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// forensicSetSuffixes names the three files Recreate preserves as one set: the
+// database, its WAL and the WAL index over it.
+var forensicSetSuffixes = []string{"", "-wal", "-shm"}
 
 // TestMediaDB_Recreate_KeepBackup_PreservesConsistentForensicSet pins what a
 // corruption post-mortem needs from Recreate: the database, its WAL and its
@@ -43,10 +46,21 @@ func TestMediaDB_Recreate_KeepBackup_PreservesConsistentForensicSet(t *testing.T
 	path := mediaDB.GetDBPath()
 	require.FileExists(t, path+"-wal", "the row must still be in the WAL for the set to matter")
 
+	// Hold the three files aside exactly as they stand now, while the row is
+	// still WAL-only. Closing the database checkpoints the row into the main
+	// file and deletes the sidecars, so a copy taken here is the only way to
+	// have the set back afterwards. Keeping a second connection open would
+	// leave them on disk instead, but a file SQLite still has open cannot be
+	// renamed or deleted on Windows, and renaming all three is exactly what
+	// Recreate is about to do.
+	held := filepath.Join(t.TempDir(), filepath.Base(path))
+	for _, suffix := range forensicSetSuffixes {
+		copyFileIfExists(t, path+suffix, held+suffix)
+	}
+
 	// The set only matters if the row is genuinely WAL-only, so prove the main
-	// database alone cannot answer for it. This has to happen before Recreate:
-	// Recreate closes the database first, and that close can checkpoint the row
-	// into the main file.
+	// database alone cannot answer for it. Its own copy, not the held one: this
+	// one is opened read-write, which would write sidecars next to it.
 	mainOnly := filepath.Join(t.TempDir(), "main-only.db")
 	copyFileIfExists(t, path, mainOnly)
 	var mainOnlyMedia int
@@ -59,52 +73,32 @@ func TestMediaDB_Recreate_KeepBackup_PreservesConsistentForensicSet(t *testing.T
 		require.ErrorContains(t, mainOnlyErr, "no such table")
 	}
 
-	// A second, read-only connection keeps the WAL and SHM on disk through
-	// Close(): SQLite checkpoints and deletes them only when the last
-	// connection leaves, and a read-only connection can do neither. That is
-	// the on-disk state a crashed or corrupt process leaves behind, which is
-	// what the forensic set exists to capture.
-	// The media driver, not the bare one: this file carries an index collated
-	// with ZAPAROO_TITLE_V1, and a connection without that collation cannot
-	// even run integrity_check against it. The count below happens not to need
-	// it, which is not a property worth depending on.
-	holder, err := sql.Open(sqliteMediaDriver, "file:"+path+"?mode=ro")
-	require.NoError(t, err)
-	holderConn, err := holder.Conn(ctx)
-	require.NoError(t, err)
-	var seen int
-	require.NoError(t, holderConn.QueryRowContext(ctx, "SELECT COUNT(*) FROM Media").Scan(&seen))
-	require.Equal(t, 1, seen)
-	holderReleased := false
-	releaseHolder := func() {
-		if holderReleased {
-			return
-		}
-		holderReleased = true
-		require.NoError(t, holderConn.Close())
-		require.NoError(t, holder.Close())
+	// Put the pre-checkpoint set back over the closed database. That is the
+	// on-disk state a process that died before its WAL was checkpointed leaves
+	// behind, and the state the forensic set exists to capture: a main file
+	// without the row, the WAL that holds it, and the index over that WAL.
+	require.NoError(t, mediaDB.Close())
+	for _, suffix := range forensicSetSuffixes {
+		copyFileIfExists(t, held+suffix, path+suffix)
 	}
-	t.Cleanup(releaseHolder)
+	require.FileExists(t, path+"-wal", "the restored set must still carry the WAL")
 
 	mediaDB.MarkCorrupt("test")
 	require.NoError(t, mediaDB.Recreate(true))
 
-	preserved := make(map[string]string, 3)
-	for _, file := range []string{path, path + "-wal", path + "-shm"} {
-		backup := database.CorruptBackupPath(file)
-		require.FileExists(t, backup, "forensic set must include %s", filepath.Base(file))
-		preserved[file] = backup
+	preserved := make(map[string]string, len(forensicSetSuffixes))
+	for _, suffix := range forensicSetSuffixes {
+		backup := database.CorruptBackupPath(path + suffix)
+		require.FileExists(t, backup, "forensic set must include %s", filepath.Base(path+suffix))
+		preserved[path+suffix] = backup
 	}
-	// The renamed files are no longer in use by anything: release the holder
-	// before reading them back so the check below sees closed, quiescent files.
-	releaseHolder()
 
 	// One consistent set: put back under a single name it opens cleanly and
 	// holds the committed row, which was only ever in the WAL.
 	target := filepath.Join(t.TempDir(), "forensic.db")
-	copyFileIfExists(t, preserved[path], target)
-	copyFileIfExists(t, preserved[path+"-wal"], target+"-wal")
-	copyFileIfExists(t, preserved[path+"-shm"], target+"-shm")
+	for _, suffix := range forensicSetSuffixes {
+		copyFileIfExists(t, preserved[path+suffix], target+suffix)
+	}
 	forensic := openSnapshot(t, target)
 	requireIntegrityOK(t, forensic)
 	assert.Equal(t, 1, countRowsWhere(t, forensic, "Media", ""))

--- a/pkg/database/mediadb/wal_checkpoint_threshold_test.go
+++ b/pkg/database/mediadb/wal_checkpoint_threshold_test.go
@@ -51,17 +51,24 @@ func newWALTestDB(t *testing.T) walTestDB {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "test.db")
 
-	sqlDB, err := sql.Open(sqliteDriverName(), dbPath+getSqliteConnParams())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, sqlDB.Close())
-	})
-
 	mediaDB := &MediaDB{
 		ctx:    ctx,
 		dbPath: dbPath,
 		clock:  clockwork.NewRealClock(),
 	}
+	// Close through MediaDB rather than the *sql.DB: it rolls back an open
+	// transaction first, and a transaction still holds its connection out of
+	// the pool, so sql.DB.Close() alone reports success while the file stays
+	// open. On Windows the t.TempDir removal that runs next then fails, hiding
+	// whatever actually failed the test behind a cleanup error. Registered
+	// before the handle is stored because Close is a no-op until then, and
+	// cleanups run last-registered-first.
+	t.Cleanup(func() {
+		require.NoError(t, mediaDB.Close())
+	})
+
+	sqlDB, err := sql.Open(sqliteDriverName(), dbPath+getSqliteConnParams())
+	require.NoError(t, err)
 	mediaDB.sql.Store(sqlDB)
 	require.NoError(t, mediaDB.Allocate())
 

--- a/pkg/service/discovery/mdns/mdns_test.go
+++ b/pkg/service/discovery/mdns/mdns_test.go
@@ -20,6 +20,7 @@
 package mdns
 
 import (
+	"math"
 	"net"
 	"testing"
 
@@ -27,6 +28,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// phantomIfaceIndex is an interface index no host can have, so net.Interface
+// Addrs() finds nothing for it and the interface has no address to advertise.
+// Index 0 does not work: BSD, and so macOS, reads a zero index as "no filter"
+// and hands back every address on the machine, which made a phantom built with
+// it come back fully addressed there while returning nothing on Linux and
+// Windows.
+const phantomIfaceIndex = math.MaxInt32
 
 func testService() Service {
 	return Service{
@@ -381,9 +390,8 @@ func TestLinkForUsesIPv6Zone(t *testing.T) {
 func TestBuildLinksDropsInterfacesWithoutUsableAddresses(t *testing.T) {
 	t.Parallel()
 
-	// Index 0 never matches a real interface, so Addrs() returns nothing and
-	// the interface is dropped rather than advertised with no address.
-	links := buildLinks([]net.Interface{{Index: 0, Name: "phantom0"}})
+	// An interface with no address is dropped rather than advertised with none.
+	links := buildLinks([]net.Interface{{Index: phantomIfaceIndex, Name: "phantom0"}})
 	assert.Empty(t, links)
 }
 
@@ -626,8 +634,8 @@ func TestStartWithoutUsableInterfaces(t *testing.T) {
 	t.Cleanup(r.Stop)
 
 	require.ErrorIs(t, r.Start(nil), ErrNoInterfaces)
-	// Index 0 matches no real interface, so it contributes no address.
-	require.ErrorIs(t, r.Start([]net.Interface{{Index: 0, Name: "phantom0"}}), ErrNoInterfaces)
+	// An interface that contributes no address leaves nothing to advertise on.
+	require.ErrorIs(t, r.Start([]net.Interface{{Index: phantomIfaceIndex, Name: "phantom0"}}), ErrNoInterfaces)
 	assert.Empty(t, r.Interfaces())
 }
 


### PR DESCRIPTION
- `snapshotDatabase` no longer copies the `-shm` into a crash snapshot. A live writer keeps SQLite's WAL-index locks inside that file, so `os.ReadFile` over it fails on Windows, which is why the mid-transaction snapshot was the only crash-consistency test to fail there. The `-shm` is the WAL index and the next connection rebuilds it from the WAL, so recovery reaches the same state without it.
- The forensic-set test no longer pins its WAL and SHM in place with a second live connection across `Recreate`. That is the condition `Recreate`'s own comment warns about: on Windows the renames failed and the following `os.Remove` failed hard. It now copies the three files aside while the row is still WAL-only, closes the database, and puts them back.
- `newWALTestDB` closes through `MediaDB` rather than the `*sql.DB`. An open transaction holds its connection out of the pool, so `sql.DB.Close()` reported success while the file stayed open and the `t.TempDir` removal then failed, burying the real failure under a cleanup error.
- The mDNS tests build their address-less interface with an index no host can have instead of index 0. Go's BSD `interfaceAddrTable` skips its index filter when the index is zero, so on macOS `Addrs()` returns every address on the machine and the phantom arrives fully addressed.
- `build.yml` now calls `lint-and-test.yml` and requires it before `create-release` and `build`. A `v*` tag previously built, signed and published with no dependency on the test workflow; v2.17.1 shipped on a commit whose Windows job was failing. `test_build` skips the gate, so `build-check.yml` still only asks whether every target compiles.
- The gate run passes a new `release_gate` input that skips the SARIF and Codecov uploads. Both report against branches, and code scanning rejects an upload for a tag ref, which would fail the job and block the release. It replaces the `github.event_name != 'workflow_call'` guard, which never fires because inside a reusable workflow `event_name` is still the caller's event.

Closes #1396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release validation by requiring linting and tests to pass before releases and standard builds proceed.
  - Improved handling of release checks so coverage and security report uploads are skipped when not applicable.
  - Increased reliability of database recovery and consistency checks, including scenarios involving interrupted writes.
  - Improved network discovery testing on macOS and BSD systems by preventing invalid interfaces from being advertised.
- **Tests**
  - Strengthened platform-specific and database durability test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->