### PR TITLE
feat(windows): support keyboard input

### DIFF
--- a/cmd/windows/main.go
+++ b/cmd/windows/main.go
@@ -143,6 +143,17 @@ func restartAfterReleasing(instance *singleInstance, restartFn func() error) err
 	return restartFn()
 }
 
+// windowsDefaults turns on connection encryption for new installs and, because
+// Service.Encryption is a pointer, for existing configs that never wrote the
+// key. Remote clients cannot hold a role over a plaintext connection, so this
+// is what gates keyboard and gamepad input for anyone off the machine.
+func windowsDefaults() config.Values {
+	defaults := config.BaseDefaults
+	enabled := true
+	defaults.Service.Encryption = &enabled
+	return defaults
+}
+
 func main() {
 	if err := run(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
@@ -180,13 +191,16 @@ func run() error {
 
 	logWriters := []io.Writer{os.Stderr}
 
-	defaults := config.BaseDefaults
+	defaults := windowsDefaults()
 	iniPath := filepath.Join(helpers.ExeDir(), "tapto.ini")
 	if migrate.Required(iniPath, filepath.Join(helpers.ConfigDir(pl), config.CfgFile)) {
 		migrated, migrateErr := migrate.IniToToml(iniPath)
 		if migrateErr != nil {
 			return fmt.Errorf("error migrating config: %w", migrateErr)
 		}
+		// A tapto.ini predates encryption entirely, so migrating one must not
+		// silently hand back the old plaintext default.
+		migrated.Service.Encryption = defaults.Service.Encryption
 		defaults = migrated
 	}
 

--- a/cmd/windows/main_test.go
+++ b/cmd/windows/main_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	syswindows "golang.org/x/sys/windows"
@@ -134,4 +135,13 @@ func TestRestartAfterReleasing_DoesNotRestartWhenReleaseFails(t *testing.T) {
 	require.ErrorIs(t, err, releaseErr)
 	assert.False(t, restarted)
 	assert.NotZero(t, instance.handle)
+}
+
+func TestWindowsDefaults(t *testing.T) {
+	t.Parallel()
+
+	defaults := windowsDefaults()
+	require.NotNil(t, defaults.Service.Encryption)
+	assert.True(t, *defaults.Service.Encryption)
+	assert.Nil(t, config.BaseDefaults.Service.Encryption, "must not mutate shared platform defaults")
 }

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -5194,6 +5194,8 @@ The input macro format is identical to what goes after the `:` in a ZapScript `i
 
 Persistent `{press:key}` and `{release:key}` input is available only over supported WebSocket input sessions. A press remains held across requests from that WebSocket until its matching release. Each WebSocket owns its held keys and buttons; one connection cannot release another connection's input. Core releases all owned input when the WebSocket disconnects, input execution fails, or Core shuts down. HTTP JSON-RPC requests reject persistent press and release tokens because HTTP has no durable session lifecycle.
 
+On Windows, Core runs unelevated in the user's desktop session, so two limits apply that Core cannot detect or work around: keys sent to a window belonging to an elevated program are silently discarded by Windows, and nothing reaches the secure desktop, meaning UAC prompts, the lock screen and Ctrl+Alt+Del. Keys are injected as scancodes, so which character a key produces still depends on the active keyboard layout.
+
 ### input.keyboard
 
 **Access:** Requires `input`.

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -5194,6 +5194,8 @@ The input macro format is identical to what goes after the `:` in a ZapScript `i
 
 Persistent `{press:key}` and `{release:key}` input is available only over supported WebSocket input sessions. A press remains held across requests from that WebSocket until its matching release. Each WebSocket owns its held keys and buttons; one connection cannot release another connection's input. Core releases all owned input when the WebSocket disconnects, input execution fails, or Core shuts down. HTTP JSON-RPC requests reject persistent press and release tokens because HTTP has no durable session lifecycle.
 
+Keys sent by a client that is neither localhost nor an admin are checked against the `allow` and `block` lists in the `[zapscript.input]` config section, the same lists the ZapScript input commands use. On desktop platforms a default block list rejects keys such as `{alt+f4}`, `{ctrl+alt+delete}` and the Linux TTY switches. Wrapping a key in a `{press:...}`, `{release:...}` or `{hold:...}` macro does not evade the lists. Setting `block = []` clears the defaults. Unlike the ZapScript path, the API does not apply the `mode` setting, so plain characters can always be typed by a client that holds `input`.
+
 On Windows, Core runs unelevated in the user's desktop session, so two limits apply that Core cannot detect or work around: keys sent to a window belonging to an elevated program are silently discarded by Windows, and nothing reaches the secure desktop, meaning UAC prompts, the lock screen and Ctrl+Alt+Del. Keys are injected as scancodes, so which character a key produces still depends on the active keyboard layout.
 
 ### input.keyboard

--- a/pkg/api/methods/input.go
+++ b/pkg/api/methods/input.go
@@ -42,6 +42,23 @@ func hasPersistentInputTokens(args []string) bool {
 	return false
 }
 
+// checkInputTokens applies the configured allow and block lists to a request's
+// tokens. Admins and localhost are exempt: they can already change the config
+// that defines the lists, so enforcing them there would only be theatre. A
+// member holds CapInput so the app's remote keyboard works, and this is what
+// stops that reaching {alt+f4} or {ctrl+alt+delete}.
+func checkInputTokens(env *requests.RequestEnv, args []string) error {
+	if isLocalOrAdmin(env) {
+		return nil
+	}
+	for _, arg := range args {
+		if err := zapscript.CheckAPIInputKey(env.Config, env.PlatformID, arg); err != nil {
+			return models.ClientErrf("%w", err)
+		}
+	}
+	return nil
+}
+
 func parseInputMacro(cmdName, macro string) ([]string, error) {
 	script, err := zapscriptlib.NewParser("**" + cmdName + ":" + macro).ParseScript()
 	if err != nil {
@@ -65,6 +82,10 @@ func HandleInputKeyboard(env requests.RequestEnv) (any, error) {
 
 	args, err := parseInputMacro(zapscriptlib.ZapScriptCmdInputKeyboard, params.Keys)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := checkInputTokens(&env, args); err != nil {
 		return nil, err
 	}
 
@@ -98,6 +119,10 @@ func HandleInputGamepad(env requests.RequestEnv) (any, error) {
 
 	args, err := parseInputMacro(zapscriptlib.ZapScriptCmdInputGamepad, params.Buttons)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := checkInputTokens(&env, args); err != nil {
 		return nil, err
 	}
 

--- a/pkg/api/methods/input_test.go
+++ b/pkg/api/methods/input_test.go
@@ -27,9 +27,11 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -258,4 +260,102 @@ func TestHandleInputGamepad_PlatformError(t *testing.T) {
 	_, err := HandleInputGamepad(env)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "virtual gamepad is disabled")
+}
+
+// memberEnv builds a request env for a paired member on a remote connection,
+// which is the case the input lists are meant to constrain.
+func memberEnv(pl *mocks.MockPlatform, cfg *config.Instance, params json.RawMessage) requests.RequestEnv {
+	return requests.RequestEnv{
+		Platform:   pl,
+		PlatformID: platformids.Windows,
+		ClientRole: "member",
+		Config:     cfg,
+		Params:     params,
+	}
+}
+
+func TestHandleInputKeyboard_BlockListAppliesToMembers(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("KeyboardPress", mock.Anything).Return(nil)
+
+	// These all resolve to real keys, so a pass here cannot be an unknown-key
+	// error wearing a block list's clothes.
+	blocked := []string{
+		`{"keys":"{alt+f4}"}`,
+		`{"keys":"{ctrl+alt+delete}"}`,
+		`{"keys":"{ctrl+alt+t}"}`,
+		`{"keys":"{press:ctrl+alt+delete}"}`,
+	}
+	for _, params := range blocked {
+		_, err := HandleInputKeyboard(memberEnv(pl, nil, json.RawMessage(params)))
+		require.Error(t, err, "params %s should be blocked", params)
+		require.ErrorIs(t, err, zapscript.ErrInputBlocked, "params %s", params)
+	}
+	pl.AssertNotCalled(t, "KeyboardPress", "{alt+f4}")
+	pl.AssertNotCalled(t, "KeyboardPress", "{ctrl+alt+delete}")
+}
+
+// The app's remote keyboard sends plain characters, so the mode check must not
+// reach the API even though Windows defaults to combos mode.
+func TestHandleInputKeyboard_MembersMayStillType(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("KeyboardPress", mock.Anything).Return(nil)
+
+	_, err := HandleInputKeyboard(memberEnv(pl, nil, json.RawMessage(`{"keys":"hello"}`)))
+	require.NoError(t, err)
+	pl.AssertCalled(t, "KeyboardPress", "h")
+}
+
+func TestHandleInputKeyboard_BlockListExemptsAdminAndLocal(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("KeyboardPress", mock.Anything).Return(nil)
+	params := json.RawMessage(`{"keys":"{alt+f4}"}`)
+
+	_, err := HandleInputKeyboard(requests.RequestEnv{
+		Platform: pl, PlatformID: platformids.Windows, ClientRole: "admin", Params: params,
+	})
+	require.NoError(t, err)
+
+	_, err = HandleInputKeyboard(requests.RequestEnv{
+		Platform: pl, IsLocal: true, Params: params,
+	})
+	require.NoError(t, err)
+}
+
+func TestHandleInputKeyboard_ClearedBlockListLetsMembersThrough(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("KeyboardPress", mock.Anything).Return(nil)
+
+	values := config.BaseDefaults
+	values.ZapScript.Input.Block = []string{}
+	cfg, err := config.NewConfig(t.TempDir(), values)
+	require.NoError(t, err)
+
+	_, err = HandleInputKeyboard(memberEnv(pl, cfg, json.RawMessage(`{"keys":"{alt+f4}"}`)))
+	require.NoError(t, err)
+	pl.AssertCalled(t, "KeyboardPress", "{alt+f4}")
+}
+
+func TestHandleInputGamepad_BlockListDoesNotBlockButtons(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("GamepadPress", mock.Anything).Return(nil)
+
+	_, err := HandleInputGamepad(memberEnv(pl, nil, json.RawMessage(`{"buttons":"{start}"}`)))
+	require.NoError(t, err)
+	pl.AssertCalled(t, "GamepadPress", "{start}")
 }

--- a/pkg/helpers/windowsinput/keyboard_windows.go
+++ b/pkg/helpers/windowsinput/keyboard_windows.go
@@ -1,0 +1,137 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package windowsinput
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+//nolint:gochecknoglobals // lazily resolved system DLL procedures
+var (
+	moduser32 = windows.NewLazySystemDLL("user32.dll")
+
+	procSendInput = moduser32.NewProc("SendInput")
+)
+
+const (
+	inputKeyboard = 1
+
+	keyEventExtendedKey = 0x0001
+	keyEventKeyUp       = 0x0002
+	keyEventScancode    = 0x0008
+)
+
+// ErrUnknownKey is returned for a keycode with no Windows scancode.
+var ErrUnknownKey = errors.New("key is not supported on windows")
+
+// keybdInput mirrors the Win32 KEYBDINPUT structure.
+type keybdInput struct {
+	wVk         uint16
+	wScan       uint16
+	dwFlags     uint32
+	time        uint32
+	dwExtraInfo uintptr
+}
+
+// input mirrors the Win32 INPUT structure. The trailing padding makes the
+// struct match the size of INPUT's largest union member, MOUSEINPUT, on both
+// 32-bit and 64-bit builds; SendInput rejects a mismatched cbSize.
+type input struct {
+	typ uint32
+	ki  keybdInput
+	_   [8]byte
+}
+
+// Keyboard injects keystrokes into the session Core is running in.
+//
+// It has no device to open or close: SendInput posts to the calling session's
+// input queue, so a Keyboard is only meaningful in an interactive session.
+// Windows filters injected input in two cases neither this type nor its caller
+// can detect or defeat, both of which need an elevated process to fix: UIPI
+// drops input aimed at a window owned by a higher integrity level, and nothing
+// reaches the secure desktop (UAC prompts, the lock screen, Ctrl+Alt+Del).
+type Keyboard struct{}
+
+// NewKeyboard returns a virtual keyboard for the current session.
+func NewKeyboard() (*Keyboard, error) {
+	if err := procSendInput.Find(); err != nil {
+		return nil, fmt.Errorf("user32!SendInput unavailable: %w", err)
+	}
+	return &Keyboard{}, nil
+}
+
+// KeyDown presses a key, identified by its evdev keycode.
+func (*Keyboard) KeyDown(code int) error {
+	return sendKey(code, false)
+}
+
+// KeyUp releases a key, identified by its evdev keycode.
+func (*Keyboard) KeyUp(code int) error {
+	return sendKey(code, true)
+}
+
+// Close releases the keyboard. Nothing is held open, so this always succeeds.
+func (*Keyboard) Close() error {
+	return nil
+}
+
+func sendKey(code int, up bool) error {
+	scancode, extended, ok := Scancode(code)
+	if !ok {
+		return fmt.Errorf("%w: keycode %d", ErrUnknownKey, code)
+	}
+
+	// Scancodes address physical keys, so what a key produces still depends on
+	// the active keyboard layout. That matches how the uinput backend behaves
+	// on Linux, and it is what games reading raw input expect.
+	flags := uint32(keyEventScancode)
+	if extended {
+		flags |= keyEventExtendedKey
+	}
+	if up {
+		flags |= keyEventKeyUp
+	}
+
+	in := input{
+		typ: inputKeyboard,
+		ki: keybdInput{
+			wScan:   scancode,
+			dwFlags: flags,
+		},
+	}
+
+	sent, _, err := procSendInput.Call(
+		1,
+		uintptr(unsafe.Pointer(&in)), //nolint:gosec // required for Windows API
+		unsafe.Sizeof(in),
+	)
+	if sent != 1 {
+		// SendInput reports a short count when another process has the input
+		// desktop locked, or when input is blocked outright.
+		return fmt.Errorf("SendInput rejected keycode %d: %w", code, err)
+	}
+	return nil
+}

--- a/pkg/helpers/windowsinput/keyboard_windows_test.go
+++ b/pkg/helpers/windowsinput/keyboard_windows_test.go
@@ -1,0 +1,71 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package windowsinput
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInputStructSize pins the INPUT layout. SendInput takes the struct size as
+// an argument and silently does nothing when it disagrees, so a layout mistake
+// would look like input that is accepted and then vanishes.
+func TestInputStructSize(t *testing.T) {
+	t.Parallel()
+
+	want := uintptr(40) // 64-bit: 4 type + 4 padding + 32 union
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		want = 28 // 32-bit: 4 type + 24 union
+	}
+	assert.Equal(t, want, unsafe.Sizeof(input{}), "INPUT size must match the Win32 definition")
+
+	// The keyboard arm must sit at the union offset, not immediately after the
+	// type field.
+	kiOffset := unsafe.Offsetof(input{}.ki)
+	wantOffset := uintptr(8)
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		wantOffset = 4
+	}
+	assert.Equal(t, wantOffset, kiOffset, "KEYBDINPUT must start at the union offset")
+}
+
+func TestNewKeyboard(t *testing.T) {
+	t.Parallel()
+
+	kbd, err := NewKeyboard()
+	require.NoError(t, err)
+	require.NotNil(t, kbd)
+	assert.NoError(t, kbd.Close())
+}
+
+func TestKeyDownRejectsUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	kbd, err := NewKeyboard()
+	require.NoError(t, err)
+
+	require.ErrorIs(t, kbd.KeyDown(200), ErrUnknownKey)
+	require.ErrorIs(t, kbd.KeyUp(200), ErrUnknownKey)
+}

--- a/pkg/helpers/windowsinput/scancode.go
+++ b/pkg/helpers/windowsinput/scancode.go
@@ -1,0 +1,72 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package windowsinput drives virtual keyboard input on Windows. The input
+// engine works in raw evdev keycodes, so this package translates them to the
+// AT scancode set 1 values SendInput expects.
+package windowsinput
+
+// extendedScancodes holds the evdev keycodes whose scancodes need the 0xE0
+// extended prefix. These are the keys the original AT keyboard did not have,
+// so they were added on an escaped code rather than a free one.
+//
+//nolint:gochecknoglobals // immutable translation table
+var extendedScancodes = map[int]uint16{
+	96:  0x1C, // KEY_KPENTER
+	97:  0x1D, // KEY_RIGHTCTRL
+	98:  0x35, // KEY_KPSLASH
+	99:  0x37, // KEY_SYSRQ
+	100: 0x38, // KEY_RIGHTALT
+	102: 0x47, // KEY_HOME
+	103: 0x48, // KEY_UP
+	104: 0x49, // KEY_PAGEUP
+	105: 0x4B, // KEY_LEFT
+	106: 0x4D, // KEY_RIGHT
+	107: 0x4F, // KEY_END
+	108: 0x50, // KEY_DOWN
+	109: 0x51, // KEY_PAGEDOWN
+	110: 0x52, // KEY_INSERT
+	111: 0x53, // KEY_DELETE
+	114: 0x2E, // KEY_VOLUMEDOWN
+	115: 0x30, // KEY_VOLUMEUP
+	125: 0x5B, // KEY_LEFTMETA
+	126: 0x5C, // KEY_RIGHTMETA
+	127: 0x5D, // KEY_COMPOSE
+}
+
+// Scancode returns the AT set 1 scancode for an evdev keycode, whether it needs
+// the extended prefix, and whether the key is known at all.
+//
+// Linux assigned its keycodes 1-83 to match the scancodes the AT keyboard
+// already sent, so that range needs no translation; F11 and F12 kept the same
+// trick at 87 and 88. Everything else was added later and has to be looked up.
+func Scancode(code int) (scancode uint16, extended, ok bool) {
+	if sc, isExtended := extendedScancodes[code]; isExtended {
+		return sc, true, true
+	}
+	if code < 1 || code > 88 {
+		return 0, false, false
+	}
+	// 84 to 86 are the keys Linux added in the gap before F11, and they have
+	// no unprefixed AT scancode.
+	if code >= 84 && code <= 86 {
+		return 0, false, false
+	}
+	return uint16(code), false, true
+}

--- a/pkg/helpers/windowsinput/scancode_test.go
+++ b/pkg/helpers/windowsinput/scancode_test.go
@@ -1,0 +1,99 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package windowsinput
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/linuxinput/keyboardmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEveryMappedKeyHasScancode fails when a key is added to KeyboardMap
+// without a Windows scancode, which would otherwise only show up as an
+// unsupported key at runtime on Windows.
+func TestEveryMappedKeyHasScancode(t *testing.T) {
+	t.Parallel()
+
+	for name, code := range keyboardmap.KeyboardMap {
+		// Negative codes are shift-modified aliases; the engine presses shift
+		// itself and then the positive base code.
+		base := code
+		if base < 0 {
+			base = -base
+		}
+		_, _, ok := Scancode(base)
+		assert.True(t, ok, "key %q (keycode %d) has no windows scancode", name, base)
+	}
+}
+
+func TestScancode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		code     int
+		want     uint16
+		extended bool
+		ok       bool
+	}{
+		{name: "escape", code: 1, want: 0x01, ok: true},
+		{name: "a", code: 30, want: 0x1E, ok: true},
+		{name: "enter", code: 28, want: 0x1C, ok: true},
+		{name: "left shift", code: 42, want: 0x2A, ok: true},
+		{name: "right shift", code: 54, want: 0x36, ok: true},
+		{name: "left alt", code: 56, want: 0x38, ok: true},
+		{name: "f1", code: 59, want: 0x3B, ok: true},
+		{name: "f11 past the gap", code: 87, want: 0x57, ok: true},
+		{name: "f12 past the gap", code: 88, want: 0x58, ok: true},
+		{name: "up is extended", code: 103, want: 0x48, extended: true, ok: true},
+		{name: "delete is extended", code: 111, want: 0x53, extended: true, ok: true},
+		{name: "right ctrl is extended", code: 97, want: 0x1D, extended: true, ok: true},
+		{name: "left meta is extended", code: 125, want: 0x5B, extended: true, ok: true},
+		{name: "unmapped", code: 200, ok: false},
+		{name: "zero", code: 0, ok: false},
+		{name: "negative", code: -30, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sc, extended, ok := Scancode(tt.code)
+			require.Equal(t, tt.ok, ok)
+			if !tt.ok {
+				return
+			}
+			assert.Equal(t, tt.want, sc)
+			assert.Equal(t, tt.extended, extended)
+		})
+	}
+}
+
+// TestExtendedAndIdentityDoNotOverlap guards the assumption that the identity
+// range and the extended table describe disjoint sets of keycodes.
+func TestExtendedAndIdentityDoNotOverlap(t *testing.T) {
+	t.Parallel()
+
+	for code := range extendedScancodes {
+		inIdentityRange := (code >= 1 && code <= 83) || code == 87 || code == 88
+		assert.False(t, inIdentityRange, "keycode %d is in both the identity range and the extended table", code)
+	}
+}

