### PR TITLE
feat(windows): support virtual gamepad input

### DIFF
--- a/cmd/windows/setup.iss.tmpl
+++ b/cmd/windows/setup.iss.tmpl
@@ -64,7 +64,12 @@ Source: "README.txt"; DestDir: "{app}"; Flags: ignoreversion
 ; The ViGEmBus bootstrapper exits successfully and does nothing at all when
 ; its extraction target does not already exist, so the directory is created
 ; here rather than left to the /extract switch.
-Name: "{tmp}\vigembus"; Tasks: vigembus; Flags: deleteafterinstall
+;
+; It is machine-wide rather than under {tmp} because the install step may run
+; as a different administrator, whose own temp directory this is not. Nothing
+; here is trusted: the elevated step checks the package before installing it.
+Name: "{commonappdata}\Zaparoo\vigembus-stage"; Tasks: vigembus; Flags: deleteafterinstall
+Name: "{commonappdata}\Zaparoo"; Tasks: vigembus; Flags: deleteafterinstall
 
 {{end}}[Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
@@ -88,23 +93,36 @@ Filename: "{cmd}"; Parameters: "/c netsh advfirewall firewall delete rule name="
   Tasks: firewall; Check: not IsAdminInstallMode; AfterInstall: MarkFirewallRuleAdded
 {{if .ViGEmMsi}}; The vendor bootstrapper never returns when asked to install silently, but
 ; it does unpack reliably, so the driver goes in through its own MSI instead.
-; Unpacking needs no elevation; only the MSI does.
-Filename: "{tmp}\ViGEmBusSetup.exe"; Parameters: "/extract:""{tmp}\vigembus"""; \
+; Unpacking needs no elevation and is not trusted; installing needs both.
+Filename: "{tmp}\ViGEmBusSetup.exe"; Parameters: "/extract:""{commonappdata}\Zaparoo\vigembus-stage"""; \
   StatusMsg: "Unpacking the ViGEmBus driver..."; Flags: runhidden waituntilterminated; \
   Tasks: vigembus
+; The install runs from a script passed on the command line, not from a file,
+; because a file it read could be replaced by anything running as the user and
+; would then be run with administrator rights. The script checks the package
+; is signed by its publisher, from a copy only administrators can write.
+;
 ; The gate is elevation, not install scope: PrivilegesRequired=lowest keeps
 ; Zaparoo a per-user install even when Setup was started elevated, so
 ; IsAdminInstallMode is False there and would skip a driver this process is
 ; perfectly able to install.
-Filename: "msiexec.exe"; Parameters: "/i ""{code:ViGEmMsiPath}"" /qn /norestart"; \
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
+  Parameters: "-NoProfile -NonInteractive -EncodedCommand {{.ViGEmInstallScript}}"; \
   StatusMsg: "Installing the ViGEmBus driver..."; Flags: runhidden waituntilterminated; \
-  Tasks: vigembus; Check: IsAdminLoggedOn and ViGEmMsiFound
+  Tasks: vigembus; Check: IsAdminLoggedOn and ViGEmMsiStaged
 ; Otherwise the driver needs an elevation prompt. Ask once, and carry on with
 ; the install if it is declined. A silent install must never raise that prompt,
 ; so an unelevated silent install cannot install the driver.
-Filename: "msiexec.exe"; Parameters: "/i ""{code:ViGEmMsiPath}"" /qn /norestart"; \
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
+  Parameters: "-NoProfile -NonInteractive -EncodedCommand {{.ViGEmInstallScript}}"; \
   StatusMsg: "Installing the ViGEmBus driver..."; Flags: shellexec waituntilterminated runhidden skipifsilent; Verb: runas; \
-  Tasks: vigembus; Check: (not IsAdminLoggedOn) and ViGEmMsiFound
+  Tasks: vigembus; Check: (not IsAdminLoggedOn) and ViGEmMsiStaged
+; [Dirs] deleteafterinstall will not remove a directory that still has files
+; in it, and the unpacked driver is several megabytes, so the staging tree is
+; cleared explicitly. This runs whether or not the install itself went ahead,
+; so a declined elevation prompt does not leave it behind either.
+Filename: "{cmd}"; Parameters: "/c rmdir /s /q ""{commonappdata}\Zaparoo\vigembus-stage"""; \
+  Flags: runhidden waituntilterminated; Tasks: vigembus
 {{end}}Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 Filename: "{app}\README.txt"; Description: "View README"; Flags: shellexec postinstall skipifsilent unchecked
 
@@ -136,31 +154,27 @@ begin
   Result := RegValueExists(HKEY_AUTO, 'Software\Zaparoo\Core', 'FirewallRule');
 end;
 {{if .ViGEmMsi}}
-var
-  VigemMsiCached: String;
-  VigemMsiSearched: Boolean;
-
-// FindViGEmMsi locates the unpacked driver package. The bootstrapper unpacks
-// into a folder named after its own product code, so the MSI sits one level
-// below a name this script cannot predict and has to be searched for.
-function FindViGEmMsi: String;
+// ViGEmMsiStaged reports whether the driver package was actually unpacked, so
+// that a failed unpack does not raise an elevation prompt that could not
+// achieve anything. It says nothing about whether the package can be trusted;
+// the elevated script decides that, where the answer cannot be tampered with.
+function ViGEmMsiStaged: Boolean;
 var
   Root, Candidate: String;
   Rec: TFindRec;
 begin
-  if VigemMsiSearched then
+  Result := False;
+  Root := ExpandConstant('{commonappdata}\Zaparoo\vigembus-stage');
+
+  // The bootstrapper unpacks into a folder named after its own product code,
+  // so the package sits one level below a name this script cannot predict.
+  if FileExists(Root + '\{{.ViGEmMsi}}') then
   begin
-    Result := VigemMsiCached;
+    Result := True;
     Exit;
   end;
-  VigemMsiSearched := True;
-  VigemMsiCached := '';
 
-  Root := ExpandConstant('{tmp}\vigembus');
-  Candidate := Root + '\{{.ViGEmMsi}}';
-  if FileExists(Candidate) then
-    VigemMsiCached := Candidate
-  else if FindFirst(Root + '\*', Rec) then
+  if FindFirst(Root + '\*', Rec) then
   begin
     try
       repeat
@@ -170,7 +184,7 @@ begin
           Candidate := Root + '\' + Rec.Name + '\{{.ViGEmMsi}}';
           if FileExists(Candidate) then
           begin
-            VigemMsiCached := Candidate;
+            Result := True;
             Break;
           end;
         end;
@@ -179,19 +193,5 @@ begin
       FindClose(Rec);
     end;
   end;
-
-  Result := VigemMsiCached;
-end;
-
-// ViGEmMsiFound keeps the installer from calling msiexec with an empty path,
-// and so from raising an elevation prompt that could not achieve anything.
-function ViGEmMsiFound: Boolean;
-begin
-  Result := FindViGEmMsi <> '';
-end;
-
-function ViGEmMsiPath(Param: String): String;
-begin
-  Result := FindViGEmMsi;
 end;
 {{end}}

--- a/cmd/windows/setup.iss.tmpl
+++ b/cmd/windows/setup.iss.tmpl
@@ -36,7 +36,11 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "runonstartup"; Description: "Run Zaparoo Core on startup"; GroupDescription: "Startup options:"
 Name: "firewall"; Description: "Allow Zaparoo Core through Windows Firewall"; GroupDescription: "Network:"
-
+{{if .ViGEmMsi}}; ViGEmBus is a third-party kernel-mode driver by Nefarius Software
+; Solutions. Zaparoo only needs it to emulate a gamepad, so it is offered
+; rather than installed, and the caption says plainly what gets installed.
+Name: "vigembus"; Description: "Install the ViGEmBus virtual gamepad driver (a kernel-mode driver by Nefarius Software Solutions)"; GroupDescription: "Optional drivers:"; Flags: unchecked
+{{end}}
 [Registry]
 Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
   ValueType: string; ValueName: "ZaparooCore"; ValueData: """{app}\Zaparoo.exe"""; \
@@ -54,8 +58,15 @@ Root: HKA; Subkey: "Software\Zaparoo"; Flags: dontcreatekey uninsdeletekeyifempt
 Source: "{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 Source: "LICENSE.txt"; DestDir: "{app}"; Flags: ignoreversion
 Source: "README.txt"; DestDir: "{app}"; Flags: ignoreversion
+{{if .ViGEmMsi}}Source: "ViGEmBusSetup.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Tasks: vigembus
+{{end}}
+{{if .ViGEmMsi}}[Dirs]
+; The ViGEmBus bootstrapper exits successfully and does nothing at all when
+; its extraction target does not already exist, so the directory is created
+; here rather than left to the /extract switch.
+Name: "{tmp}\vigembus"; Tasks: vigembus; Flags: deleteafterinstall
 
-[Icons]
+{{end}}[Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
@@ -75,7 +86,26 @@ Filename: "{cmd}"; Parameters: "/c netsh advfirewall firewall delete rule name="
 Filename: "{cmd}"; Parameters: "/c netsh advfirewall firewall delete rule name=""{#MyAppName}"" >nul 2>&1 & netsh advfirewall firewall add rule name=""{#MyAppName}"" dir=in action=allow program=""{app}\{#MyAppExeName}"" enable=yes profile=any"; \
   StatusMsg: "Adding Windows Firewall rule..."; Flags: shellexec waituntilterminated runhidden skipifsilent; Verb: runas; \
   Tasks: firewall; Check: not IsAdminInstallMode; AfterInstall: MarkFirewallRuleAdded
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+{{if .ViGEmMsi}}; The vendor bootstrapper never returns when asked to install silently, but
+; it does unpack reliably, so the driver goes in through its own MSI instead.
+; Unpacking needs no elevation; only the MSI does.
+Filename: "{tmp}\ViGEmBusSetup.exe"; Parameters: "/extract:""{tmp}\vigembus"""; \
+  StatusMsg: "Unpacking the ViGEmBus driver..."; Flags: runhidden waituntilterminated; \
+  Tasks: vigembus
+; The gate is elevation, not install scope: PrivilegesRequired=lowest keeps
+; Zaparoo a per-user install even when Setup was started elevated, so
+; IsAdminInstallMode is False there and would skip a driver this process is
+; perfectly able to install.
+Filename: "msiexec.exe"; Parameters: "/i ""{code:ViGEmMsiPath}"" /qn /norestart"; \
+  StatusMsg: "Installing the ViGEmBus driver..."; Flags: runhidden waituntilterminated; \
+  Tasks: vigembus; Check: IsAdminLoggedOn and ViGEmMsiFound
+; Otherwise the driver needs an elevation prompt. Ask once, and carry on with
+; the install if it is declined. A silent install must never raise that prompt,
+; so an unelevated silent install cannot install the driver.
+Filename: "msiexec.exe"; Parameters: "/i ""{code:ViGEmMsiPath}"" /qn /norestart"; \
+  StatusMsg: "Installing the ViGEmBus driver..."; Flags: shellexec waituntilterminated runhidden skipifsilent; Verb: runas; \
+  Tasks: vigembus; Check: (not IsAdminLoggedOn) and ViGEmMsiFound
+{{end}}Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 Filename: "{app}\README.txt"; Description: "View README"; Flags: shellexec postinstall skipifsilent unchecked
 
 [UninstallRun]
@@ -105,3 +135,63 @@ function FirewallRuleWasAdded: Boolean;
 begin
   Result := RegValueExists(HKEY_AUTO, 'Software\Zaparoo\Core', 'FirewallRule');
 end;
+{{if .ViGEmMsi}}
+var
+  VigemMsiCached: String;
+  VigemMsiSearched: Boolean;
+
+// FindViGEmMsi locates the unpacked driver package. The bootstrapper unpacks
+// into a folder named after its own product code, so the MSI sits one level
+// below a name this script cannot predict and has to be searched for.
+function FindViGEmMsi: String;
+var
+  Root, Candidate: String;
+  Rec: TFindRec;
+begin
+  if VigemMsiSearched then
+  begin
+    Result := VigemMsiCached;
+    Exit;
+  end;
+  VigemMsiSearched := True;
+  VigemMsiCached := '';
+
+  Root := ExpandConstant('{tmp}\vigembus');
+  Candidate := Root + '\{{.ViGEmMsi}}';
+  if FileExists(Candidate) then
+    VigemMsiCached := Candidate
+  else if FindFirst(Root + '\*', Rec) then
+  begin
+    try
+      repeat
+        if ((Rec.Attributes and FILE_ATTRIBUTE_DIRECTORY) <> 0) and
+           (Rec.Name <> '.') and (Rec.Name <> '..') then
+        begin
+          Candidate := Root + '\' + Rec.Name + '\{{.ViGEmMsi}}';
+          if FileExists(Candidate) then
+          begin
+            VigemMsiCached := Candidate;
+            Break;
+          end;
+        end;
+      until not FindNext(Rec);
+    finally
+      FindClose(Rec);
+    end;
+  end;
+
+  Result := VigemMsiCached;
+end;
+
+// ViGEmMsiFound keeps the installer from calling msiexec with an empty path,
+// and so from raising an elevation prompt that could not achieve anything.
+function ViGEmMsiFound: Boolean;
+begin
+  Result := FindViGEmMsi <> '';
+end;
+
+function ViGEmMsiPath(Param: String): String;
+begin
+  Result := FindViGEmMsi;
+end;
+{{end}}

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -5198,6 +5198,8 @@ Keys sent by a client that is neither localhost nor an admin are checked against
 
 On Windows, Core runs unelevated in the user's desktop session, so two limits apply that Core cannot detect or work around: keys sent to a window belonging to an elevated program are silently discarded by Windows, and nothing reaches the secure desktop, meaning UAC prompts, the lock screen and Ctrl+Alt+Del. Keys are injected as scancodes, so which character a key produces still depends on the active keyboard layout.
 
+The virtual gamepad needs a driver on Windows. `input.gamepad` emulates an Xbox 360 controller through ViGEmBus, a kernel-mode driver the Zaparoo installer offers as an optional task; Core never installs it on its own, and installing it is the only step that needs administrator rights. Gamepad support is also off by default on Windows, because an unexpected virtual pad changes controller numbering in games: set `gamepad_enabled = true` under `[input]` to turn it on. With the setting on and the driver absent, `input.gamepad` reports that the driver is missing instead of reporting success. Uninstalling Zaparoo leaves the driver in place, because other software may be using it; remove it separately through Apps & Features, where it is listed as "ViGEm Bus Driver".
+
 ### input.keyboard
 
 **Access:** Requires `input`.

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -5200,6 +5200,8 @@ On Windows, Core runs unelevated in the user's desktop session, so two limits ap
 
 The virtual gamepad needs a driver on Windows. `input.gamepad` emulates an Xbox 360 controller through ViGEmBus, a kernel-mode driver the Zaparoo installer offers as an optional task; Core never installs it on its own, and installing it is the only step that needs administrator rights. Gamepad support is also off by default on Windows, because an unexpected virtual pad changes controller numbering in games: set `gamepad_enabled = true` under `[input]` to turn it on. With the setting on and the driver absent, `input.gamepad` reports that the driver is missing instead of reporting success. Uninstalling Zaparoo leaves the driver in place, because other software may be using it; remove it separately through Apps & Features, where it is listed as "ViGEm Bus Driver".
 
+The driver is published for x86 and x64 only, so the ARM64 build of Zaparoo does not offer the task and has no virtual gamepad: `gamepad_enabled` there reports the driver as missing whatever the setting says. Keyboard input is unaffected on every architecture.
+
 ### input.keyboard
 
 **Access:** Requires `input`.

--- a/pkg/helpers/windowsinput/vigem.go
+++ b/pkg/helpers/windowsinput/vigem.go
@@ -1,0 +1,83 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package windowsinput
+
+import "errors"
+
+// The ViGEmBus protocol: the IOCTL codes and request structures the driver
+// accepts. The driver validates each request's Size field, so the layouts here
+// have to match the ones in the driver's BusShared.h exactly; a mismatch is
+// rejected with an error that says nothing about the real cause, which is why
+// they are pinned by tests.
+const (
+	fileDeviceBusExtender = 0x2a
+	methodBuffered        = 0
+	fileWriteData         = 2
+
+	vigemBase = 0x801
+)
+
+//nolint:gochecknoglobals // derived from ctlCode, which is not a constant expression
+var (
+	ioctlPluginTarget     = ctlCode(fileDeviceBusExtender, vigemBase+0x000, methodBuffered, fileWriteData)
+	ioctlUnplugTarget     = ctlCode(fileDeviceBusExtender, vigemBase+0x001, methodBuffered, fileWriteData)
+	ioctlCheckVersion     = ctlCode(fileDeviceBusExtender, vigemBase+0x002, methodBuffered, fileWriteData)
+	ioctlWaitDeviceReady  = ctlCode(fileDeviceBusExtender, vigemBase+0x003, methodBuffered, fileWriteData)
+	ioctlXusbSubmitReport = ctlCode(fileDeviceBusExtender, vigemBase+0x201, methodBuffered, fileWriteData)
+)
+
+// ErrDriverMissing reports that the ViGEmBus driver is not installed. That is
+// the expected state on a machine that has never asked for gamepad support, so
+// it has to reach the user as a clear message rather than a silent success.
+var ErrDriverMissing = errors.New("the ViGEmBus driver is not installed")
+
+// ctlCode builds a Windows IOCTL code, mirroring the CTL_CODE macro.
+func ctlCode(devType, function, method, access uint32) uint32 {
+	return devType<<16 | access<<14 | function<<2 | method
+}
+
+type vigemCheckVersion struct {
+	Size    uint32
+	Version uint32
+}
+
+type vigemPluginTarget struct {
+	Size       uint32
+	SerialNo   uint32
+	TargetType uint32
+	VendorID   uint16
+	ProductID  uint16
+}
+
+type vigemWaitDeviceReady struct {
+	Size     uint32
+	SerialNo uint32
+}
+
+type vigemUnplugTarget struct {
+	Size     uint32
+	SerialNo uint32
+}
+
+type xusbSubmitReport struct {
+	Size     uint32
+	SerialNo uint32
+	Report   xusbReport
+}

--- a/pkg/helpers/windowsinput/vigem_integration_windows_test.go
+++ b/pkg/helpers/windowsinput/vigem_integration_windows_test.go
@@ -1,0 +1,173 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package windowsinput
+
+import (
+	"errors"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/linuxinput/gamepadmap"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// XInput is how a game sees an Xbox 360 pad, so reading the virtual pad back
+// through it proves the whole path: the bus accepted the device, Windows
+// enumerated it, and the reports arrive as button state. Without it a test can
+// only show that the IOCTLs returned success.
+//
+//nolint:gochecknoglobals // lazily resolved system DLL procedures
+var (
+	modxinput          = windows.NewLazySystemDLL("xinput1_4.dll")
+	modxinputFallback  = windows.NewLazySystemDLL("xinput9_1_0.dll")
+	procXInputGetState = modxinput.NewProc("XInputGetState")
+)
+
+const (
+	xinputMaxUsers          = 4
+	errorDeviceNotConnected = 1167
+)
+
+// xinputState mirrors XINPUT_STATE. Its gamepad half has the same layout as
+// the report we submit, which is the point: what goes in comes back out.
+type xinputState struct {
+	packetNumber uint32
+	gamepad      xusbReport
+}
+
+func xinputGetState(t *testing.T, index uint32) (xinputState, bool) {
+	t.Helper()
+
+	var state xinputState
+	ret, _, _ := procXInputGetState.Call(
+		uintptr(index),
+		uintptr(unsafe.Pointer(&state)), //nolint:gosec // required for Windows API
+	)
+	switch ret {
+	case 0:
+		return state, true
+	case errorDeviceNotConnected:
+		return state, false
+	default:
+		t.Fatalf("XInputGetState(%d) failed: %d", index, ret)
+		return state, false
+	}
+}
+
+// connectedPads reports which XInput slots are currently filled.
+func connectedPads(t *testing.T) map[uint32]bool {
+	t.Helper()
+
+	pads := make(map[uint32]bool, xinputMaxUsers)
+	for i := range uint32(xinputMaxUsers) {
+		if _, ok := xinputGetState(t, i); ok {
+			pads[i] = true
+		}
+	}
+	return pads
+}
+
+// waitFor polls until cond holds, because a virtual device takes a moment to
+// enumerate and a report only lands on the next poll of the pad.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// This test needs the ViGEmBus driver, so it skips on a machine without it,
+// which includes CI.
+func TestGamepadIsVisibleToXInput(t *testing.T) {
+	if err := procXInputGetState.Find(); err != nil {
+		procXInputGetState = modxinputFallback.NewProc("XInputGetState")
+		if err := procXInputGetState.Find(); err != nil {
+			t.Skip("XInput is unavailable:", err)
+		}
+	}
+
+	before := connectedPads(t)
+
+	pad, err := NewGamepad()
+	if errors.Is(err, ErrDriverMissing) {
+		t.Skip("the ViGEmBus driver is not installed")
+	}
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, pad.Close())
+	})
+
+	// The new slot is whichever one was not filled a moment ago.
+	var index uint32
+	found := waitFor(t, 5*time.Second, func() bool {
+		for i := range uint32(xinputMaxUsers) {
+			if before[i] {
+				continue
+			}
+			if _, ok := xinputGetState(t, i); ok {
+				index = i
+				return true
+			}
+		}
+		return false
+	})
+	require.True(t, found, "the virtual pad never appeared to XInput")
+
+	require.NoError(t, pad.ButtonDown(gamepadmap.ButtonSouth))
+	require.True(t, waitFor(t, 2*time.Second, func() bool {
+		state, ok := xinputGetState(t, index)
+		return ok && state.gamepad.buttons&xusbA != 0
+	}), "A never registered as pressed")
+
+	require.NoError(t, pad.ButtonUp(gamepadmap.ButtonSouth))
+	require.True(t, waitFor(t, 2*time.Second, func() bool {
+		state, ok := xinputGetState(t, index)
+		return ok && state.gamepad.buttons&xusbA == 0
+	}), "A never registered as released")
+
+	// A trigger is analogue, so it proves the report's byte fields as well as
+	// its button bits.
+	require.NoError(t, pad.ButtonDown(gamepadmap.ButtonTriggerLeft))
+	require.True(t, waitFor(t, 2*time.Second, func() bool {
+		state, ok := xinputGetState(t, index)
+		return ok && state.gamepad.leftTrigger == triggerFull
+	}), "the left trigger never reached its limit")
+	require.NoError(t, pad.ButtonUp(gamepadmap.ButtonTriggerLeft))
+
+	// Two buttons at once must not clear each other.
+	require.NoError(t, pad.ButtonDown(gamepadmap.ButtonStart))
+	require.NoError(t, pad.ButtonDown(gamepadmap.ButtonDpadUp))
+	require.True(t, waitFor(t, 2*time.Second, func() bool {
+		state, ok := xinputGetState(t, index)
+		return ok && state.gamepad.buttons&(xusbStart|xusbDpadUp) == xusbStart|xusbDpadUp
+	}), "start and dpad-up were not held together")
+	require.NoError(t, pad.ButtonUp(gamepadmap.ButtonStart))
+	require.NoError(t, pad.ButtonUp(gamepadmap.ButtonDpadUp))
+}