--- a/pkg/platforms/shared/inputbackend_windows.go
+++ b/pkg/platforms/shared/inputbackend_windows.go
@@ -17,14 +17,26 @@
 // You should have received a copy of the GNU General Public License
 // along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !linux && !windows
+//go:build windows
 
 package shared
 
+import (
+	"fmt"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/windowsinput"
+)
+
 func newPlatformKeyboard() (KeyboardDevice, error) {
-	return nil, ErrInputUnsupported
+	kbd, err := windowsinput.NewKeyboard()
+	if err != nil {
+		return nil, fmt.Errorf("create windows keyboard: %w", err)
+	}
+	return kbd, nil
 }
 
+// Virtual gamepad support on Windows needs the ViGEmBus driver and is not
+// implemented yet.
 func newPlatformGamepad() (GamepadDevice, error) {
 	return nil, ErrInputUnsupported
 }

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -71,6 +71,7 @@ type processWindowFocuser interface {
 }
 
 type Platform struct {
+	shared.InputManager
 	activeMedia             func() *models.ActiveMedia
 	setActiveMedia          func(*models.ActiveMedia)
 	customPlatformToSystem  map[string]string
@@ -144,7 +145,13 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 	return enabled
 }
 
-func (*Platform) StartPre(_ *config.Instance) error {
+func (p *Platform) StartPre(cfg *config.Instance) error {
+	// Virtual gamepad emulation needs the ViGEmBus driver, which Core does not
+	// require, so it stays off unless the user asks for it.
+	if err := p.InitDevices(cfg, false); err != nil {
+		return fmt.Errorf("failed to initialize input devices: %w", err)
+	}
+
 	return nil
 }
 
@@ -186,6 +193,8 @@ func (p *Platform) StartPost(
 }
 
 func (p *Platform) Stop() error {
+	p.CloseDevices()
+
 	if p.launcherManager != nil {
 		p.launcherManager.NewContext()
 	}
@@ -591,14 +600,6 @@ func (p *Platform) LaunchMedia(
 
 	p.setLastLauncher(launcher)
 
-	return nil
-}
-
-func (*Platform) KeyboardPress(_ string) error {
-	return nil
-}
-
-func (*Platform) GamepadPress(_ string) error {
 	return nil
 }
 

--- a/pkg/zapscript/input.go
+++ b/pkg/zapscript/input.go
@@ -104,13 +104,43 @@ func checkInputKey(cfg *config.Instance, platformID, key string) error {
 		return nil
 	}
 
+	settled, err := checkInputKeyLists(cfg, platformID, key)
+	if err != nil {
+		return err
+	}
+	if settled {
+		return nil
+	}
+
+	return checkInputKeyMode(cfg, platformID, key)
+}
+
+// CheckAPIInputKey applies the allow and block lists to a key arriving over the
+// API. It deliberately skips the mode check that checkInputKey ends with:
+// desktop platforms default to combos mode, which rejects plain characters, and
+// the API carries the app's on-screen keyboard where typing text is the point.
+//
+// Both lists are the same [zapscript.input] allow and block config the
+// ZapScript path uses, so clearing one clears it everywhere.
+func CheckAPIInputKey(cfg *config.Instance, platformID, key string) error {
+	key, named := inputmacro.KeyForToken(key)
+	if !named {
+		return nil
+	}
+	_, err := checkInputKeyLists(cfg, platformID, key)
+	return err
+}
+
+// checkInputKeyLists applies the allow list then the block list. A matched
+// allow list entry settles the question and no further check should run.
+func checkInputKeyLists(cfg *config.Instance, platformID, key string) (settled bool, err error) {
 	// 1. Strict allow mode — overrides everything
 	allowList := cfg.InputAllowList()
 	if len(allowList) > 0 {
 		if !isKeyInList(key, allowList) {
-			return fmt.Errorf("%w: %s", ErrInputNotAllowed, key)
+			return false, fmt.Errorf("%w: %s", ErrInputNotAllowed, key)
 		}
-		return nil
+		return true, nil
 	}
 
 	// 2. Block list check — nil means not configured (use defaults),
@@ -120,9 +150,13 @@ func checkInputKey(cfg *config.Instance, platformID, key string) error {
 		blockList = defaultDesktopBlockList
 	}
 	if isKeyInList(key, blockList) {
-		return fmt.Errorf("%w: %s", ErrInputBlocked, key)
+		return false, fmt.Errorf("%w: %s", ErrInputBlocked, key)
 	}
 
+	return false, nil
+}
+
+func checkInputKeyMode(cfg *config.Instance, platformID, key string) error {
 	// 3. Mode check
 	mode := cfg.InputMode(defaultInputMode(platformID))
 	switch mode {


### PR DESCRIPTION
Closes #152. The platform-neutral input engine this builds on landed in #1410.

`pkg/platforms/windows` implemented `KeyboardPress` as a no-op returning `nil`, so `input.keyboard` and the ZapScript keyboard commands reported success on Windows and did nothing.

## No helper process is needed

The concern on #151 was that input would force Core to run as administrator. It does not. `cmd/windows/main.go` refuses to start elevated, the manifest is `asInvoker`, and the installer is `PrivilegesRequired=lowest` with HKCU `Run` autostart — so Core already runs unelevated in the user's own desktop session, which is exactly where `SendInput` works. Confirmed on hardware: Core runs with `SessionId 1`.

## Translation

The engine works in evdev keycodes. Linux assigned keycodes 1-83 to match the scancodes an AT keyboard already sent, and kept the trick for F11 and F12 at 87 and 88, so most of the translation is the identity; keys added later need a lookup and the `0xE0` extended prefix. A test walks `KeyboardMap` and fails if a key is ever added without a Windows scancode.

`INPUT` is passed to `SendInput` with its own size, and `SendInput` silently does nothing when that size is wrong, so the struct layout is pinned by a test on both 32-bit and 64-bit rather than left to surface as input that is accepted and then vanishes.

## Encryption on by default

Windows took `config.BaseDefaults` unchanged, so encryption was off and a remote client could reach the API in the clear. Linux desktop and SteamOS already default it on; Windows now matches, which matters more here because keyboard input has just become real on this platform.

No new gating code is needed. Windows is absent from `permissions.legacyCapabilities`, so an unpaired remote client already fails closed, and a client's role is only ever populated from an encrypted session — no encryption means no role, and no role means no `input` capability.

`Service.Encryption` is a pointer, so existing configs that never wrote the key inherit the new default on upgrade, while an explicit `encryption = false` is preserved. The `tapto.ini` migration replaced the defaults wholesale, which would have handed the old plaintext default back to exactly the oldest installs; it now keeps the platform value the way `cmd/steamos` does.

**This changes behaviour for existing Windows installs** with unencrypted remote clients, and wants a release note.

## Allow and block lists now cover the API

`checkInputKey` guarded the ZapScript commands but was never called from the API handlers, so the two paths disagreed about the same keys: a scanned token could not send `{alt+f4}` on a desktop platform, while a paired member could send it over the API.

Members keep `input` — the app's remote keyboard depends on it. Instead, tokens from clients that are neither localhost nor admin run through the same `[zapscript.input]` allow and block lists, so the default desktop block list covers both paths and `block = []` clears both. Admins and localhost stay exempt, since they can edit the config that defines the lists.

The `mode` check is deliberately left to the ZapScript path: desktop platforms default to combos mode, which rejects plain characters, and typing text is the entire point of the API's keyboard surface.

## Documented limits

Two Windows behaviours are documented rather than worked around, because working around either needs an elevated process:

- UIPI discards input aimed at a window owned by a higher integrity level.
- Nothing reaches the secure desktop (UAC prompts, lock screen, Ctrl+Alt+Del).

Injecting scancodes also means the character a key produces still depends on the active keyboard layout, which is how the uinput backend already behaves.

Virtual gamepad support needs the ViGEmBus driver and is not implemented here; the gamepad backend reports that it is unsupported rather than pretending. #151 stays open.

## Validation

`task lint-fix` and `task cross-lint:windows` both 0 issues; `task test` (`-race`, full tree plus mister module) green; `windowsinput`, `cmd/windows` and `shared` test binaries cross-built with zigcc and run on Windows 11: PASS.

End-to-end on a Windows 11 machine, driving a deployed build through the API:

| Case | Result |
| :-- | :-- |
| `Zaparoo types on Windows 123` | 28 characters, capital via shift batching |
| `{enter}second line{home}!@#` | newline, extended `{home}`, shifted symbols |
| `{ctrl+a}{del}` | combo and extended delete, document cleared |
| `input.gamepad` | errors with "virtual gamepad is disabled" |
| unknown key | errors instead of reporting success |
| elevated foreground window | input filtered by Windows, as documented |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Windows now supports keyboard input injection.
  - Windows uses encrypted service connections by default, including migrated configurations.
  - API keyboard and gamepad requests now honor configured allow/block lists for non-local, non-admin clients.
- **Bug Fixes**
  - Blocked key combinations can no longer bypass restrictions through input macros.
- **Documentation**
  - Added API guidance covering input filtering, Windows limitations, keyboard layouts, and secure desktop behavior.
- **Limitations**
  - Windows gamepad input remains unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->