--- a/pkg/helpers/windowsinput/vigem_test.go
+++ b/pkg/helpers/windowsinput/vigem_test.go
@@ -1,0 +1,84 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package windowsinput
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The driver checks each request's Size against its own sizeof and rejects a
+// mismatch without saying why, so the layouts are pinned here rather than left
+// to surface as an unexplained failure on a user's machine. The expected
+// values come from the driver's BusShared.h.
+func TestRequestStructSizes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		got  uintptr
+		want uintptr
+	}{
+		{"VIGEM_CHECK_VERSION", unsafe.Sizeof(vigemCheckVersion{}), 8},
+		{"VIGEM_PLUGIN_TARGET", unsafe.Sizeof(vigemPluginTarget{}), 16},
+		{"VIGEM_WAIT_DEVICE_READY", unsafe.Sizeof(vigemWaitDeviceReady{}), 8},
+		{"VIGEM_UNPLUG_TARGET", unsafe.Sizeof(vigemUnplugTarget{}), 8},
+		{"XUSB_REPORT", unsafe.Sizeof(xusbReport{}), 12},
+		{"XUSB_SUBMIT_REPORT", unsafe.Sizeof(xusbSubmitReport{}), 20},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.got)
+		})
+	}
+}
+
+// The report has to sit immediately after the two header fields, with no
+// padding, or the driver reads the wrong bytes as button state.
+func TestSubmitReportLayout(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, uintptr(8), unsafe.Offsetof(xusbSubmitReport{}.Report))
+}
+
+// CTL_CODE arithmetic is easy to get subtly wrong, and a wrong code reaches
+// the driver as an unrecognised request rather than an obvious mistake.
+func TestIoctlCodes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		got  uint32
+		want uint32
+	}{
+		{"IOCTL_VIGEM_PLUGIN_TARGET", ioctlPluginTarget, 0x2AA004},
+		{"IOCTL_VIGEM_UNPLUG_TARGET", ioctlUnplugTarget, 0x2AA008},
+		{"IOCTL_VIGEM_CHECK_VERSION", ioctlCheckVersion, 0x2AA00C},
+		{"IOCTL_VIGEM_WAIT_DEVICE_READY", ioctlWaitDeviceReady, 0x2AA010},
+		{"IOCTL_XUSB_SUBMIT_REPORT", ioctlXusbSubmitReport, 0x2AA808},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.got)
+		})
+	}
+}

--- a/pkg/helpers/windowsinput/vigem_windows.go
+++ b/pkg/helpers/windowsinput/vigem_windows.go
@@ -1,0 +1,341 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package windowsinput
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"golang.org/x/sys/windows"
+)
+
+// SetupAPI device-interface enumeration is not wrapped by x/sys/windows.
+//
+//nolint:gochecknoglobals // lazily resolved system DLL procedures
+var (
+	modsetupapi = windows.NewLazySystemDLL("setupapi.dll")
+
+	procSetupDiEnumDeviceInterfaces      = modsetupapi.NewProc("SetupDiEnumDeviceInterfaces")
+	procSetupDiGetDeviceInterfaceDetailW = modsetupapi.NewProc("SetupDiGetDeviceInterfaceDetailW")
+)
+
+// guidDevInterfaceViGEmBus is {96E42B22-F5E9-42F8-B043-ED0F932F014F}, the
+// device interface the ViGEmBus driver exposes.
+const (
+	// vigemCommonVersion is the protocol version the bus was built against.
+	// It refuses a client that reports any other, so this has to be checked
+	// before anything is plugged in.
+	vigemCommonVersion = 0x0001
+
+	// targetTypeXbox360Wired is VIGEM_TARGET_TYPE Xbox360Wired.
+	targetTypeXbox360Wired = 0
+
+	// serialAttempts bounds the search for a free bus slot. The bus refuses a
+	// serial another client already holds, so a client has to probe for one;
+	// XInput only ever surfaces four pads, so a machine that needs more
+	// attempts than this has a different problem.
+	serialAttempts = 32
+)
+
+// maxDeviceDetailSize bounds the SetupAPI detail buffer. A device interface
+// path is a few hundred bytes at most.
+const maxDeviceDetailSize = 4096
+
+//nolint:gochecknoglobals // constant GUID
+var guidDevInterfaceViGEmBus = windows.GUID{
+	Data1: 0x96E42B22, Data2: 0xF5E9, Data3: 0x42F8,
+	Data4: [8]byte{0xB0, 0x43, 0xED, 0x0F, 0x93, 0x2F, 0x01, 0x4F},
+}
+
+type spDeviceInterfaceData struct {
+	cbSize             uint32
+	interfaceClassGUID windows.GUID
+	flags              uint32
+	reserved           uintptr
+}
+
+// Gamepad is a virtual Xbox 360 pad plugged into the ViGEmBus driver.
+//
+// The driver's device interface carries no restrictive ACL, so an unelevated
+// process in the user's own session can drive it. Administrator rights are
+// only needed once, to install the driver.
+type Gamepad struct {
+	handle windows.Handle
+	event  windows.Handle
+	serial uint32
+	report xusbReport
+	mu     syncutil.Mutex
+}
+
+// NewGamepad plugs a virtual Xbox 360 pad into ViGEmBus. It returns
+// ErrDriverMissing when the driver is not installed.
+func NewGamepad() (*Gamepad, error) {
+	path, err := vigemDevicePath()
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, fmt.Errorf("vigem device path %q: %w", path, err)
+	}
+
+	handle, err := windows.CreateFile(p,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil, windows.OPEN_EXISTING, windows.FILE_FLAG_OVERLAPPED, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open vigem bus: %w", err)
+	}
+
+	// The bus refuses a client whose protocol version it was not built
+	// against, so this has to happen before anything is plugged in.
+	event, err := windows.CreateEvent(nil, 1, 0, nil)
+	if err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("create vigem event: %w", err)
+	}
+
+	g := &Gamepad{handle: handle, event: event}
+
+	version := vigemCheckVersion{
+		Size:    uint32(unsafe.Sizeof(vigemCheckVersion{})),
+		Version: vigemCommonVersion,
+	}
+	if err := ioctl(g, ioctlCheckVersion, &version, version.Size); err != nil {
+		g.closeHandles()
+		return nil, fmt.Errorf("vigem version check: %w", err)
+	}
+
+	if err := g.plugIn(); err != nil {
+		g.closeHandles()
+		return nil, err
+	}
+	return g, nil
+}
+
+// ButtonDown presses a button, identified by its evdev button code.
+func (g *Gamepad) ButtonDown(code int) error {
+	return g.setButton(code, true)
+}
+
+// ButtonUp releases a button, identified by its evdev button code.
+func (g *Gamepad) ButtonUp(code int) error {
+	return g.setButton(code, false)
+}
+
+// Close unplugs the pad and releases the bus handle.
+func (g *Gamepad) Close() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.handle == windows.InvalidHandle {
+		return nil
+	}
+
+	unplug := vigemUnplugTarget{
+		Size:     uint32(unsafe.Sizeof(vigemUnplugTarget{})),
+		SerialNo: g.serial,
+	}
+	err := ioctl(g, ioctlUnplugTarget, &unplug, unplug.Size)
+	g.closeHandles()
+	if err != nil {
+		return fmt.Errorf("unplug virtual gamepad: %w", err)
+	}
+	return nil
+}
+
+func (g *Gamepad) setButton(code int, down bool) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if err := g.report.setButton(code, down); err != nil {
+		return err
+	}
+	return g.submit()
+}
+
+// submit sends the current report. The caller must hold g.mu.
+func (g *Gamepad) submit() error {
+	report := xusbSubmitReport{
+		Size:     uint32(unsafe.Sizeof(xusbSubmitReport{})),
+		SerialNo: g.serial,
+		Report:   g.report,
+	}
+	// The driver answers ERROR_NO_MORE_ITEMS when nothing has polled the pad
+	// yet, because it had no pending USB IN request to complete. The report is
+	// still stored and sent on the next poll, so this is not a failure.
+	err := ioctl(g, ioctlXusbSubmitReport, &report, report.Size)
+	if err != nil && !errors.Is(err, windows.ERROR_NO_MORE_ITEMS) {
+		return fmt.Errorf("submit gamepad report: %w", err)
+	}
+	return nil
+}
+
+// plugIn claims the first free bus slot. The caller must not hold g.mu.
+func (g *Gamepad) plugIn() error {
+	var lastErr error
+	for serial := uint32(1); serial <= serialAttempts; serial++ {
+		plugin := vigemPluginTarget{
+			Size:       uint32(unsafe.Sizeof(vigemPluginTarget{})),
+			SerialNo:   serial,
+			TargetType: targetTypeXbox360Wired,
+		}
+		if err := ioctl(g, ioctlPluginTarget, &plugin, plugin.Size); err != nil {
+			lastErr = err
+			continue
+		}
+
+		// Plugging in only queues the child device; the bus keeps this second
+		// request pending until the pad is powered up and able to take
+		// reports. Without it the first report can race the device.
+		ready := vigemWaitDeviceReady{
+			Size:     uint32(unsafe.Sizeof(vigemWaitDeviceReady{})),
+			SerialNo: serial,
+		}
+		if err := ioctl(g, ioctlWaitDeviceReady, &ready, ready.Size); err != nil {
+			lastErr = err
+			unplug := vigemUnplugTarget{
+				Size:     uint32(unsafe.Sizeof(vigemUnplugTarget{})),
+				SerialNo: serial,
+			}
+			_ = ioctl(g, ioctlUnplugTarget, &unplug, unplug.Size)
+			continue
+		}
+
+		g.serial = serial
+		return nil
+	}
+	return fmt.Errorf("no free vigem bus slot after %d attempts: %w", serialAttempts, lastErr)
+}
+
+func (g *Gamepad) closeHandles() {
+	if g.event != 0 {
+		_ = windows.CloseHandle(g.event)
+		g.event = 0
+	}
+	if g.handle != windows.InvalidHandle {
+		_ = windows.CloseHandle(g.handle)
+		g.handle = windows.InvalidHandle
+	}
+}
+
+// vigemRequest is one of the driver's request structures. Each begins with its
+// own size, which is what the caller passes to ioctl.
+type vigemRequest interface {
+	vigemCheckVersion | vigemPluginTarget | vigemWaitDeviceReady | vigemUnplugTarget | xusbSubmitReport
+}
+
+// ioctl issues a buffered IOCTL carrying req, waiting out a request the driver
+// pends. It is a free function because Go methods cannot be generic.
+func ioctl[T vigemRequest](g *Gamepad, code uint32, req *T, size uint32) error {
+	if err := windows.ResetEvent(g.event); err != nil {
+		return fmt.Errorf("reset vigem event: %w", err)
+	}
+
+	overlapped := windows.Overlapped{HEvent: g.event}
+	var returned uint32
+	in := (*byte)(unsafe.Pointer(req)) //nolint:gosec // required for Windows API
+	err := windows.DeviceIoControl(g.handle, code, in, size, nil, 0, &returned, &overlapped)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, windows.ERROR_IO_PENDING) {
+		return fmt.Errorf("vigem ioctl 0x%X: %w", code, err)
+	}
+	if err := windows.GetOverlappedResult(g.handle, &overlapped, &returned, true); err != nil {
+		return fmt.Errorf("vigem ioctl 0x%X: %w", code, err)
+	}
+	return nil
+}
+
+// driverMissing reports an absent driver. A machine without ViGEmBus is the
+// ordinary case, and SetupAPI says so with ERROR_NO_MORE_ITEMS, whose text
+// ("No more data is available") only muddies a message a user has to act on.
+// Anything else is unexpected and keeps its cause.
+func driverMissing(err error) error {
+	if errors.Is(err, windows.ERROR_NO_MORE_ITEMS) {
+		return ErrDriverMissing
+	}
+	return fmt.Errorf("%w: %w", ErrDriverMissing, err)
+}
+
+// vigemDevicePath resolves the ViGEmBus device interface path.
+func vigemDevicePath() (string, error) {
+	set, err := windows.SetupDiGetClassDevsEx(
+		&guidDevInterfaceViGEmBus, "", 0,
+		windows.DIGCF_PRESENT|windows.DIGCF_DEVICEINTERFACE, 0, "")
+	if err != nil {
+		return "", driverMissing(err)
+	}
+	defer func() { _ = windows.SetupDiDestroyDeviceInfoList(set) }()
+
+	iface := spDeviceInterfaceData{}
+	iface.cbSize = uint32(unsafe.Sizeof(iface))
+	ret, _, callErr := procSetupDiEnumDeviceInterfaces.Call(
+		uintptr(set), 0,
+		uintptr(unsafe.Pointer(&guidDevInterfaceViGEmBus)), //nolint:gosec // required for Windows API
+		0,
+		uintptr(unsafe.Pointer(&iface))) //nolint:gosec // required for Windows API
+	if ret == 0 {
+		return "", driverMissing(callErr)
+	}
+
+	// The first call reports the buffer size the path needs.
+	var needed uint32
+	_, _, _ = procSetupDiGetDeviceInterfaceDetailW.Call(
+		uintptr(set),
+		uintptr(unsafe.Pointer(&iface)), //nolint:gosec // required for Windows API
+		0, 0,
+		uintptr(unsafe.Pointer(&needed)), //nolint:gosec // required for Windows API
+		0)
+	if needed < 8 || needed > maxDeviceDetailSize {
+		return "", fmt.Errorf("vigem device path: implausible detail size %d", needed)
+	}
+
+	buf := make([]byte, needed)
+	// cbSize covers the fixed part of SP_DEVICE_INTERFACE_DETAIL_DATA only,
+	// which is 8 bytes on 64-bit and 6 on 32-bit, not the struct's real size.
+	detailSize := uint32(8)
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		detailSize = 6
+	}
+	*(*uint32)(unsafe.Pointer(&buf[0])) = detailSize //nolint:gosec // required for Windows API
+
+	ret, _, callErr = procSetupDiGetDeviceInterfaceDetailW.Call(
+		uintptr(set),
+		uintptr(unsafe.Pointer(&iface)),  //nolint:gosec // required for Windows API
+		uintptr(unsafe.Pointer(&buf[0])), //nolint:gosec // required for Windows API
+		uintptr(needed),
+		uintptr(unsafe.Pointer(&needed)), //nolint:gosec // required for Windows API
+		0)
+	if ret == 0 {
+		return "", fmt.Errorf("vigem device path: %w", callErr)
+	}
+
+	// DevicePath is a UTF-16 string starting immediately after cbSize.
+	tail := buf[4:]
+	chars := unsafe.Slice((*uint16)(unsafe.Pointer(&tail[0])), len(tail)/2) //nolint:gosec // required for Windows API
+	return windows.UTF16ToString(chars), nil
+}

--- a/pkg/helpers/windowsinput/vigem_windows.go
+++ b/pkg/helpers/windowsinput/vigem_windows.go
@@ -56,7 +56,21 @@ const (
 	// XInput only ever surfaces four pads, so a machine that needs more
 	// attempts than this has a different problem.
 	serialAttempts = 32
+
+	// waitTimeout is WAIT_TIMEOUT, which x/sys/windows does not declare.
+	waitTimeout = 0x102
+
+	// ioctlTimeoutMillis bounds a request the bus keeps pending, in the
+	// milliseconds WaitForSingleObject wants. Plugging a pad in takes
+	// milliseconds; ten seconds is long enough that a slow machine is never
+	// cut off, and short enough that a driver which has stopped answering does
+	// not hold up startup indefinitely.
+	ioctlTimeoutMillis = 10_000
 )
+
+// ErrDriverUnresponsive reports that the driver accepted a request and never
+// completed it.
+var ErrDriverUnresponsive = errors.New("the ViGEmBus driver stopped responding")
 
 // maxDeviceDetailSize bounds the SetupAPI detail buffer. A device interface
 // path is a few hundred bytes at most.
@@ -264,7 +278,35 @@ func ioctl[T vigemRequest](g *Gamepad, code uint32, req *T, size uint32) error {
 	if !errors.Is(err, windows.ERROR_IO_PENDING) {
 		return fmt.Errorf("vigem ioctl 0x%X: %w", code, err)
 	}
-	if err := windows.GetOverlappedResult(g.handle, &overlapped, &returned, true); err != nil {
+	return g.awaitPending(code, &overlapped, &returned)
+}
+
+// awaitPending waits out a request the bus kept pending, giving up rather than
+// blocking for good. WAIT_DEVICE_READY stays pending until the child device
+// powers up, and this runs from StartPre, so a driver that never answers would
+// otherwise hang the whole service at startup.
+//
+// A request that is abandoned has to be cancelled and reaped first: the
+// overlapped structure is Go memory, and the driver would still be writing
+// into it after this call returned.
+func (g *Gamepad) awaitPending(code uint32, overlapped *windows.Overlapped, returned *uint32) error {
+	event, err := windows.WaitForSingleObject(g.event, ioctlTimeoutMillis)
+	if err != nil {
+		return fmt.Errorf("vigem ioctl 0x%X: waiting failed: %w", code, err)
+	}
+
+	if event == waitTimeout {
+		if err := windows.CancelIoEx(g.handle, overlapped); err != nil &&
+			!errors.Is(err, windows.ERROR_NOT_FOUND) {
+			return fmt.Errorf("vigem ioctl 0x%X timed out and could not be cancelled: %w", code, err)
+		}
+		// The result is the cancellation, not an answer, so only the reaping
+		// matters here.
+		_ = windows.GetOverlappedResult(g.handle, overlapped, returned, true)
+		return fmt.Errorf("vigem ioctl 0x%X: %w", code, ErrDriverUnresponsive)
+	}
+
+	if err := windows.GetOverlappedResult(g.handle, overlapped, returned, true); err != nil {
 		return fmt.Errorf("vigem ioctl 0x%X: %w", code, err)
 	}
 	return nil

--- a/pkg/helpers/windowsinput/vigem_windows_test.go
+++ b/pkg/helpers/windowsinput/vigem_windows_test.go
@@ -1,0 +1,50 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package windowsinput
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// A machine without the driver is the ordinary case, and the message reaches
+// the user through the API, so it must not trail SetupAPI's "No more data is
+// available" behind an otherwise clear sentence.
+func TestDriverMissingKeepsTheExpectedCaseClean(t *testing.T) {
+	t.Parallel()
+
+	err := driverMissing(windows.ERROR_NO_MORE_ITEMS)
+	require.ErrorIs(t, err, ErrDriverMissing)
+	assert.Equal(t, ErrDriverMissing.Error(), err.Error())
+}
+
+// Anything else is unexpected, and keeps its cause.
+func TestDriverMissingKeepsAnUnexpectedCause(t *testing.T) {
+	t.Parallel()
+
+	err := driverMissing(windows.ERROR_ACCESS_DENIED)
+	require.ErrorIs(t, err, ErrDriverMissing)
+	require.ErrorIs(t, err, windows.ERROR_ACCESS_DENIED)
+}

--- a/pkg/helpers/windowsinput/xusb.go
+++ b/pkg/helpers/windowsinput/xusb.go
@@ -1,0 +1,117 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package windowsinput
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/linuxinput/gamepadmap"
+)
+
+// XUSB button bits, matching the XINPUT_GAMEPAD_* constants an Xbox 360 pad
+// reports.
+const (
+	xusbDpadUp        = 0x0001
+	xusbDpadDown      = 0x0002
+	xusbDpadLeft      = 0x0004
+	xusbDpadRight     = 0x0008
+	xusbStart         = 0x0010
+	xusbBack          = 0x0020
+	xusbLeftShoulder  = 0x0100
+	xusbRightShoulder = 0x0200
+	xusbGuide         = 0x0400
+	xusbA             = 0x1000
+	xusbB             = 0x2000
+	xusbX             = 0x4000
+	xusbY             = 0x8000
+)
+
+// triggerFull is the analogue value a digital trigger press reports. The
+// engine only knows about pressed and released, so a trigger goes straight to
+// its limit the way it does through uinput on Linux.
+const triggerFull = 0xFF
+
+// ErrUnknownButton is returned for a button code with no XUSB equivalent.
+var ErrUnknownButton = errors.New("gamepad button is not supported on windows")
+
+// buttonBits maps evdev button codes to the XUSB bit they set. The face
+// buttons follow the same physical positions the Linux xpad driver reports,
+// so a ZapScript button means the same key on both platforms.
+//
+//nolint:gochecknoglobals // lookup table
+var buttonBits = map[int]uint16{
+	gamepadmap.ButtonSouth:       xusbA,
+	gamepadmap.ButtonEast:        xusbB,
+	gamepadmap.ButtonWest:        xusbX,
+	gamepadmap.ButtonNorth:       xusbY,
+	gamepadmap.ButtonBumperLeft:  xusbLeftShoulder,
+	gamepadmap.ButtonBumperRight: xusbRightShoulder,
+	gamepadmap.ButtonSelect:      xusbBack,
+	gamepadmap.ButtonStart:       xusbStart,
+	gamepadmap.ButtonMode:        xusbGuide,
+	gamepadmap.ButtonDpadUp:      xusbDpadUp,
+	gamepadmap.ButtonDpadDown:    xusbDpadDown,
+	gamepadmap.ButtonDpadLeft:    xusbDpadLeft,
+	gamepadmap.ButtonDpadRight:   xusbDpadRight,
+}
+
+// xusbReport mirrors the XUSB_REPORT structure the driver expects.
+type xusbReport struct {
+	buttons      uint16
+	leftTrigger  uint8
+	rightTrigger uint8
+	// The engine only knows buttons, so the four thumb axes are always sent
+	// centred. They are named rather than reserved because the driver reads
+	// the report by offset and the layout has to stay recognisable.
+	thumbLX int16 //nolint:unused // part of the driver's report layout
+	thumbLY int16 //nolint:unused // part of the driver's report layout
+	thumbRX int16 //nolint:unused // part of the driver's report layout
+	thumbRY int16 //nolint:unused // part of the driver's report layout
+}
+
+// setButton records a press or release of an evdev button code. The report is
+// cumulative: the caller submits the whole thing after every change, which is
+// how XUSB reports work and how holding several buttons at once stays correct.
+func (r *xusbReport) setButton(code int, down bool) error {
+	if bit, ok := buttonBits[code]; ok {
+		if down {
+			r.buttons |= bit
+		} else {
+			r.buttons &^= bit
+		}
+		return nil
+	}
+
+	var trigger uint8
+	if down {
+		trigger = triggerFull
+	}
+
+	switch code {
+	case gamepadmap.ButtonTriggerLeft:
+		r.leftTrigger = trigger
+	case gamepadmap.ButtonTriggerRight:
+		r.rightTrigger = trigger
+	default:
+		return fmt.Errorf("%w: code %d", ErrUnknownButton, code)
+	}
+	return nil
+}

--- a/pkg/helpers/windowsinput/xusb_test.go
+++ b/pkg/helpers/windowsinput/xusb_test.go
@@ -1,0 +1,130 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package windowsinput
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/linuxinput/gamepadmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every button ZapScript can name has to reach the driver. This fails when a
+// button is added to gamepadmap without a Windows mapping.
+func TestEveryMappedButtonIsSupported(t *testing.T) {
+	t.Parallel()
+
+	for name, code := range gamepadmap.GamepadMap {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			report := xusbReport{}
+			require.NoError(t, report.setButton(code, true), "button %q (code %d)", name, code)
+		})
+	}
+}
+
+func TestButtonBitsAreDistinct(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[uint16]int, len(buttonBits))
+	for code, bit := range buttonBits {
+		if other, ok := seen[bit]; ok {
+			t.Errorf("codes %d and %d both set bit 0x%04X", other, code, bit)
+		}
+		seen[bit] = code
+	}
+}
+
+func TestSetButtonHoldsSeveralAtOnce(t *testing.T) {
+	t.Parallel()
+
+	report := xusbReport{}
+	require.NoError(t, report.setButton(gamepadmap.ButtonSouth, true))
+	require.NoError(t, report.setButton(gamepadmap.ButtonStart, true))
+	assert.Equal(t, uint16(xusbA|xusbStart), report.buttons)
+
+	// Releasing one must leave the other held.
+	require.NoError(t, report.setButton(gamepadmap.ButtonSouth, false))
+	assert.Equal(t, uint16(xusbStart), report.buttons)
+
+	require.NoError(t, report.setButton(gamepadmap.ButtonStart, false))
+	assert.Equal(t, uint16(0), report.buttons)
+}
+
+func TestSetButtonReleasingUnheldButtonIsHarmless(t *testing.T) {
+	t.Parallel()
+
+	report := xusbReport{buttons: xusbA}
+	require.NoError(t, report.setButton(gamepadmap.ButtonStart, false))
+	assert.Equal(t, uint16(xusbA), report.buttons)
+}
+
+// The triggers are analogue on a real pad, but the engine only knows pressed
+// and released, so they swing between the limits.
+func TestSetButtonDrivesTriggers(t *testing.T) {
+	t.Parallel()
+
+	report := xusbReport{}
+
+	require.NoError(t, report.setButton(gamepadmap.ButtonTriggerLeft, true))
+	assert.Equal(t, uint8(triggerFull), report.leftTrigger)
+	assert.Equal(t, uint8(0), report.rightTrigger)
+	assert.Equal(t, uint16(0), report.buttons, "a trigger must not set a button bit")
+
+	require.NoError(t, report.setButton(gamepadmap.ButtonTriggerRight, true))
+	assert.Equal(t, uint8(triggerFull), report.rightTrigger)
+
+	require.NoError(t, report.setButton(gamepadmap.ButtonTriggerLeft, false))
+	assert.Equal(t, uint8(0), report.leftTrigger)
+	assert.Equal(t, uint8(triggerFull), report.rightTrigger)
+}
+
+func TestSetButtonRejectsUnknownCode(t *testing.T) {
+	t.Parallel()
+
+	report := xusbReport{}
+	err := report.setButton(0x999, true)
+	require.ErrorIs(t, err, ErrUnknownButton)
+}
+
+// The face buttons follow physical positions, so a ZapScript name means the
+// same key on Windows as it does through uinput on Linux.
+func TestFaceButtonPositions(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		code int
+		bit  uint16
+	}{
+		{"south is A", gamepadmap.ButtonSouth, xusbA},
+		{"east is B", gamepadmap.ButtonEast, xusbB},
+		{"west is X", gamepadmap.ButtonWest, xusbX},
+		{"north is Y", gamepadmap.ButtonNorth, xusbY},
+		{"select is back", gamepadmap.ButtonSelect, xusbBack},
+		{"mode is guide", gamepadmap.ButtonMode, xusbGuide},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.bit, buttonBits[tc.code])
+		})
+	}
+}

--- a/pkg/platforms/shared/inputbackend_windows.go
+++ b/pkg/platforms/shared/inputbackend_windows.go
@@ -35,8 +35,13 @@ func newPlatformKeyboard() (KeyboardDevice, error) {
 	return kbd, nil
 }
 
-// Virtual gamepad support on Windows needs the ViGEmBus driver and is not
-// implemented yet.
+// newPlatformGamepad plugs a virtual Xbox 360 pad into the ViGEmBus driver.
+// The driver is an optional install, so a machine without it reports that
+// rather than failing obscurely.
 func newPlatformGamepad() (GamepadDevice, error) {
-	return nil, ErrInputUnsupported
+	gpd, err := windowsinput.NewGamepad()
+	if err != nil {
+		return nil, fmt.Errorf("create windows gamepad: %w", err)
+	}
+	return gpd, nil
 }

--- a/pkg/platforms/shared/inputmanager.go
+++ b/pkg/platforms/shared/inputmanager.go
@@ -73,10 +73,24 @@ type InputManager struct {
 	gamepadRefs   map[int]int
 	kbd           KeyboardDevice
 	gpd           GamepadDevice
+	gamepadErr    error
 	keyboardDelay time.Duration
 	gamepadDelay  time.Duration
 	sequenceMu    syncutil.Mutex
 	inputMu       syncutil.Mutex
+}
+
+// ErrGamepadDisabled reports that virtual gamepad support is switched off.
+var ErrGamepadDisabled = errors.New("virtual gamepad is disabled")
+
+// gamepadUnavailable explains why there is no gamepad to drive. A gamepad that
+// was asked for but could not be created reports the reason it failed, rather
+// than claiming it was never enabled.
+func (l *InputManager) gamepadUnavailable() error {
+	if l.gamepadErr != nil {
+		return fmt.Errorf("virtual gamepad unavailable: %w", l.gamepadErr)
+	}
+	return ErrGamepadDisabled
 }
 
 // InitDevices initializes keyboard and optionally gamepad based on config.
@@ -98,13 +112,20 @@ func (l *InputManager) InitDevices(cfg *config.Instance, gamepadEnabledByDefault
 	l.kbd = kbd
 	l.keyboardDelay = DefaultInputDelay
 
+	l.gamepadErr = nil
 	if cfg.VirtualGamepadEnabled(gamepadEnabledByDefault) {
 		gpd, err := newGpd()
 		if err != nil {
-			return fmt.Errorf("failed to create gamepad: %w", err)
+			// The virtual gamepad is optional, and on Windows it needs a
+			// driver installed separately from Core. Losing it must not stop
+			// the service from starting, so the error is kept and reported by
+			// the commands that actually need a gamepad.
+			l.gamepadErr = err
+			log.Warn().Err(err).Msg("virtual gamepad unavailable")
+		} else {
+			l.gpd = gpd
+			l.gamepadDelay = DefaultInputDelay
 		}
-		l.gpd = gpd
-		l.gamepadDelay = DefaultInputDelay
 	}
 
 	log.Debug().Msg("input devices initialized successfully")

--- a/pkg/platforms/shared/inputmanager_test.go
+++ b/pkg/platforms/shared/inputmanager_test.go
@@ -157,9 +157,39 @@ func TestInitDevices_GamepadError(t *testing.T) {
 		},
 	}
 
+	// A gamepad that cannot be created must not stop the service from
+	// starting: on Windows it needs a driver installed separately from Core.
 	err = input.InitDevices(cfg, true)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create gamepad")
+	require.NoError(t, err)
+	assert.False(t, input.gamepadDeviceEnabled())
+
+	// The failure still has to reach whoever asks for a gamepad, naming the
+	// real cause rather than reporting the feature as switched off.
+	err = input.GamepadPress("A")
+	require.ErrorIs(t, err, expectedErr)
+	assert.Contains(t, err.Error(), "virtual gamepad unavailable")
+}
+
+func TestInitDevices_GamepadDisabledReportsDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.NewConfig(t.TempDir(), config.BaseDefaults)
+	require.NoError(t, err)
+
+	input := &InputManager{
+		NewKeyboard: func() (KeyboardDevice, error) {
+			return &mockKeyboard{}, nil
+		},
+		NewGamepad: func() (GamepadDevice, error) {
+			t.Error("gamepad must not be created when it is disabled")
+			return nil, errors.New("unexpected gamepad creation")
+		},
+	}
+
+	require.NoError(t, input.InitDevices(cfg, false))
+
+	err = input.GamepadPress("A")
+	require.ErrorIs(t, err, ErrGamepadDisabled)
 }
 
 // TestCloseDevices_NilGamepad tests that CloseDevices handles nil gamepad gracefully

--- a/pkg/platforms/shared/inputsession.go
+++ b/pkg/platforms/shared/inputsession.go
@@ -231,7 +231,7 @@ func (l *InputManager) gamepadDownLocked(code int) error {
 		return nil
 	}
 	if l.gpd == nil {
-		return errors.New("virtual gamepad is disabled")
+		return l.gamepadUnavailable()
 	}
 	if err := l.gpd.ButtonDown(code); err != nil {
 		return fmt.Errorf("button down %d: %w", code, err)
@@ -250,7 +250,7 @@ func (l *InputManager) gamepadUpLocked(code int) error {
 		return nil
 	}
 	if l.gpd == nil {
-		return errors.New("virtual gamepad is disabled")
+		return l.gamepadUnavailable()
 	}
 	if err := l.gpd.ButtonUp(code); err != nil {
 		return fmt.Errorf("button up %d: %w", code, err)
@@ -559,7 +559,7 @@ func (l *InputManager) pressGamepadToken(name string) (retErr error) {
 	l.sequenceMu.Lock()
 	defer l.sequenceMu.Unlock()
 	if !l.gamepadDeviceEnabled() {
-		return errors.New("virtual gamepad is disabled")
+		return l.gamepadUnavailable()
 	}
 	code, ok := gamepadmap.ToGamepadCode(name)
 	if !ok {
@@ -758,7 +758,7 @@ func (l *InputManager) gamepadPressSequenceLocked(
 	session *inputSession,
 ) (retErr error) {
 	if !l.gamepadDeviceEnabled() {
-		return errors.New("virtual gamepad is disabled")
+		return l.gamepadUnavailable()
 	}
 	if interKeyDelay == 0 {
 		interKeyDelay = DefaultInterKeyDelay

--- a/scripts/tasks/utils/windowsiss/main.go
+++ b/scripts/tasks/utils/windowsiss/main.go
@@ -20,6 +20,8 @@
 package main
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"flag"
 	"fmt"
 	"os"
@@ -27,6 +29,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"unicode/utf16"
 )
 
 type InnoSetupData struct {
@@ -41,6 +44,68 @@ type InnoSetupData struct {
 	// only x86 and x64 packages, so an ARM64 installer leaves the task out
 	// entirely rather than offering one that cannot work.
 	ViGEmMsi string
+	// ViGEmInstallScript is the base64 of the PowerShell that installs the
+	// driver, ready for powershell.exe -EncodedCommand.
+	ViGEmInstallScript string
+}
+
+// vigemInstallScript installs the unpacked driver, and runs elevated.
+//
+// It exists because the staging directory is writable by an unprivileged
+// process, so handing its contents straight to an elevated msiexec would let
+// anything running as the user swap the package and have Windows install it
+// with administrator rights. A directory only administrators can write is
+// therefore created and locked first, the unpacked package copied into it,
+// and only then is the package checked and installed: the order matters,
+// because a signature checked before the files are out of reach could be
+// checked on one package and acted on for another.
+//
+// The whole unpacked directory is copied, not just the MSI, because the
+// package installs files that sit beside it and fails with 1603 without them.
+//
+// It is passed to powershell.exe with -EncodedCommand rather than written to
+// disk, so that the script itself cannot be swapped the same way.
+const vigemInstallScript = `
+$ErrorActionPreference = 'Stop'
+$stage = Join-Path $env:ProgramData 'Zaparoo\vigembus-stage'
+$found = Get-ChildItem -LiteralPath $stage -Recurse -Filter '%MSI%' -File -ErrorAction SilentlyContinue |
+  Select-Object -First 1
+if (-not $found) { exit 3 }
+$safeDir = Join-Path $env:SystemRoot ('Temp\zaparoo-vigembus-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $safeDir -Force | Out-Null
+$acl = New-Object System.Security.AccessControl.DirectorySecurity
+$acl.SetSecurityDescriptorSddlForm('D:PAI(A;OICI;FA;;;BA)(A;OICI;FA;;;SY)')
+Set-Acl -LiteralPath $safeDir -AclObject $acl
+Copy-Item -Path (Join-Path $found.Directory.FullName '*') -Destination $safeDir -Recurse -Force
+$safe = Join-Path $safeDir '%MSI%'
+$sig = Get-AuthenticodeSignature -LiteralPath $safe
+if ($sig.Status -ne 'Valid' -or $sig.SignerCertificate.Subject -notlike '*Nefarius Software Solutions*') {
+  Remove-Item -LiteralPath $safeDir -Recurse -Force
+  exit 4
+}
+$p = Start-Process msiexec.exe -ArgumentList '/i', ('"' + $safe + '"'), '/qn', '/norestart' -Wait -PassThru
+Remove-Item -LiteralPath $safeDir -Recurse -Force
+exit $p.ExitCode
+`
+
+// vigemInstallCommand renders the elevated install script for an
+// architecture, encoded the way powershell.exe -EncodedCommand expects.
+func vigemInstallCommand(msi string) string {
+	if msi == "" {
+		return ""
+	}
+	script := strings.ReplaceAll(vigemInstallScript, "%MSI%", msi)
+	return base64.StdEncoding.EncodeToString(utf16LE(script))
+}
+
+// utf16LE encodes a string the way -EncodedCommand reads it.
+func utf16LE(s string) []byte {
+	units := utf16.Encode([]rune(s))
+	out := make([]byte, len(units)*2)
+	for i, u := range units {
+		binary.LittleEndian.PutUint16(out[i*2:], u)
+	}
+	return out
 }
 
 // vigemMsiForArch names the ViGEmBus MSI to install on a given build
@@ -98,6 +163,7 @@ func main() {
 		ArchitecturesInstall64: archInstall,
 		Year:                   strconv.Itoa(time.Now().Year()),
 		ViGEmMsi:               vigemMsiForArch(*arch),
+		ViGEmInstallScript:     vigemInstallCommand(vigemMsiForArch(*arch)),
 	}
 
 	tmpl, err := template.ParseFiles("cmd/windows/setup.iss.tmpl")

--- a/scripts/tasks/utils/windowsiss/main.go
+++ b/scripts/tasks/utils/windowsiss/main.go
@@ -36,6 +36,25 @@ type InnoSetupData struct {
 	ArchitecturesAllowed   string
 	ArchitecturesInstall64 string
 	Year                   string
+	// ViGEmMsi is the MSI the ViGEmBus bootstrapper unpacks for this
+	// architecture, or empty when the driver is not offered. The vendor ships
+	// only x86 and x64 packages, so an ARM64 installer leaves the task out
+	// entirely rather than offering one that cannot work.
+	ViGEmMsi string
+}
+
+// vigemMsiForArch names the ViGEmBus MSI to install on a given build
+// architecture. The bootstrapper unpacks both, so the installer picks rather
+// than relying on the bootstrapper's own detection.
+func vigemMsiForArch(arch string) string {
+	switch arch {
+	case "amd64":
+		return "ViGEmBus.x64.msi"
+	case "386":
+		return "ViGEmBus.msi"
+	default:
+		return ""
+	}
 }
 
 func main() {
@@ -78,6 +97,7 @@ func main() {
 		ArchitecturesAllowed:   archAllowed,
 		ArchitecturesInstall64: archInstall,
 		Year:                   strconv.Itoa(time.Now().Year()),
+		ViGEmMsi:               vigemMsiForArch(*arch),
 	}
 
 	tmpl, err := template.ParseFiles("cmd/windows/setup.iss.tmpl")

--- a/scripts/tasks/utils/windowsiss/main_test.go
+++ b/scripts/tasks/utils/windowsiss/main_test.go
@@ -1,0 +1,48 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The build copies the bundled driver in only when the generated script asks
+// for it, so an architecture with no MSI has to produce an empty name rather
+// than a plausible-looking one.
+func TestViGEmMsiForArch(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		arch string
+		want string
+	}{
+		{"amd64", "ViGEmBus.x64.msi"},
+		{"386", "ViGEmBus.msi"},
+		{"arm64", ""},
+		{"riscv64", ""},
+	} {
+		t.Run(tc.arch, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, vigemMsiForArch(tc.arch))
+		})
+	}
+}

--- a/scripts/tasks/utils/windowsiss/main_test.go
+++ b/scripts/tasks/utils/windowsiss/main_test.go
@@ -20,9 +20,13 @@
 package main
 
 import (
+	"encoding/base64"
+	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The build copies the bundled driver in only when the generated script asks
@@ -45,4 +49,53 @@ func TestViGEmMsiForArch(t *testing.T) {
 			assert.Equal(t, tc.want, vigemMsiForArch(tc.arch))
 		})
 	}
+}
+
+// decodeEncodedCommand reverses what powershell.exe -EncodedCommand expects.
+func decodeEncodedCommand(t *testing.T, encoded string) string {
+	t.Helper()
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(raw)%2, "UTF-16 needs an even number of bytes")
+
+	units := make([]uint16, 0, len(raw)/2)
+	for i := 0; i < len(raw); i += 2 {
+		units = append(units, uint16(raw[i])|uint16(raw[i+1])<<8)
+	}
+	return string(utf16.Decode(units))
+}
+
+// The elevated script is the only thing standing between a staging directory
+// an unprivileged process can write and an install with administrator rights,
+// so its guards are pinned here rather than left to review.
+func TestViGEmInstallCommandGuardsTheElevatedInstall(t *testing.T) {
+	t.Parallel()
+
+	script := decodeEncodedCommand(t, vigemInstallCommand("ViGEmBus.x64.msi"))
+
+	assert.Contains(t, script, "ViGEmBus.x64.msi", "the script must look for this architecture's package")
+	assert.Contains(t, script, "Get-AuthenticodeSignature", "the package must be checked before it is installed")
+	assert.Contains(t, script, "Nefarius Software Solutions", "the publisher must be pinned")
+	assert.Contains(t, script, "SetSecurityDescriptorSddlForm", "the copy must be locked down")
+
+	// Order is the whole point: a package checked before it is locked could be
+	// checked as one file and installed as another.
+	lock := strings.Index(script, "Set-Acl")
+	check := strings.Index(script, "Get-AuthenticodeSignature")
+	install := strings.Index(script, "msiexec")
+	require.Positive(t, lock)
+	assert.Less(t, lock, check, "the copy must be locked before it is checked")
+	assert.Less(t, check, install, "the package must be checked before it is installed")
+
+	// A single backslash: a raw Go string keeps whatever is written, and a
+	// doubled one would send PowerShell to a path that does not exist.
+	assert.Contains(t, script, `Zaparoo\vigembus-stage`)
+	assert.NotContains(t, script, `Zaparoo\\vigembus-stage`)
+}
+
+func TestViGEmInstallCommandIsEmptyWithoutAPackage(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, vigemInstallCommand(""))
 }

--- a/scripts/tasks/windows.yml
+++ b/scripts/tasks/windows.yml
@@ -10,6 +10,26 @@ tasks:
           IMAGE_NAME: zaparoo/zigcc
           EXEC: sh -c 'cd cmd/windows && go-winres make --arch="amd64,arm64,386"'
 
+  fetch-vigembus:
+    internal: true
+    desc: Download the pinned ViGEmBus driver installer for bundling
+    vars:
+      # 1.22.0 is the last release of ViGEmBus, which was archived in November
+      # 2023. Its driver binary is identical to 1.21.442.0's; only the
+      # installer wrapper differs.
+      VIGEMBUS_VERSION: 1.22.0
+      VIGEMBUS_SHA256: 89220a7865076b342892f98865f3499fb7c4cfd673159e89d352c360fd014c6a
+    cmds:
+      - mkdir -p _build/vendor
+      - |
+        set -e
+        out=_build/vendor/ViGEmBusSetup.exe
+        if [ ! -f "$out" ]; then
+          curl -fsSL -o "$out" \
+            "https://github.com/nefarius/ViGEmBus/releases/download/v{{.VIGEMBUS_VERSION}}/ViGEmBus_{{.VIGEMBUS_VERSION}}_x64_x86_arm64.exe"
+        fi
+        echo "{{.VIGEMBUS_SHA256}}  $out" | sha256sum -c -
+
   build-installer:
     internal: true
     cmds:
@@ -22,6 +42,12 @@ tasks:
       - docker cp "_build/windows_{{.BUILD_ARCH}}/LICENSE.txt" zaparoo-innosetup:/work/
       - docker cp "_build/windows_{{.BUILD_ARCH}}/README.txt" zaparoo-innosetup:/work/
       - docker cp "_build/windows_{{.BUILD_ARCH}}/icon.ico" zaparoo-innosetup:/work/
+      # Only the architectures the driver ships for fetch it, and the generated
+      # setup.iss leaves the task out entirely on the others.
+      - |
+        if [ -f "_build/vendor/ViGEmBusSetup.exe" ] && grep -q "ViGEmBusSetup.exe" "_build/windows_{{.BUILD_ARCH}}/setup.iss"; then
+          docker cp "_build/vendor/ViGEmBusSetup.exe" zaparoo-innosetup:/work/
+        fi
       - docker start -i -a zaparoo-innosetup
       - mkdir -p "_build/windows_{{.BUILD_ARCH}}/Output"
       - docker cp zaparoo-innosetup:/work/Output/. "_build/windows_{{.BUILD_ARCH}}/Output"
@@ -49,6 +75,7 @@ tasks:
       - task: :zigcc:setup
       - task: build-metadata
       - task: :zigcc:build-windows-amd64
+      - task: fetch-vigembus
       - task: build-installer
         vars:
           BUILD_ARCH: amd64
@@ -59,6 +86,7 @@ tasks:
       - task: :zigcc:setup
       - task: build-metadata
       - task: :zigcc:build-windows-386
+      - task: fetch-vigembus
       - task: build-installer
         vars:
           BUILD_ARCH: "386"


### PR DESCRIPTION
Closes #151. Builds on the `windowsinput` package added in #1411.

`newPlatformGamepad` returned `ErrInputUnsupported` on Windows, so `input.gamepad` and the ZapScript gamepad commands could not work there at all.

## No administrator, and no DLL

The concern on #151 was that gamepad support would force Core to run elevated. It does not. ViGEmBus exposes its device interface with no restrictive ACL, so an unelevated process in the user's own session can open it and plug a pad. Installing the driver is the only step that needs administrator rights, and it happens once, outside Core. Verified on hardware: the integration test passes from a `RunLevel Limited` scheduled task.

ViGEmBus's client library is a DLL, and binding to it would mean cgo and a second shipped binary. This talks to the driver directly instead — SetupAPI to find the device interface, then five IOCTLs over an overlapped handle. The wire structures and IOCTL codes live in an untagged file so their layouts are pinned by tests that run on every platform; the driver validates each request's `Size` and rejects a mismatch without saying why, which is not a failure anyone should have to debug from a user's machine.

Two driver behaviours shape the code. It answers a report with `ERROR_NO_MORE_ITEMS` when nothing has polled the pad yet, which is not a failure. And it refuses a serial another client already holds, so the first free bus slot is searched for rather than assumed, the way the vendor's own client does.

## A missing gamepad no longer stops the service

`InitDevices` treated a gamepad it could not create as fatal. That was survivable while every platform with virtual input built its gamepad from the same uinput device as its keyboard — a machine that could make one could make the other. Windows breaks that: the driver is installed separately from Core, so a user who turned the setting on before installing it would have been left with a service that would not start at all.

The failure is recorded instead of returned, and reported by the commands that need a gamepad, naming the real cause rather than claiming the feature is switched off.

## Installer

The driver is offered as an unchecked task whose caption says plainly that it installs a kernel-mode driver and whose it is. It is deliberately left in place when Zaparoo is uninstalled, since other software may be using it; removal is documented instead.

The vendor's bootstrapper never returns when asked to install silently, which is why this was blocked. It unpacks reliably, so the task unpacks it and installs the driver through the vendor's own MSI. Two traps had to be found by testing rather than reading:

- **The bootstrapper exits 0 and does nothing when its `/extract` target does not already exist.** Silent, successful, no output. A `[Dirs]` entry creates it first.
- **The elevation check is `IsAdminLoggedOn`, not `IsAdminInstallMode`.** `PrivilegesRequired=lowest` keeps Zaparoo a per-user install even when Setup was started elevated, so `IsAdminInstallMode` is False there and skipped a driver the process was perfectly able to install.

An unelevated *silent* install still cannot install the driver, because a silent install must not raise an elevation prompt. That matches the existing firewall task. ARM64 gets no task at all — the bootstrapper ships x86 and x64 packages only, so offering it there would be an option that could never work.

## Defaults

Gamepad support stays off by default on Windows: an unexpected virtual pad shifts every real controller's index in games. `gamepad_enabled = true` under `[input]` turns it on.

## Validation

`task lint-fix` and `task cross-lint:windows` both 0 issues; `task test` green across 139 packages; all 19 `windowsinput` tests pass natively on Windows 11.

The integration test reads the pad back through XInput — how a game sees it — so it proves the device enumerated and reports arrive as button state, not merely that IOCTLs returned success. It skips where the driver is absent, including CI.

End to end on a Windows 11 machine, driving a deployed build through the API:

| Case | Result |
| :-- | :-- |
| Uninstall driver silently | exit 0, removed from driver store |
| Core start with no driver | starts normally, logs `virtual gamepad unavailable` |
| `input.gamepad` with no driver | errors with `the ViGEmBus driver is not installed` |
| Installer, `/VERYSILENT /TASKS=vigembus` | exit 0 in 6s, no prompt, driver installed |
| `input.gamepad "^^vv<><>BA{start}{l2}"` | dpad, `0x1000`/`0x2000`, `0x0010`, trigger 255 — exact match |
| `{hold:start:1500}` | `0x0010` held, observed by a separate process |
| Core shutdown | pad disappears from XInput |

Unelevated is the case that matters, and the integration test passes under a `RunLevel Limited` task as well as elevated.

## Not covered

ARM64 is untested — there is no ARM64 Windows device here, and the driver ships no ARM64 MSI, which is why the task is omitted on that build rather than shipped untried.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Windows virtual gamepad support through the ViGEmBus driver.
  - Windows installers can offer ViGEmBus installation as an unchecked optional task.
  - Gamepad input now supports Xbox-compatible buttons and triggers.
  - Service startup continues when the virtual gamepad is unavailable, with clear error reporting.

- **Documentation**
  - Documented the driver requirement, optional installation, configuration, and troubleshooting details for Windows gamepad input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->