### PR TITLE
fix(readers): recover reader auto-detect and make its failures diagnosable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/ZaparooProject/go-gameid v0.2.0
-	github.com/ZaparooProject/go-pn532 v0.23.0
+	github.com/ZaparooProject/go-pn532 v0.24.0
 	github.com/ZaparooProject/go-zapscript v0.19.0
 	github.com/ZaparooProject/zaparoo-core/mister v0.1.0
 	github.com/adrg/xdg v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d h1:2xp1BQbqcDDaik
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
 github.com/ZaparooProject/go-gameid v0.2.0 h1:nYDxozhwsJXacdh/lwHOJofz4SlA609WKTD38UOQy+0=
 github.com/ZaparooProject/go-gameid v0.2.0/go.mod h1:gPQg1jQ4jgkguOJeKUiIqZeucz0GsSR67UQ/JOgYUDI=
-github.com/ZaparooProject/go-pn532 v0.23.0 h1:iJ5taBHFXQxYhS8zncMonWEW6pOIyklLpnVx/GFS2n4=
-github.com/ZaparooProject/go-pn532 v0.23.0/go.mod h1:ao2ojvudUN8ZqcBAkjodRhCjm2jDf/efS0mdSC6eDHg=
+github.com/ZaparooProject/go-pn532 v0.24.0 h1:PkFrB01e3WNit9sBQJ15SWAFzJNahbL7cFwrI3mmRys=
+github.com/ZaparooProject/go-pn532 v0.24.0/go.mod h1:fSidCDd3a43w9TN9sHIpJdl1gQ5CTX/WgtnrniAdV+4=
 github.com/ZaparooProject/go-zapscript v0.19.0 h1:M4t3dlOrfx0g8ZkLuGt7pRhNa5SqWMs5oAgucZpovQE=
 github.com/ZaparooProject/go-zapscript v0.19.0/go.mod h1:ofo4vj6lFW0eUuSyPLt0R0JjJxExhn9eitSmFBWQVoU=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=

--- a/pkg/api/methods/logs.go
+++ b/pkg/api/methods/logs.go
@@ -35,7 +35,7 @@ func HandleLogsDownload(env requests.RequestEnv) (any, error) { //nolint:gocriti
 
 	// Carries the captured stderr with the log: a crash that kills the service
 	// exists only there, and this is the path a user's uploaded log comes from.
-	data, err := helpers.ReadLogBundle(env.Platform, config.LogUploadMaxBytes)
+	data, err := helpers.ReadLogBundle(env.Platform, config.LogBundleMaxBytes)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to read log file")
 		return nil, fmt.Errorf("failed to read log file: %w", err)

--- a/pkg/api/methods/logs.go
+++ b/pkg/api/methods/logs.go
@@ -22,24 +22,22 @@ package methods
 import (
 	"encoding/base64"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/rs/zerolog/log"
 )
 
 func HandleLogsDownload(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
 	log.Info().Msg("received logs download request")
 
-	logFilePath := filepath.Join(env.Platform.Settings().LogDir, config.LogFile)
-
-	//nolint:gosec // Safe: reads log files from controlled application directories
-	data, err := os.ReadFile(logFilePath)
+	// Carries the captured stderr with the log: a crash that kills the service
+	// exists only there, and this is the path a user's uploaded log comes from.
+	data, err := helpers.ReadLogBundle(env.Platform, config.LogUploadMaxBytes)
 	if err != nil {
-		log.Error().Err(err).Str("path", logFilePath).Msg("failed to read log file")
+		log.Error().Err(err).Msg("failed to read log file")
 		return nil, fmt.Errorf("failed to read log file: %w", err)
 	}
 

--- a/pkg/api/methods/logs_test.go
+++ b/pkg/api/methods/logs_test.go
@@ -1,0 +1,121 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func logsRequestEnv(t *testing.T, logBody, stderrBody string) requests.RequestEnv {
+	t.Helper()
+
+	logDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(logDir, config.LogFile), []byte(logBody), 0o600))
+	if stderrBody != "" {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(logDir, config.StderrFile), []byte(stderrBody), 0o600))
+	}
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Settings").Return(platforms.Settings{LogDir: logDir, TempDir: logDir})
+	return requests.RequestEnv{Context: context.Background(), Platform: pl, IsLocal: true}
+}
+
+func decodeLogResponse(t *testing.T, result any) string {
+	t.Helper()
+	resp, ok := result.(models.LogDownloadResponse)
+	require.True(t, ok, "unexpected response type %T", result)
+	raw, err := base64.StdEncoding.DecodeString(resp.Content)
+	require.NoError(t, err)
+	assert.Len(t, raw, resp.Size, "Size must describe the content actually returned")
+	return string(raw)
+}
+
+func TestHandleLogsDownload_IncludesCapturedCrash(t *testing.T) {
+	t.Parallel()
+
+	// This is the path a reported log comes from. A crash that kills the
+	// service exists only in the stderr capture, so if it does not travel
+	// here it does not reach a bug report at all.
+	env := logsRequestEnv(t, "{\"msg\":\"one\"}\n", "panic: misaligned address\n")
+
+	result, err := HandleLogsDownload(env)
+	require.NoError(t, err)
+
+	body := decodeLogResponse(t, result)
+	assert.Contains(t, body, "{\"msg\":\"one\"}")
+	assert.Contains(t, body, "panic: misaligned address")
+}
+
+func TestHandleLogsDownload_FitsTheUploadBudget(t *testing.T) {
+	t.Parallel()
+
+	// What this returns is what a client uploads, and the service rejects an
+	// oversized request outright — taking the crash report with it.
+	env := logsRequestEnv(t,
+		strings.Repeat("{\"filler\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}\n", 40000),
+		"panic: still here\n")
+
+	result, err := HandleLogsDownload(env)
+	require.NoError(t, err)
+
+	body := decodeLogResponse(t, result)
+	assert.LessOrEqual(t, len(body), config.LogBundleMaxBytes)
+	assert.Contains(t, body, "panic: still here", "trimming must not drop the crash")
+}
+
+func TestHandleLogsDownload_WorksWithoutACaptureFile(t *testing.T) {
+	t.Parallel()
+
+	// The capture only exists once the daemon has started the service.
+	env := logsRequestEnv(t, "log line one\n", "")
+
+	result, err := HandleLogsDownload(env)
+	require.NoError(t, err)
+
+	assert.Equal(t, "log line one\n", decodeLogResponse(t, result))
+}
+
+func TestHandleLogsDownload_ErrorsWhenTheLogIsMissing(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Settings").Return(platforms.Settings{LogDir: t.TempDir(), TempDir: t.TempDir()})
+
+	_, err := HandleLogsDownload(requests.RequestEnv{
+		Context: context.Background(), Platform: pl, IsLocal: true,
+	})
+
+	require.Error(t, err)
+}

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -58,10 +58,20 @@ const (
 	MediaDir             = "media"
 	CacheDir             = "cache"
 	LogUploadURL         = "https://logs.zaparoo.org/"
-	// LogUploadMaxBytes is the largest payload logs.zaparoo.org accepts. The
-	// log rotates at 1 MB, so a bundle has to be trimmed to leave room for the
-	// stderr capture or the upload is rejected outright.
-	LogUploadMaxBytes = 1 << 20
+	// LogUploadMaxBytes is the largest request logs.zaparoo.org accepts, and
+	// it is a decimal megabyte rather than a mebibyte. The limit applies to
+	// the whole request body, not the file part, so a bundle sent at exactly
+	// this size comes back 413 once multipart framing is added around it.
+	// Measured against the service: a 999,912 byte body is accepted and a
+	// 1,000,112 byte body is rejected.
+	LogUploadMaxBytes = 1_000_000
+	// LogUploadEnvelopeReserve is headroom for that framing. The boundary and
+	// part headers come to about 200 bytes; this is deliberately generous.
+	LogUploadEnvelopeReserve = 4 * 1024
+	// LogBundleMaxBytes is what a log bundle destined for upload may occupy.
+	// Both the TUI upload and the download API budget against this, because
+	// what the API hands back is what a client uploads.
+	LogBundleMaxBytes = LogUploadMaxBytes - LogUploadEnvelopeReserve
 	MinFreeDiskBytes  = 500 * 1024 * 1024 // 500 MB
 
 	// VersionFlagName is the flag that prints VersionLine and exits. The

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -34,10 +34,12 @@ func IsDevelopmentVersion() bool {
 }
 
 const (
-	AppName              = "zaparoo"
-	MediaDbFile          = "media.db"
-	UserDbFile           = "user.db"
-	LogFile              = "core.log"
+	AppName     = "zaparoo"
+	MediaDbFile = "media.db"
+	UserDbFile  = "user.db"
+	LogFile     = "core.log"
+	// StderrFile holds panics and runtime fatal errors, which never reach zerolog.
+	StderrFile           = "core.stderr.log"
 	PidFile              = "core.pid"
 	CfgFile              = "config.toml"
 	AuthFile             = "auth.toml"
@@ -56,7 +58,11 @@ const (
 	MediaDir             = "media"
 	CacheDir             = "cache"
 	LogUploadURL         = "https://logs.zaparoo.org/"
-	MinFreeDiskBytes     = 500 * 1024 * 1024 // 500 MB
+	// LogUploadMaxBytes is the largest payload logs.zaparoo.org accepts. The
+	// log rotates at 1 MB, so a bundle has to be trimmed to leave room for the
+	// stderr capture or the upload is rejected outright.
+	LogUploadMaxBytes = 1 << 20
+	MinFreeDiskBytes  = 500 * 1024 * 1024 // 500 MB
 
 	// VersionFlagName is the flag that prints VersionLine and exits. The
 	// self-update probe passes it to a binary it has just downloaded, so the

--- a/pkg/helpers/logbundle_test.go
+++ b/pkg/helpers/logbundle_test.go
@@ -1,0 +1,138 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package helpers_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func bundlePlatform(t *testing.T, logBody, stderrBody string) platforms.Platform {
+	t.Helper()
+
+	logDir := t.TempDir()
+	if logBody != "" {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(logDir, config.LogFile), []byte(logBody), 0o600))
+	}
+	if stderrBody != "" {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(logDir, config.StderrFile), []byte(stderrBody), 0o600))
+	}
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Settings").Return(platforms.Settings{LogDir: logDir, TempDir: logDir})
+	return pl
+}
+
+func TestReadLogBundle_AppendsStderr(t *testing.T) {
+	t.Parallel()
+
+	pl := bundlePlatform(t, "{\"msg\":\"one\"}\n", "panic: boom\n")
+
+	data, err := helpers.ReadLogBundle(pl, 0)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), "{\"msg\":\"one\"}")
+	assert.Contains(t, string(data), "panic: boom",
+		"the crash only exists in the stderr file, so it has to travel with the log")
+	assert.Contains(t, string(data), config.StderrFile, "the appended section should be labelled")
+}
+
+func TestReadLogBundle_OmitsEmptyStderr(t *testing.T) {
+	t.Parallel()
+
+	pl := bundlePlatform(t, "log line one\n", "   \n\n")
+
+	data, err := helpers.ReadLogBundle(pl, 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, "log line one\n", string(data),
+		"a stderr file holding only whitespace should add nothing")
+}
+
+func TestReadLogBundle_MissingStderrIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	pl := bundlePlatform(t, "log line one\n", "")
+
+	data, err := helpers.ReadLogBundle(pl, 0)
+	require.NoError(t, err, "the stderr file does not exist until the daemon starts the service")
+	assert.Equal(t, "log line one\n", string(data))
+}
+
+func TestReadLogBundle_KeepsCrashWhenLogFillsTheBudget(t *testing.T) {
+	t.Parallel()
+
+	// The log rotates at 1 MB, which is the whole upload budget, so a full log
+	// plus a crash would be rejected by the service and the report lost.
+	const limit = 4096
+	bigLog := strings.Repeat("{\"msg\":\"filler\"}\n", 1000)
+	pl := bundlePlatform(t, bigLog, "panic: misaligned address\n")
+
+	data, err := helpers.ReadLogBundle(pl, limit)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, len(data), limit, "the bundle must fit the upload limit")
+	assert.Contains(t, string(data), "panic: misaligned address",
+		"the crash must survive trimming; it is the reason for the bundle")
+	assert.Contains(t, string(data), "trimmed", "trimming should be stated in the output")
+	assert.Contains(t, string(data), "{\"msg\":\"filler\"}", "the newest log entries should be kept")
+}
+
+func TestReadLogBundle_TrimsOnWholeLines(t *testing.T) {
+	t.Parallel()
+
+	// A cut mid-line leaves a broken JSON entry that parsers trip over.
+	const limit = 512
+	body := strings.Repeat("{\"n\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}\n", 200)
+	pl := bundlePlatform(t, body, "")
+
+	data, err := helpers.ReadLogBundle(pl, limit)
+	require.NoError(t, err)
+
+	lines := bytes.Split(bytes.TrimRight(data, "\n"), []byte("\n"))
+	for _, line := range lines[1:] { // first line is the trim notice
+		assert.True(t, bytes.HasPrefix(line, []byte("{")) && bytes.HasSuffix(line, []byte("}")),
+			"every retained line should be whole, got %q", line)
+	}
+}
+
+func TestReadLogBundle_NoLimitKeepsEverything(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Repeat("x", 100000) + "\n"
+	pl := bundlePlatform(t, body, "")
+
+	data, err := helpers.ReadLogBundle(pl, 0)
+	require.NoError(t, err)
+
+	assert.Len(t, data, len(body), "an unlimited bundle should not trim, e.g. a copy to storage")
+}

--- a/pkg/helpers/logbundle_test.go
+++ b/pkg/helpers/logbundle_test.go
@@ -189,3 +189,41 @@ func TestReadLogBundle_DropsAPartialFirstLine(t *testing.T) {
 	assert.Empty(t, strings.TrimSpace(body[1]),
 		"nothing but the notice should survive when no whole line fits, got %q", body[1])
 }
+
+func TestReadLogBundle_CaptureSurvivesALogThatFillsTheBudget(t *testing.T) {
+	t.Parallel()
+
+	// The capture is budgeted before the log for this reason: the log rotates
+	// at the size of the whole upload budget, so budgeting the other way round
+	// lets a full log crowd out the crash — losing the one thing worth
+	// reporting, in the one case worth reporting it.
+	const limit = 2048
+	pl := bundlePlatform(t,
+		strings.Repeat("{\"filler\":\"aaaaaaaaaaaaaaaaaaaa\"}\n", 400),
+		"panic: the crash that matters\n")
+
+	data, err := helpers.ReadLogBundle(pl, limit)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, len(data), limit)
+	assert.Contains(t, string(data), "panic: the crash that matters")
+}
+
+func TestReadLogBundle_CaptureIsKeptWhenItIsOneLongLine(t *testing.T) {
+	t.Parallel()
+
+	// A capture is free text, not JSON, so it is trimmed by bytes rather than
+	// lines. Line-aligning it would discard a single-line capture whole, which
+	// an earlier attempt at this did.
+	const limit = 512
+	pl := bundlePlatform(t,
+		strings.Repeat("{\"a\":1}\n", 200),
+		strings.Repeat("X", 900)+"TAIL_OF_CAPTURE")
+
+	data, err := helpers.ReadLogBundle(pl, limit)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, len(data), limit)
+	assert.Contains(t, string(data), "TAIL_OF_CAPTURE",
+		"a single-line capture must be trimmed, not discarded")
+}

--- a/pkg/helpers/logbundle_test.go
+++ b/pkg/helpers/logbundle_test.go
@@ -136,3 +136,56 @@ func TestReadLogBundle_NoLimitKeepsEverything(t *testing.T) {
 
 	assert.Len(t, data, len(body), "an unlimited bundle should not trim, e.g. a copy to storage")
 }
+
+func TestReadLogBundle_NeverExceedsBudgetWhenStderrIsLarge(t *testing.T) {
+	t.Parallel()
+
+	// Regression test: the log budget was computed as
+	// maxBytes - separator - len(stderr), which goes negative once the capture
+	// is large. trimFront read a non-positive budget as "no limit" and returned
+	// the log untrimmed, so the bundle blew the cap in exactly the case the cap
+	// exists for — a full log plus a crash.
+	const limit = 300
+	pl := bundlePlatform(t,
+		strings.Repeat("{\"a\":1}\n", 500),
+		strings.Repeat("E", 400)+"\n")
+
+	data, err := helpers.ReadLogBundle(pl, limit)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, len(data), limit, "bundle must fit the limit however large the capture is")
+	assert.Contains(t, string(data), "EEEE", "the capture is appended last, so trimming must keep it")
+}
+
+func TestReadLogBundle_NeverExceedsTinyBudget(t *testing.T) {
+	t.Parallel()
+
+	// The trim notice itself is ~60 bytes, and it used to be returned whole
+	// even when it was longer than the entire budget.
+	pl := bundlePlatform(t, strings.Repeat("{\"a\":1}\n", 500), "")
+
+	for _, limit := range []int{1, 10, 20, 59, 80} {
+		data, err := helpers.ReadLogBundle(pl, limit)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, len(data), limit, "limit %d", limit)
+	}
+}
+
+func TestReadLogBundle_DropsAPartialFirstLine(t *testing.T) {
+	t.Parallel()
+
+	// A budget that lands inside a single long line has no whole line to keep.
+	// It used to return the tail of that line, which is a fragment: the output
+	// began mid-JSON and any parser reading it trips on the first entry.
+	oneLongLine := "{\"k\":\"" + strings.Repeat("v", 400) + "\"}\n"
+	pl := bundlePlatform(t, oneLongLine, "")
+
+	data, err := helpers.ReadLogBundle(pl, 120)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, len(data), 120)
+	body := strings.SplitN(string(data), "\n", 2)
+	require.Len(t, body, 2)
+	assert.Empty(t, strings.TrimSpace(body[1]),
+		"nothing but the notice should survive when no whole line fits, got %q", body[1])
+}

--- a/pkg/helpers/logging.go
+++ b/pkg/helpers/logging.go
@@ -104,12 +104,10 @@ func LogWriter() io.Writer {
 // the stderr file. Every path that hands a log to a user ships a single file,
 // so a crash has to travel inside that file or it does not travel at all.
 //
-// maxBytes of zero or less means no limit. Otherwise the stderr capture is kept
-// whole and the log is trimmed from the front to make room: the log rotates at
-// 1 MB, which is already the whole upload budget, so appending anything without
-// trimming would push the payload over and lose the upload entirely — taking
-// the crash report with it. Trimming the front keeps the most recent entries,
-// which are the ones next to the crash.
+// maxBytes of zero or less means no limit. Otherwise the capture is budgeted
+// first and the log takes what is left: the log rotates at 1 MB, which is
+// already the whole upload budget, so budgeting the other way round loses the
+// crash to a full log in exactly the case worth reporting.
 func ReadLogBundle(pl platforms.Platform, maxBytes int) ([]byte, error) {
 	logPath := filepath.Join(pl.Settings().LogDir, config.LogFile)
 	//nolint:gosec // Path is derived from platform settings and a fixed filename.
@@ -128,16 +126,30 @@ func ReadLogBundle(pl platforms.Platform, maxBytes int) ([]byte, error) {
 		// returning, so this is not an error for the caller.
 		stderrData = nil //nolint:nilerr // the log is usable without the stderr capture
 	}
+
+	unlimited := maxBytes <= 0
 	if len(bytes.TrimSpace(stderrData)) == 0 {
-		return trimLogFront(data, maxBytes), nil
+		if unlimited {
+			return data, nil
+		}
+		return trimLines(data, maxBytes), nil
 	}
 
 	separator := fmt.Sprintf("\n===== %s =====\n", config.StderrFile)
-	if maxBytes > 0 {
-		// The capture is the reason this function exists, so it gets its space
-		// first and the log takes what is left.
-		stderrData = trimLogFront(stderrData, maxBytes-len(separator))
-		data = trimLogFront(data, maxBytes-len(separator)-len(stderrData))
+	if !unlimited {
+		// One byte held back for the newline the log may need before the
+		// separator, so the assembled bundle cannot overshoot by one.
+		captureBudget := maxBytes - len(separator) - 1
+		if captureBudget <= 0 {
+			// No room for the capture and its label; the log alone is all that
+			// can be delivered within the limit.
+			return trimLines(data, maxBytes), nil
+		}
+		// Trimmed by bytes rather than lines: this is free text, not JSON, and
+		// half a panic is worth more than none. A capture that is one long line
+		// would otherwise be discarded whole.
+		stderrData = trimBytes(stderrData, captureBudget)
+		data = trimLines(data, maxBytes-len(separator)-len(stderrData)-1)
 	}
 
 	var buf bytes.Buffer
@@ -150,26 +162,46 @@ func ReadLogBundle(pl platforms.Platform, maxBytes int) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// trimLogFront drops whole lines from the start of data until it fits maxBytes,
-// and says how much it dropped. Cutting mid-line would leave a broken JSON
-// entry at the top of the log, which readers and any parser trip over.
-func trimLogFront(data []byte, maxBytes int) []byte {
-	if maxBytes <= 0 || len(data) <= maxBytes {
+// trimBytes keeps the last maxBytes bytes of data. A non-positive budget keeps
+// nothing: callers use it for a computed remainder, where zero means no room
+// rather than no limit.
+func trimBytes(data []byte, maxBytes int) []byte {
+	if maxBytes <= 0 {
+		return nil
+	}
+	if len(data) <= maxBytes {
+		return data
+	}
+	return data[len(data)-maxBytes:]
+}
+
+// trimLines drops whole lines from the start of data until it fits maxBytes,
+// and says how much it dropped. A non-positive budget keeps nothing.
+//
+// Cutting mid-line would leave a broken JSON entry that readers and parsers
+// trip over, so a budget that lands inside a single line keeps none of it.
+func trimLines(data []byte, maxBytes int) []byte {
+	if maxBytes <= 0 {
+		return nil
+	}
+	if len(data) <= maxBytes {
 		return data
 	}
 
 	notice := fmt.Sprintf("... %d earlier bytes trimmed to fit the upload limit ...\n",
 		len(data)-maxBytes)
-	budget := maxBytes - len(notice)
-	if budget <= 0 {
-		return []byte(notice)
+	if len(notice) > maxBytes {
+		// Too small to even say what happened, let alone carry content.
+		return nil
 	}
 
-	tail := data[len(data)-budget:]
-	if idx := bytes.IndexByte(tail, '\n'); idx >= 0 && idx+1 < len(tail) {
-		tail = tail[idx+1:]
+	tail := data[len(data)-(maxBytes-len(notice)):]
+	idx := bytes.IndexByte(tail, '\n')
+	if idx < 0 || idx+1 >= len(tail) {
+		// The budget lands inside one line; keeping any of it emits a fragment.
+		return []byte(notice)
 	}
-	return append([]byte(notice), tail...)
+	return append([]byte(notice), tail[idx+1:]...)
 }
 
 func CloseLogging() error {

--- a/pkg/helpers/logging.go
+++ b/pkg/helpers/logging.go
@@ -20,6 +20,7 @@
 package helpers
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -96,6 +97,81 @@ func LogWriter() io.Writer {
 
 // CloseLogging closes the active file logger so tests and shutdown paths can
 // safely remove the log directory on Windows.
+// ReadLogBundle returns the log file's contents with the service's captured
+// stderr appended when it holds anything, trimmed to fit maxBytes.
+//
+// Panics and Go runtime fatal errors never reach zerolog, so they exist only in
+// the stderr file. Every path that hands a log to a user ships a single file,
+// so a crash has to travel inside that file or it does not travel at all.
+//
+// maxBytes of zero or less means no limit. Otherwise the stderr capture is kept
+// whole and the log is trimmed from the front to make room: the log rotates at
+// 1 MB, which is already the whole upload budget, so appending anything without
+// trimming would push the payload over and lose the upload entirely — taking
+// the crash report with it. Trimming the front keeps the most recent entries,
+// which are the ones next to the crash.
+func ReadLogBundle(pl platforms.Platform, maxBytes int) ([]byte, error) {
+	logPath := filepath.Join(pl.Settings().LogDir, config.LogFile)
+	//nolint:gosec // Path is derived from platform settings and a fixed filename.
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read log file: %w", err)
+	}
+
+	stderrPath := filepath.Join(pl.Settings().LogDir, config.StderrFile)
+	//nolint:gosec // Path is derived from platform settings and a fixed filename.
+	stderrData, stderrErr := os.ReadFile(stderrPath)
+	if stderrErr != nil {
+		// A missing or unreadable stderr file is the normal case: it only
+		// exists once the service has been started by the daemon, and it is
+		// empty unless something crashed. The log itself is still worth
+		// returning, so this is not an error for the caller.
+		stderrData = nil //nolint:nilerr // the log is usable without the stderr capture
+	}
+	if len(bytes.TrimSpace(stderrData)) == 0 {
+		return trimLogFront(data, maxBytes), nil
+	}
+
+	separator := fmt.Sprintf("\n===== %s =====\n", config.StderrFile)
+	if maxBytes > 0 {
+		// The capture is the reason this function exists, so it gets its space
+		// first and the log takes what is left.
+		stderrData = trimLogFront(stderrData, maxBytes-len(separator))
+		data = trimLogFront(data, maxBytes-len(separator)-len(stderrData))
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.Write(data)
+	if len(data) > 0 && !bytes.HasSuffix(data, []byte("\n")) {
+		_ = buf.WriteByte('\n')
+	}
+	_, _ = buf.WriteString(separator)
+	_, _ = buf.Write(stderrData)
+	return buf.Bytes(), nil
+}
+
+// trimLogFront drops whole lines from the start of data until it fits maxBytes,
+// and says how much it dropped. Cutting mid-line would leave a broken JSON
+// entry at the top of the log, which readers and any parser trip over.
+func trimLogFront(data []byte, maxBytes int) []byte {
+	if maxBytes <= 0 || len(data) <= maxBytes {
+		return data
+	}
+
+	notice := fmt.Sprintf("... %d earlier bytes trimmed to fit the upload limit ...\n",
+		len(data)-maxBytes)
+	budget := maxBytes - len(notice)
+	if budget <= 0 {
+		return []byte(notice)
+	}
+
+	tail := data[len(data)-budget:]
+	if idx := bytes.IndexByte(tail, '\n'); idx >= 0 && idx+1 < len(tail) {
+		tail = tail[idx+1:]
+	}
+	return append([]byte(notice), tail...)
+}
+
 func CloseLogging() error {
 	logMu.Lock()
 	defer logMu.Unlock()

--- a/pkg/readers/libnfc/libnfc.go
+++ b/pkg/readers/libnfc/libnfc.go
@@ -307,9 +307,24 @@ func (r *Reader) Metadata() readers.DriverMetadata {
 	switch r.mode {
 	case modeACR122Only:
 		return readers.DriverMetadata{
-			ID:                "libnfcacr122",
-			DefaultEnabled:    true,
-			DefaultAutoDetect: true,
+			ID:             "libnfcacr122",
+			DefaultEnabled: true,
+			// Auto-detect is off by default because Detect calls
+			// nfc.ListDevices, which enumerates the USB bus through libusb.
+			// On the reader manager's 1 Hz tick that ran once a second on every
+			// device, whether or not an ACR122 was attached, and enumerating
+			// while the bus changes under it killed the service outright: on a
+			// MiSTer, unplugging a USB reader produced
+			//
+			//   panic: member access within misaligned address 0x327ffc4 for
+			//   type 'struct libusb_context', which requires 8 byte alignment
+			//
+			// which is a hard abort from the cgo side, with no Go panic and
+			// nothing in the log. rs232barcode and mqtt already ship
+			// enabled-but-not-auto-detected for the milder version of this
+			// trade-off; an ACR122 owner opts in with a readers.connect entry
+			// or readers.drivers.libnfcacr122.auto_detect = true.
+			DefaultAutoDetect: false,
 			Description:       "LibNFC ACR122 USB NFC reader",
 		}
 	case modeLegacyUART:

--- a/pkg/readers/libnfc/libnfc_test.go
+++ b/pkg/readers/libnfc/libnfc_test.go
@@ -100,7 +100,11 @@ func TestMetadata(t *testing.T) {
 		assert.Equal(t, "libnfcacr122", metadata.ID)
 		assert.Equal(t, "LibNFC ACR122 USB NFC reader", metadata.Description)
 		assert.True(t, metadata.DefaultEnabled)
-		assert.True(t, metadata.DefaultAutoDetect)
+		// Auto-detect stays off by default: Detect enumerates the USB bus
+		// through libusb, and doing that on the 1 Hz tick while the bus changes
+		// aborted the process on ARM with a misaligned libusb_context access.
+		assert.False(t, metadata.DefaultAutoDetect,
+			"ACR122 auto-detect must stay opt-in; enabling it enumerates libusb every second on every device")
 	})
 
 	t.Run("legacy uart mode", func(t *testing.T) {

--- a/pkg/readers/pn532/detectsummary_test.go
+++ b/pkg/readers/pn532/detectsummary_test.go
@@ -1,0 +1,145 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// summary guard is package-level state
+//
+//nolint:paralleltest // captureDebugLog swaps the global logger, and the
+package pn532
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ZaparooProject/go-pn532/detection"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetDetectSummary clears the package-level guard so each test starts from a
+// known state and does not inherit another test's last summary.
+func resetDetectSummary(t *testing.T) {
+	t.Helper()
+	detectSummaryMu.Lock()
+	lastDetectSummary = ""
+	detectSummaryMu.Unlock()
+	t.Cleanup(func() {
+		detectSummaryMu.Lock()
+		lastDetectSummary = ""
+		detectSummaryMu.Unlock()
+	})
+}
+
+func TestLogDetectionSummary_LogsOncePerChange(t *testing.T) {
+	// The reader manager calls Detect once a second. Logging every call would
+	// bury the log, so the summary is the thing that makes an info-level
+	// report affordable at all: an unchanged picture must stay silent.
+	resetDetectSummary(t)
+	buf := captureDebugLog(t)
+
+	ports := []string{"/dev/ttyUSB0"}
+	devices := []detection.DeviceInfo{{Transport: "uart", Path: "/dev/ttyUSB0"}}
+
+	for range 5 {
+		logDetectionSummary(ports, nil, devices, nil, nil)
+	}
+
+	entries := decodeLogEntries(t, buf)
+	require.Len(t, entries, 1, "five identical ticks should produce one line")
+	assert.Equal(t, "PN532 auto-detect", entries[0].Message)
+}
+
+func TestLogDetectionSummary_LogsAgainWhenPortsChange(t *testing.T) {
+	// Plugging or unplugging a port is exactly what a user needs to see.
+	resetDetectSummary(t)
+	buf := captureDebugLog(t)
+
+	logDetectionSummary([]string{"/dev/ttyUSB0"}, nil, nil, nil, nil)
+	logDetectionSummary([]string{"/dev/ttyUSB0", "/dev/ttyUSB1"}, nil, nil, nil, nil)
+	logDetectionSummary([]string{"/dev/ttyUSB0"}, nil, nil, nil, nil)
+
+	assert.Len(t, decodeLogEntries(t, buf), 3, "each change should be reported")
+}
+
+func TestLogDetectionSummary_IgnoresOrderingOfPortsAndIgnores(t *testing.T) {
+	// The ignore list is built from map iteration and the enumerated ports
+	// arrive in directory order. Without sorting, a stable bus would appear to
+	// change on every tick and the log would fill up again.
+	resetDetectSummary(t)
+	buf := captureDebugLog(t)
+
+	logDetectionSummary(
+		[]string{"/dev/ttyUSB0", "/dev/ttyUSB1"},
+		[]string{"/dev/ttyACM0", "/dev/ttyUSB9"}, nil, nil, nil)
+	logDetectionSummary(
+		[]string{"/dev/ttyUSB1", "/dev/ttyUSB0"},
+		[]string{"/dev/ttyUSB9", "/dev/ttyACM0"}, nil, nil, nil)
+
+	assert.Len(t, decodeLogEntries(t, buf), 1, "reordering alone is not a change")
+}
+
+func TestLogDetectionSummary_ReportsEnumerationFailure(t *testing.T) {
+	// An enumeration failure leaves the port list empty, which reads exactly
+	// like a bus with no serial ports on it. Without the error surfaced, the
+	// summary cannot tell those apart, which is the ambiguity it exists to
+	// remove.
+	resetDetectSummary(t)
+	buf := captureDebugLog(t)
+
+	logDetectionSummary(nil, nil, nil, errors.New("permission denied"), nil)
+
+	require.Len(t, decodeLogEntries(t, buf), 1)
+	assert.Contains(t, buf.String(), "enumeration_error")
+	assert.Contains(t, buf.String(), "permission denied")
+}
+
+func TestLogDetectionSummary_EnumerationFailureIsPartOfTheSummary(t *testing.T) {
+	// An enumeration that starts failing is a change worth reporting even
+	// though every visible list stays empty.
+	resetDetectSummary(t)
+	buf := captureDebugLog(t)
+
+	logDetectionSummary(nil, nil, nil, nil, nil)
+	logDetectionSummary(nil, nil, nil, errors.New("permission denied"), nil)
+
+	assert.Len(t, decodeLogEntries(t, buf), 2,
+		"an enumeration failure appearing is a state change")
+}
+
+func TestLogDetectionSummary_OmitsExpectedDetectionMiss(t *testing.T) {
+	// "no devices found" is the steady state on a machine with no reader, not
+	// an error worth showing a user.
+	resetDetectSummary(t)
+	buf := captureDebugLog(t)
+
+	logDetectionSummary([]string{"/dev/ttyUSB0"}, nil, nil, nil, detection.ErrNoDevicesFound)
+
+	require.Len(t, decodeLogEntries(t, buf), 1)
+	assert.NotContains(t, buf.String(), "error",
+		"an expected miss should not be dressed up as an error")
+}
+
+func TestLogDetectionSummary_ReportsUnexpectedDetectionError(t *testing.T) {
+	resetDetectSummary(t)
+	buf := captureDebugLog(t)
+
+	logDetectionSummary([]string{"/dev/ttyUSB0"}, nil, nil, nil, errors.New("bus exploded"))
+
+	require.Len(t, decodeLogEntries(t, buf), 1)
+	assert.Contains(t, buf.String(), "bus exploded")
+}

--- a/pkg/readers/pn532/pn532.go
+++ b/pkg/readers/pn532/pn532.go
@@ -629,9 +629,6 @@ func (*Reader) Detect(connected []string) string {
 	// probe found nothing at all. DetectAll does not expose the candidates it
 	// tried; see https://github.com/ZaparooProject/go-pn532/issues/94.
 	currentPorts, enumErr := helpers.GetSerialDeviceList()
-	if enumErr != nil {
-		log.Debug().Err(enumErr).Msg("PN532: failed to enumerate serial ports")
-	}
 
 	// Try to detect PN532 devices
 	opts := newDetectionOptions(ignorePaths)
@@ -639,7 +636,7 @@ func (*Reader) Detect(connected []string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), quickDetectionTimeout)
 	defer cancel()
 	devices, err := detection.DetectAll(ctx, &opts)
-	logDetectionSummary(currentPorts, ignorePaths, devices, err)
+	logDetectionSummary(currentPorts, ignorePaths, devices, enumErr, err)
 	if err != nil {
 		if isExpectedDetectionMiss(err) {
 			log.Trace().Msg("no PN532 devices found during detection")
@@ -737,7 +734,11 @@ var (
 // identical. This logs at info, because someone reporting a reader that is not
 // detected has no reason to have enabled debug logging first, and only when the
 // picture changes, so the 1 Hz tick still costs a handful of lines per session.
-func logDetectionSummary(ports, ignored []string, devices []detection.DeviceInfo, detectErr error) {
+func logDetectionSummary(
+	ports, ignored []string,
+	devices []detection.DeviceInfo,
+	enumErr, detectErr error,
+) {
 	// Sorted copies: ignored is built from map iteration, and the enumerated
 	// ports arrive in directory order, so an unsorted summary would report a
 	// change on ticks where nothing actually changed.
@@ -752,10 +753,11 @@ func logDetectionSummary(ports, ignored []string, devices []detection.DeviceInfo
 	}
 	slices.Sort(detected)
 
-	summary := fmt.Sprintf("ports:%s ignored:%s detected:%s err:%v",
+	summary := fmt.Sprintf("ports:%s ignored:%s detected:%s enum_err:%v err:%v",
 		strings.Join(sortedPorts, ","),
 		strings.Join(sortedIgnored, ","),
 		strings.Join(detected, ","),
+		enumErr,
 		detectErr)
 
 	detectSummaryMu.Lock()
@@ -767,6 +769,11 @@ func logDetectionSummary(ports, ignored []string, devices []detection.DeviceInfo
 	}
 
 	event := log.Info().Strs("ports", sortedPorts)
+	if enumErr != nil {
+		// Without this an enumeration failure is indistinguishable from a bus
+		// with no serial ports on it: both report an empty port list.
+		event = event.AnErr("enumeration_error", enumErr)
+	}
 	if len(sortedIgnored) > 0 {
 		event = event.Strs("ignored", sortedIgnored)
 	}

--- a/pkg/readers/pn532/pn532.go
+++ b/pkg/readers/pn532/pn532.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -622,12 +623,23 @@ func (*Reader) Detect(connected []string) string {
 	// allow mock-based testing.
 	log.Trace().Msgf("PN532: ignoring paths: %v", ignorePaths)
 
+	// Enumerate before probing rather than after. The port list is needed for
+	// the failed-probe bookkeeping below either way, and reading it up front
+	// means the detection summary can report what was on the bus even when the
+	// probe found nothing at all. DetectAll does not expose the candidates it
+	// tried; see https://github.com/ZaparooProject/go-pn532/issues/94.
+	currentPorts, enumErr := helpers.GetSerialDeviceList()
+	if enumErr != nil {
+		log.Debug().Err(enumErr).Msg("PN532: failed to enumerate serial ports")
+	}
+
 	// Try to detect PN532 devices
 	opts := newDetectionOptions(ignorePaths)
 
 	ctx, cancel := context.WithTimeout(context.Background(), quickDetectionTimeout)
 	defer cancel()
 	devices, err := detection.DetectAll(ctx, &opts)
+	logDetectionSummary(currentPorts, ignorePaths, devices, err)
 	if err != nil {
 		if isExpectedDetectionMiss(err) {
 			log.Trace().Msg("no PN532 devices found during detection")
@@ -649,10 +661,6 @@ func (*Reader) Detect(connected []string) string {
 	// Track which enumerated ports were NOT detected as PN532 devices.
 	// Store the device file's ModTime so we can detect device swaps at
 	// the same path (the file is recreated with a new ModTime on replug).
-	// DetectAll currently does not expose candidate paths it tried; see
-	// https://github.com/ZaparooProject/go-pn532/issues/94. Until then,
-	// enumerate serial ports here to infer failed probe paths.
-	currentPorts, enumErr := helpers.GetSerialDeviceList()
 	if enumErr == nil {
 		detectedPaths := make(map[string]bool, len(devices))
 		for _, device := range devices {
@@ -710,6 +718,65 @@ func (*Reader) Detect(connected []string) string {
 	// All detected devices are already in use
 	log.Trace().Msg("pn532: all detected devices are already connected")
 	return ""
+}
+
+// Detection summary state. This is package level because SupportedReaders
+// builds a fresh Reader for every auto-detect tick, so nothing kept on the
+// instance survives into the next one.
+var (
+	detectSummaryMu   syncutil.Mutex
+	lastDetectSummary string
+)
+
+// logDetectionSummary reports the state of PN532 auto-detect once per change.
+//
+// A user log of a reader that auto-detect never found had nothing in it to work
+// from: the ports Core enumerated, the paths it had been told to skip, and what
+// the probe returned were all trace-level or absent, so "the reader was never
+// enumerated" and "the reader was enumerated and did not answer" looked
+// identical. This logs at info, because someone reporting a reader that is not
+// detected has no reason to have enabled debug logging first, and only when the
+// picture changes, so the 1 Hz tick still costs a handful of lines per session.
+func logDetectionSummary(ports, ignored []string, devices []detection.DeviceInfo, detectErr error) {
+	// Sorted copies: ignored is built from map iteration, and the enumerated
+	// ports arrive in directory order, so an unsorted summary would report a
+	// change on ticks where nothing actually changed.
+	sortedPorts := slices.Clone(ports)
+	slices.Sort(sortedPorts)
+	sortedIgnored := slices.Clone(ignored)
+	slices.Sort(sortedIgnored)
+
+	detected := make([]string, 0, len(devices))
+	for _, d := range devices {
+		detected = append(detected, d.Transport+":"+d.Path)
+	}
+	slices.Sort(detected)
+
+	summary := fmt.Sprintf("ports:%s ignored:%s detected:%s err:%v",
+		strings.Join(sortedPorts, ","),
+		strings.Join(sortedIgnored, ","),
+		strings.Join(detected, ","),
+		detectErr)
+
+	detectSummaryMu.Lock()
+	changed := summary != lastDetectSummary
+	lastDetectSummary = summary
+	detectSummaryMu.Unlock()
+	if !changed {
+		return
+	}
+
+	event := log.Info().Strs("ports", sortedPorts)
+	if len(sortedIgnored) > 0 {
+		event = event.Strs("ignored", sortedIgnored)
+	}
+	if len(detected) > 0 {
+		event = event.Strs("detected", detected)
+	}
+	if detectErr != nil && !isExpectedDetectionMiss(detectErr) {
+		event = event.Err(detectErr)
+	}
+	event.Msg("PN532 auto-detect")
 }
 
 func isExpectedDetectionMiss(err error) bool {

--- a/pkg/service/autodetect.go
+++ b/pkg/service/autodetect.go
@@ -21,6 +21,7 @@ package service
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -29,21 +30,55 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/jonboulle/clockwork"
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	// failedPathInitialBackoff and failedPathMaxBackoff bound how long a path
+	// that failed to open is kept out of auto-detect.
+	failedPathInitialBackoff = 2 * time.Second
+	failedPathMaxBackoff     = 60 * time.Second
+)
+
+// failedPath suppresses a device path that failed to open, temporarily.
+//
+// It used to suppress it permanently: nothing cleared an entry for a path that
+// had never connected, so one failed open — a port still settling at boot, a
+// momentary busy or permission error — ended auto-detect for that device until
+// Core was restarted. The suppression only exists to stop a 1 Hz retry storm
+// against a device that is not answering, which a growing backoff does just as
+// well without the dead end.
+type failedPath struct {
+	retryAt time.Time
+	backoff time.Duration
+}
+
+// AutoDetector tracks auto-detected readers by device path.
+//
+// A path is the identity here, so an empty one is not tracked at all. Some
+// drivers return a connection string with no path — libnfc's ACR122 fallback
+// returns the bare "libnfcauto:" — and keying either map on "" made one
+// pathless driver's state apply to every other pathless driver: one failing to
+// open would suppress the rest, and the shared entry surfaced in the detection
+// summary as a suppressed path that no device owned.
 type AutoDetector struct {
+	clock                clockwork.Clock
 	lastLogTime          time.Time
 	connected            map[string]bool
-	failed               map[string]bool
+	failed               map[string]failedPath
 	lastDetectionSummary string
 	mu                   syncutil.RWMutex
 }
 
-func NewAutoDetector(_ *config.Instance) *AutoDetector {
+func NewAutoDetector(clock clockwork.Clock) *AutoDetector {
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
 	return &AutoDetector{
+		clock:     clock,
 		connected: make(map[string]bool),
-		failed:    make(map[string]bool),
+		failed:    make(map[string]failedPath),
 	}
 }
 
@@ -62,7 +97,7 @@ func (ad *AutoDetector) DetectReaders(
 	ad.updateConnectedFromReaders(connectedReaders)
 
 	var detectedDevices []string
-	var detectionErrors []string
+	var skippedDrivers []string
 
 	for _, reader := range supportedReaders {
 		metadata := reader.Metadata()
@@ -79,11 +114,12 @@ func (ad *AutoDetector) DetectReaders(
 		}
 
 		if !cfg.IsReaderEnabled(driver, config.ReaderEnableContextAutoDetect) {
+			skippedDrivers = append(skippedDrivers, metadata.ID)
 			closeUnused()
 			continue
 		}
 
-		failedPaths := ad.getFailedPaths()
+		failedPaths := ad.suppressedPaths()
 
 		// Build exclude list from connected reader paths and failed paths.
 		// The exclude list uses "driver:path" format for compatibility with Detect()
@@ -139,41 +175,55 @@ func (ad *AutoDetector) DetectReaders(
 		}
 	}
 
-	ad.logDetectionResults(detectedDevices, detectionErrors)
+	ad.logDetectionResults(detectedDevices, skippedDrivers)
 
 	return nil
 }
 
-// logDetectionResults provides intelligent logging that only logs when detection state changes
-// or when a heartbeat is needed to show auto-detect is still active
-func (ad *AutoDetector) logDetectionResults(detectedDevices, _ []string) {
-	// Create a summary of the current detection state (only track what's relevant for changes)
-	summary := fmt.Sprintf("new_detected:%d total_failed:%d",
-		len(detectedDevices), len(ad.failed))
+// logDetectionResults reports what auto-detect did, once per change rather than
+// once per tick.
+//
+// It logs at info because this is the only account of an auto-detect that found
+// nothing, and a user reporting "my reader is not detected" has no reason to
+// have turned debug logging on first. The 1 Hz tick makes that affordable only
+// because the summary is stable while the hardware is: a run that keeps finding
+// the same nothing logs one line and then stays quiet until something changes.
+func (ad *AutoDetector) logDetectionResults(detectedDevices, skippedDrivers []string) {
+	suppressed := ad.suppressedPaths()
 
-	// Check if we should log (state changed or heartbeat timeout)
+	summary := fmt.Sprintf("detected:%s skipped:%s suppressed:%s",
+		strings.Join(detectedDevices, ","),
+		strings.Join(skippedDrivers, ","),
+		strings.Join(suppressed, ","))
+
 	const heartbeatInterval = 30 * time.Second
 	stateChanged := summary != ad.lastDetectionSummary
-	heartbeatTime := ad.lastLogTime.IsZero() || time.Since(ad.lastLogTime) > heartbeatInterval
-
-	if stateChanged || heartbeatTime {
-		if len(detectedDevices) > 0 {
-			log.Debug().
-				Strs("new_devices_detected", detectedDevices).
-				Msg("auto-detect found new devices available for connection")
-		} else if heartbeatTime {
-			if len(ad.failed) > 0 {
-				log.Trace().
-					Int("total_failed_attempts", len(ad.failed)).
-					Msg("auto-detect active: no new devices found")
-			} else {
-				log.Trace().Msg("auto-detect active: no devices detected")
-			}
-		}
-
-		ad.lastDetectionSummary = summary
-		ad.lastLogTime = time.Now()
+	heartbeatTime := ad.lastLogTime.IsZero() || ad.clock.Since(ad.lastLogTime) > heartbeatInterval
+	if !stateChanged && !heartbeatTime {
+		return
 	}
+
+	if stateChanged {
+		event := log.Info()
+		if len(detectedDevices) > 0 {
+			event = event.Strs("detected", detectedDevices)
+		}
+		if len(skippedDrivers) > 0 {
+			event = event.Strs("skipped_drivers", skippedDrivers)
+		}
+		if len(suppressed) > 0 {
+			event = event.Strs("suppressed_paths", suppressed)
+		}
+		event.Msg("reader auto-detect result changed")
+	} else {
+		log.Trace().
+			Int("detected", len(detectedDevices)).
+			Int("suppressed", len(suppressed)).
+			Msg("reader auto-detect still active")
+	}
+
+	ad.lastDetectionSummary = summary
+	ad.lastLogTime = ad.clock.Now()
 }
 
 func (ad *AutoDetector) connectReader(
@@ -217,7 +267,7 @@ func (ad *AutoDetector) updateConnectedFromReaders(connectedReaders []readers.Re
 
 	ad.connected = make(map[string]bool)
 	for _, r := range connectedReaders {
-		if r != nil {
+		if r != nil && r.Path() != "" {
 			ad.connected[r.Path()] = true
 		}
 	}
@@ -230,6 +280,9 @@ func (ad *AutoDetector) isConnected(path string) bool {
 }
 
 func (ad *AutoDetector) setConnected(path string) {
+	if path == "" {
+		return
+	}
 	ad.mu.Lock()
 	defer ad.mu.Unlock()
 	ad.connected[path] = true
@@ -241,20 +294,41 @@ func (ad *AutoDetector) ClearPath(path string) {
 	delete(ad.connected, path)
 }
 
+// setFailed backs a path off after a failed open, doubling the wait each time
+// up to failedPathMaxBackoff. The entry is kept once the wait expires so a path
+// that keeps failing keeps escalating instead of restarting at the short wait.
 func (ad *AutoDetector) setFailed(path string) {
+	if path == "" {
+		return
+	}
 	ad.mu.Lock()
 	defer ad.mu.Unlock()
-	ad.failed[path] = true
+
+	entry := ad.failed[path]
+	if entry.backoff == 0 {
+		entry.backoff = failedPathInitialBackoff
+	} else {
+		entry.backoff = min(entry.backoff*2, failedPathMaxBackoff)
+	}
+	entry.retryAt = ad.clock.Now().Add(entry.backoff)
+	ad.failed[path] = entry
 }
 
-func (ad *AutoDetector) getFailedPaths() []string {
+// suppressedPaths returns the paths still inside their failure backoff, sorted
+// so the detection summary a caller builds from them does not flap on map
+// iteration order.
+func (ad *AutoDetector) suppressedPaths() []string {
 	ad.mu.RLock()
 	defer ad.mu.RUnlock()
 
+	now := ad.clock.Now()
 	paths := make([]string, 0, len(ad.failed))
-	for path := range ad.failed {
-		paths = append(paths, path)
+	for path, entry := range ad.failed {
+		if now.Before(entry.retryAt) {
+			paths = append(paths, path)
+		}
 	}
+	slices.Sort(paths)
 	return paths
 }
 

--- a/pkg/service/autodetect_test.go
+++ b/pkg/service/autodetect_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -36,8 +37,7 @@ import (
 func TestNewAutoDetector(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
-	ad := NewAutoDetector(cfg)
+	ad := NewAutoDetector(nil)
 
 	require.NotNil(t, ad)
 	assert.NotNil(t, ad.connected, "connected map should be initialized")
@@ -76,14 +76,14 @@ func TestAutoDetector_FailedPathOperations(t *testing.T) {
 	ad.setFailed("/dev/ttyUSB1")
 
 	// Get all failed paths
-	failed := ad.getFailedPaths()
+	failed := ad.suppressedPaths()
 	assert.Len(t, failed, 2)
 	assert.Contains(t, failed, "/dev/ttyUSB0")
 	assert.Contains(t, failed, "/dev/ttyUSB1")
 
 	// Clear failed path
 	ad.ClearFailedPath("/dev/ttyUSB0")
-	failed = ad.getFailedPaths()
+	failed = ad.suppressedPaths()
 	assert.Len(t, failed, 1)
 	assert.Contains(t, failed, "/dev/ttyUSB1")
 }
@@ -97,13 +97,13 @@ func TestAutoDetector_FailedPathsAreSharedAcrossDrivers(t *testing.T) {
 	// no driver should retry it until it's cleared
 	ad.setFailed("/dev/ttyUSB0")
 
-	failed := ad.getFailedPaths()
+	failed := ad.suppressedPaths()
 	assert.Len(t, failed, 1)
 	assert.Contains(t, failed, "/dev/ttyUSB0")
 
 	// Clear and verify
 	ad.ClearFailedPath("/dev/ttyUSB0")
-	failed = ad.getFailedPaths()
+	failed = ad.suppressedPaths()
 	assert.Empty(t, failed)
 }
 
@@ -414,7 +414,7 @@ func TestAutoDetector_DetectReaders_OpenError(t *testing.T) {
 
 	require.NoError(t, err) // DetectReaders doesn't return errors for individual failures
 	// Path should be marked as failed
-	failed := ad.getFailedPaths()
+	failed := ad.suppressedPaths()
 	assert.Contains(t, failed, "/dev/ttyUSB0")
 	// Regression: reader must be closed when Open fails, not left running.
 	mockReader.AssertCalled(t, "Close")
@@ -449,7 +449,7 @@ func TestAutoDetector_DetectReaders_ConnectedReturnsFalse(t *testing.T) {
 
 	require.NoError(t, err)
 	// Path should be marked as failed
-	failed := ad.getFailedPaths()
+	failed := ad.suppressedPaths()
 	assert.Contains(t, failed, "/dev/ttyUSB0")
 	mockReader.AssertCalled(t, "Close")
 }
@@ -600,8 +600,8 @@ func TestAutoDetector_LogDetectionResults_WithFailedAttempts(t *testing.T) {
 	// Should have logged (heartbeat triggered on first call)
 	assert.False(t, ad.lastLogTime.IsZero())
 
-	// Summary should include failed count
-	assert.Contains(t, ad.lastDetectionSummary, "total_failed:2")
+	// Summary should name the paths held out of detection
+	assert.Contains(t, ad.lastDetectionSummary, "suppressed:/dev/ttyUSB0,/dev/ttyUSB1")
 }
 
 func TestAutoDetector_ConcurrentAccess(t *testing.T) {
@@ -629,7 +629,7 @@ func TestAutoDetector_ConcurrentAccess(t *testing.T) {
 	go func() {
 		for range 100 {
 			_ = ad.isConnected("/dev/ttyUSB0")
-			_ = ad.getFailedPaths()
+			_ = ad.suppressedPaths()
 		}
 		done <- struct{}{}
 	}()
@@ -710,7 +710,7 @@ func TestAutoDetector_DetectReaders_ClearsFailedOnSuccess(t *testing.T) {
 
 	// Pre-mark as failed
 	ad.setFailed("/dev/ttyUSB0")
-	require.Len(t, ad.getFailedPaths(), 1)
+	require.Len(t, ad.suppressedPaths(), 1)
 
 	mockReader := mocks.NewMockReader()
 	mockReader.On("Metadata").Return(readers.DriverMetadata{
@@ -743,7 +743,7 @@ func TestAutoDetector_DetectReaders_ClearsFailedOnSuccess(t *testing.T) {
 
 	require.NoError(t, err)
 	// Failed should be cleared after successful connection
-	assert.Empty(t, ad.getFailedPaths())
+	assert.Empty(t, ad.suppressedPaths())
 
 	st.StopService()
 	close(st.Notifications)
@@ -759,7 +759,7 @@ func TestAutoDetector_GetFailedPaths_AnyPath(t *testing.T) {
 	ad.setFailed("some-path")
 	ad.setFailed("/dev/ttyUSB0")
 
-	failed := ad.getFailedPaths()
+	failed := ad.suppressedPaths()
 	assert.Len(t, failed, 2)
 	assert.Contains(t, failed, "some-path")
 	assert.Contains(t, failed, "/dev/ttyUSB0")
@@ -898,7 +898,7 @@ func TestAutoDetector_ReconnectAfterUnplugReplug(t *testing.T) {
 
 	// Simulate a failed connection attempt (e.g., device briefly unavailable during plug-in)
 	ad.setFailed(path)
-	require.Contains(t, ad.getFailedPaths(), path, "path should be in failed list after failed connection")
+	require.Contains(t, ad.suppressedPaths(), path, "path should be in failed list after failed connection")
 
 	// Simulate reader disconnect (unplug) - this is what readers.go does when pruning
 	// disconnected readers. Previously this used ClearFailedConnection(readerID) with
@@ -907,13 +907,13 @@ func TestAutoDetector_ReconnectAfterUnplugReplug(t *testing.T) {
 	ad.ClearFailedPath(path)
 
 	// Verify the path is cleared from failed list
-	assert.NotContains(t, ad.getFailedPaths(), path,
+	assert.NotContains(t, ad.suppressedPaths(), path,
 		"path should be cleared from failed list after disconnect, allowing reconnection on replug")
 
 	// Simulate replug - a new detection cycle should be able to try this path again
 	// If the bug were present, the path would still be in the failed list and
 	// auto-detect would skip it forever
-	failedPaths := ad.getFailedPaths()
+	failedPaths := ad.suppressedPaths()
 	for _, p := range failedPaths {
 		if p == path {
 			t.Fatal("REGRESSION: path still in failed list after disconnect - reader would never reconnect")
@@ -999,4 +999,95 @@ func TestAutoDetector_ExcludeListFormat_Regression(t *testing.T) {
 	st.StopService()
 	close(st.Notifications)
 	<-done
+}
+
+func TestAutoDetector_FailedPathBackoffExpires(t *testing.T) {
+	t.Parallel()
+
+	// Regression test: a path that had never connected was excluded from
+	// auto-detect for the whole process lifetime, so one failed open at boot
+	// ended auto-detect for that device until Core restarted. See #1400.
+	clock := clockwork.NewFakeClock()
+	ad := NewAutoDetector(clock)
+
+	ad.setFailed("/dev/ttyUSB0")
+	assert.Equal(t, []string{"/dev/ttyUSB0"}, ad.suppressedPaths())
+
+	clock.Advance(failedPathInitialBackoff)
+	assert.Empty(t, ad.suppressedPaths(), "the path must be retried once its backoff expires")
+}
+
+func TestAutoDetector_FailedPathBackoffEscalates(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	ad := NewAutoDetector(clock)
+
+	ad.setFailed("/dev/ttyUSB0")
+	clock.Advance(failedPathInitialBackoff)
+	require.Empty(t, ad.suppressedPaths())
+
+	// A second failure waits longer than the first, so a port that never
+	// answers is not retried every tick forever.
+	ad.setFailed("/dev/ttyUSB0")
+	clock.Advance(failedPathInitialBackoff)
+	assert.Equal(t, []string{"/dev/ttyUSB0"}, ad.suppressedPaths())
+
+	clock.Advance(failedPathInitialBackoff)
+	assert.Empty(t, ad.suppressedPaths())
+}
+
+func TestAutoDetector_FailedPathBackoffIsCapped(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	ad := NewAutoDetector(clock)
+
+	for range 20 {
+		ad.setFailed("/dev/ttyUSB0")
+		clock.Advance(failedPathMaxBackoff)
+	}
+
+	ad.setFailed("/dev/ttyUSB0")
+	clock.Advance(failedPathMaxBackoff)
+	assert.Empty(t, ad.suppressedPaths(), "backoff must not grow past failedPathMaxBackoff")
+}
+
+func TestAutoDetector_IgnoresPathlessConnectionStrings(t *testing.T) {
+	t.Parallel()
+
+	// Regression test: libnfc's ACR122 fallback returns the bare
+	// "libnfcauto:", so the path is empty. Recording that made one pathless
+	// driver's failure apply to every other pathless driver, and put an entry
+	// no device owned into the detection summary. Observed on a MiSTer as
+	// suppressed_paths:[""].
+	clock := clockwork.NewFakeClock()
+	ad := NewAutoDetector(clock)
+
+	ad.setFailed("")
+	assert.Empty(t, ad.suppressedPaths(), "an empty path is not a device to suppress")
+
+	ad.setConnected("")
+	assert.False(t, ad.isConnected(""),
+		"an empty path must never count as connected, or it suppresses other pathless drivers")
+
+	// A real path alongside it still behaves normally.
+	ad.setFailed("/dev/ttyUSB0")
+	assert.Equal(t, []string{"/dev/ttyUSB0"}, ad.suppressedPaths())
+}
+
+func TestAutoDetector_UpdateConnectedSkipsPathlessReaders(t *testing.T) {
+	t.Parallel()
+
+	ad := NewAutoDetector(nil)
+
+	pathless := mocks.NewMockReader()
+	pathless.On("Path").Return("")
+	withPath := mocks.NewMockReader()
+	withPath.On("Path").Return("/dev/ttyUSB0")
+
+	ad.updateConnectedFromReaders([]readers.Reader{pathless, withPath})
+
+	assert.False(t, ad.isConnected(""))
+	assert.True(t, ad.isConnected("/dev/ttyUSB0"))
 }

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -1048,6 +1048,34 @@ func (s *Service) waitForServicePidFile(expectedPID int, timeout time.Duration) 
 	}
 }
 
+// openServiceStderr opens the file the service process's stdout and stderr are
+// pointed at. It appends and stamps each start, because the interesting case is
+// a service that keeps dying and the previous crash is worth keeping. It lives
+// in LogDir so the log-download and upload paths can ship it with the log.
+func (s *Service) openServiceStderr() (*os.File, error) {
+	logDir := s.pl.Settings().LogDir
+	if logDir == "" {
+		// filepath.Join would yield a bare filename and the capture would land
+		// in whatever directory the service happened to start from.
+		return nil, errors.New("no log directory configured")
+	}
+	path := filepath.Join(logDir, config.StderrFile)
+	//nolint:gosec // Path is derived from the configured temp directory and fixed filename.
+	f, err := os.OpenFile(
+		path,
+		os.O_WRONLY|os.O_CREATE|os.O_APPEND|syscall.O_NOFOLLOW,
+		0o600,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error opening service stderr file: %w", err)
+	}
+	if _, err := fmt.Fprintf(f, "=== service start %s ===\n",
+		time.Now().Format(time.RFC3339)); err != nil {
+		log.Debug().Err(err).Msg("error stamping service stderr file")
+	}
+	return f, nil
+}
+
 // Start a new service daemon in the background. If the service is already
 // running (started by a peer wrapper invocation), Start returns nil without
 // re-doing prep work.
@@ -1094,6 +1122,24 @@ func (s *Service) Start() error {
 	// Detach from parent: create new session
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setsid: true,
+	}
+
+	// Without this the service's stdout and stderr go to /dev/null, so a panic
+	// or a Go runtime fatal error leaves no trace at all: the process
+	// disappears and core.log simply stops mid-session, which is
+	// indistinguishable from a clean exit that forgot to log. Nothing routine
+	// is written here, so the file stays empty unless something goes wrong.
+	stderrFile, stderrErr := s.openServiceStderr()
+	if stderrErr != nil {
+		log.Warn().Err(stderrErr).Msg("service stderr will not be captured")
+	} else {
+		defer func() {
+			if closeErr := stderrFile.Close(); closeErr != nil {
+				log.Debug().Err(closeErr).Msg("error closing service stderr file")
+			}
+		}()
+		cmd.Stdout = stderrFile
+		cmd.Stderr = stderrFile
 	}
 
 	// point new binary to existing config file

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -72,6 +72,7 @@ func newTestService(t *testing.T) *Service {
 	pl.On("Settings").Return(platforms.Settings{
 		DataDir: dataDir,
 		TempDir: tempDir,
+		LogDir:  tempDir,
 	})
 
 	return &Service{pl: pl}
@@ -152,7 +153,8 @@ func TestPrepareBinary_CreatesDataDir(t *testing.T) {
 	pl := mocks.NewMockPlatform()
 	pl.On("Settings").Return(platforms.Settings{
 		DataDir: dataDir,
-		TempDir: t.TempDir(),
+		TempDir: tempDir,
+		LogDir:  tempDir,
 	})
 	svc := &Service{pl: pl}
 
@@ -298,6 +300,7 @@ func TestPrepareBinary_UsesConfiguredFilesystem(t *testing.T) {
 	pl.On("Settings").Return(platforms.Settings{
 		DataDir: string(filepath.Separator) + "data",
 		TempDir: string(filepath.Separator) + "temp",
+		LogDir:  string(filepath.Separator) + "temp",
 	})
 	svc := &Service{pl: pl, fs: memFS}
 	srcPath := filepath.Join(string(filepath.Separator), "src", "zaparoo.bin")
@@ -1280,4 +1283,61 @@ func TestStart_FailsWhenServiceExitsDuringStartup(t *testing.T) {
 	err := svc.Start()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "did not become ready")
+}
+
+func TestStart_CapturesServiceStderr(t *testing.T) {
+	// Regression test: the service was spawned with nil Stdout/Stderr, so they
+	// went to /dev/null. A panic or a Go runtime fatal error left no trace
+	// anywhere — core.log just stopped mid-session, which looks identical to a
+	// clean exit that forgot to log.
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+
+	script := fmt.Sprintf("#!/bin/sh\n"+
+		"cleanup() { rm -f %[1]q; exit 0; }\n"+
+		"trap cleanup INT TERM HUP\n"+
+		"printf '%%s' \"$$\" > %[1]q\n"+
+		"printf 'panic: boom\\n' >&2\n"+
+		"while :; do sleep 1; done\n", pidFile)
+	sourcePath := writeFakeServiceScriptWithBody(t, script)
+	t.Setenv(config.AppEnv, sourcePath)
+	t.Cleanup(func() {
+		pid, err := svc.Pid()
+		if err == nil && pid > 0 && requireServiceRunning(t, svc) {
+			require.NoError(t, svc.Stop())
+		}
+		_ = os.Remove(pidFile)
+	})
+
+	require.NoError(t, svc.Start())
+
+	stderrPath := filepath.Join(settings.LogDir, config.StderrFile)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		content, err := os.ReadFile(stderrPath) //nolint:gosec // test-controlled file
+		assert.NoError(c, err)
+		assert.Contains(c, string(content), "panic: boom")
+	}, 5*time.Second, 50*time.Millisecond, "service stderr should reach %s", stderrPath)
+
+	content, err := os.ReadFile(stderrPath) //nolint:gosec // test-controlled file
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "=== service start ",
+		"each start should be stamped so repeated crashes stay distinguishable")
+}
+
+func TestOpenServiceStderr_RefusesEmptyLogDir(t *testing.T) {
+	t.Parallel()
+
+	// filepath.Join("", name) is a bare filename, so without this guard the
+	// capture lands in whatever directory the service started from. It showed
+	// up as a stray core.stderr.log committed into the package directory.
+	pl := mocks.NewMockPlatform()
+	pl.On("Settings").Return(platforms.Settings{DataDir: t.TempDir()})
+	svc := &Service{pl: pl}
+
+	f, err := svc.openServiceStderr()
+
+	require.Error(t, err)
+	assert.Nil(t, f)
+	assert.NoFileExists(t, config.StderrFile, "must never write to the working directory")
 }

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -274,6 +274,32 @@ func connectReaders(
 	return nil
 }
 
+// resolveAutoDetector keeps the detector in step with readers.auto_detect,
+// which the API can change at any time.
+//
+// The detector used to be built once, before the loop started, and only if
+// auto-detect happened to be on then. Turning the setting off still took effect
+// immediately, but turning it on did nothing until Core was restarted — so a
+// user who found the toggle in the app saw it do nothing at all. Dropping the
+// detector when the setting goes off also means re-enabling starts from clean
+// connected and failed state rather than from whatever the last run left.
+func resolveAutoDetector(
+	cfg *config.Instance,
+	current *AutoDetector,
+	clock clockwork.Clock,
+) *AutoDetector {
+	switch enabled := cfg.AutoDetect(); {
+	case enabled && current == nil:
+		log.Info().Msg("reader auto-detect enabled")
+		return NewAutoDetector(clock)
+	case !enabled && current != nil:
+		log.Info().Msg("reader auto-detect disabled")
+		return nil
+	default:
+		return current
+	}
+}
+
 func cancelTimedExit(exitTimer clockwork.Timer, exitGeneration *atomic.Uint64) bool {
 	exitGeneration.Add(1)
 	return exitTimer != nil && exitTimer.Stop()
@@ -501,9 +527,6 @@ func readerManager(
 	}
 
 	var autoDetector *AutoDetector
-	if svc.Config.AutoDetect() {
-		autoDetector = NewAutoDetector(svc.Config)
-	}
 
 	readerTicker := time.NewTicker(1 * time.Second)
 
@@ -542,6 +565,8 @@ func readerManager(
 					}
 					lastReaderCount = 0
 				}
+
+				autoDetector = resolveAutoDetector(svc.Config, autoDetector, clock)
 
 				readerConnectAttempts++
 				rs := svc.State.ListReaders()

--- a/pkg/service/readers_test.go
+++ b/pkg/service/readers_test.go
@@ -1385,3 +1385,47 @@ on_scan = "**echo:on_scan ran"`))
 	tok := env.expectToken(t)
 	assert.Equal(t, "token-a", tok.UID, "scan must still reach the token queue when ZapScript is disabled")
 }
+
+func TestResolveAutoDetector_EnablingAtRuntimeCreatesDetector(t *testing.T) {
+	t.Parallel()
+
+	// Regression test: the detector used to be built once before the loop
+	// started, so turning readers.auto_detect on through the API did nothing
+	// until Core restarted while turning it off took effect immediately.
+	// See #1400.
+	cfg := &config.Instance{}
+	cfg.SetAutoDetect(false)
+	clock := clockwork.NewFakeClock()
+
+	var detector *AutoDetector
+	detector = resolveAutoDetector(cfg, detector, clock)
+	require.Nil(t, detector, "auto-detect off must not build a detector")
+
+	cfg.SetAutoDetect(true)
+	detector = resolveAutoDetector(cfg, detector, clock)
+	require.NotNil(t, detector, "enabling auto-detect must take effect without a restart")
+
+	same := resolveAutoDetector(cfg, detector, clock)
+	assert.Same(t, detector, same, "a steady setting must keep the same detector")
+}
+
+func TestResolveAutoDetector_DisablingDropsDetectorState(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	cfg.SetAutoDetect(true)
+	clock := clockwork.NewFakeClock()
+
+	detector := resolveAutoDetector(cfg, nil, clock)
+	require.NotNil(t, detector)
+	detector.setFailed("/dev/ttyUSB0")
+
+	cfg.SetAutoDetect(false)
+	detector = resolveAutoDetector(cfg, detector, clock)
+	require.Nil(t, detector)
+
+	cfg.SetAutoDetect(true)
+	detector = resolveAutoDetector(cfg, detector, clock)
+	require.NotNil(t, detector)
+	assert.Empty(t, detector.suppressedPaths(), "re-enabling must not inherit stale failure state")
+}

--- a/pkg/ui/tui/exportlog.go
+++ b/pkg/ui/tui/exportlog.go
@@ -131,17 +131,19 @@ func BuildExportLogModal(
 }
 
 func copyLogToSd(pl platforms.Platform, logDestPath, logDestName string) string {
-	logPath := path.Join(pl.Settings().LogDir, config.LogFile)
-	newPath := logDestPath
-	err := helpers.CopyFile(logPath, newPath)
-	outcome := ""
+	// Writes the bundle rather than copying the file, so a crash captured in
+	// the stderr file travels with the log the user hands over.
+	// No limit: this writes to storage, not the upload service.
+	data, err := helpers.ReadLogBundle(pl, 0)
 	if err != nil {
-		outcome = fmt.Sprintf("Unable to copy log file to %s.", logDestName)
-		log.Error().Err(err).Msgf("error copying log file")
-	} else {
-		outcome = fmt.Sprintf("Copied %s to %s.", config.LogFile, logDestName)
+		log.Error().Err(err).Msg("error reading log file")
+		return fmt.Sprintf("Unable to copy log file to %s.", logDestName)
 	}
-	return outcome
+	if err := os.WriteFile(logDestPath, data, 0o600); err != nil {
+		log.Error().Err(err).Msgf("error copying log file")
+		return fmt.Sprintf("Unable to copy log file to %s.", logDestName)
+	}
+	return fmt.Sprintf("Copied %s to %s.", config.LogFile, logDestName)
 }
 
 var (
@@ -152,8 +154,6 @@ var (
 )
 
 func uploadLog(pl platforms.Platform, pages *tview.Pages, app *tview.Application) string {
-	logPath := path.Join(pl.Settings().LogDir, config.LogFile)
-
 	loadingDialog := NewDialog().
 		SetText("Uploading log file...").
 		SetTitle("Log upload")
@@ -161,8 +161,9 @@ func uploadLog(pl platforms.Platform, pages *tview.Pages, app *tview.Application
 	app.SetFocus(loadingDialog)
 	app.ForceDraw()
 
-	//nolint:gosec // logPath is from internal platform settings, not user input
-	logContent, err := os.ReadFile(logPath)
+	// Uploads the bundle: this is where a reported log usually comes from, and
+	// a crash exists only in the captured stderr.
+	logContent, err := helpers.ReadLogBundle(pl, uploadBudgetBytes())
 	if err != nil {
 		pages.RemovePage("temp_upload")
 		log.Error().Err(err).Msg("failed to read log file")
@@ -173,6 +174,13 @@ func uploadLog(pl platforms.Platform, pages *tview.Pages, app *tview.Application
 	result := doUploadLog(logContent, config.LogUploadURL, client)
 	pages.RemovePage("temp_upload")
 	return result
+}
+
+// uploadBudgetBytes is the room a bundle has inside the upload limit, once the
+// multipart envelope around it is accounted for.
+func uploadBudgetBytes() int {
+	const multipartOverhead = 4 * 1024
+	return config.LogUploadMaxBytes - multipartOverhead
 }
 
 // doUploadLog performs the upload and returns a user-friendly message.

--- a/pkg/ui/tui/exportlog.go
+++ b/pkg/ui/tui/exportlog.go
@@ -163,7 +163,7 @@ func uploadLog(pl platforms.Platform, pages *tview.Pages, app *tview.Application
 
 	// Uploads the bundle: this is where a reported log usually comes from, and
 	// a crash exists only in the captured stderr.
-	logContent, err := helpers.ReadLogBundle(pl, uploadBudgetBytes())
+	logContent, err := helpers.ReadLogBundle(pl, config.LogBundleMaxBytes)
 	if err != nil {
 		pages.RemovePage("temp_upload")
 		log.Error().Err(err).Msg("failed to read log file")
@@ -174,13 +174,6 @@ func uploadLog(pl platforms.Platform, pages *tview.Pages, app *tview.Application
 	result := doUploadLog(logContent, config.LogUploadURL, client)
 	pages.RemovePage("temp_upload")
 	return result
-}
-
-// uploadBudgetBytes is the room a bundle has inside the upload limit, once the
-// multipart envelope around it is accounted for.
-func uploadBudgetBytes() int {
-	const multipartOverhead = 4 * 1024
-	return config.LogUploadMaxBytes - multipartOverhead
 }
 
 // doUploadLog performs the upload and returns a user-friendly message.

--- a/scripts/zigcc/Dockerfile
+++ b/scripts/zigcc/Dockerfile
@@ -54,8 +54,28 @@ RUN chmod +x /usr/local/bin/build_c_lib.sh
 ENV TARGETS="x86_64-linux-gnu aarch64-linux-gnu arm-linux-gnueabihf"
 ENV HOSTS="x86_64-linux aarch64-linux arm-linux"
 
+# Pin the native dependencies by commit. These were cloned from master with
+# --depth 1, so the C libraries linked into every release were whatever
+# upstream HEAD happened to be on the day the image was built: not recorded
+# anywhere, not reproducible, and able to change under a Core release with no
+# diff in this repo to show it.
+#
+# These are the exact commits the last production image (v1.5.0, built
+# 2026-09-03 04:05 UTC) picked up, so the pin reproduces what is already
+# shipping rather than changing it. Release tags would not: master was 140
+# commits past v1.0.30 for libusb and 79 past libnfc-1.8.0, and because
+# configure.ac only bumps at release both still report the released version
+# number — so a tag pin looks identical by version string while silently
+# rolling the C libraries back.
+ENV LIBUSB_COMMIT="a45bb163a603ac5ae3499806b151509848b0065c"
+ENV LIBUSB_COMPAT_COMMIT="4831748a1439aec81e9cbb9984b1b0289c1c7051"
+ENV LIBNFC_COMMIT="3fa0751ad58fb0053d3de2e61bbbd4066259104c"
+
 WORKDIR /src
-RUN git clone --depth 1 https://github.com/libusb/libusb.git
+RUN mkdir libusb && cd libusb && git init -q . && \
+    git remote add origin https://github.com/libusb/libusb.git && \
+    git fetch -q --depth 1 origin "$LIBUSB_COMMIT" && \
+    git checkout -q FETCH_HEAD
 WORKDIR /src/libusb
 
 # Generate configure script
@@ -66,7 +86,10 @@ RUN /usr/local/bin/build_c_lib.sh libusb "/opt/deps" "--disable-udev --enable-st
 
 # Build libusb-compat-0.1 for each target (provides old libusb-0.1 API on top of libusb-1.0)
 WORKDIR /src
-RUN git clone --depth 1 https://github.com/libusb/libusb-compat-0.1.git
+RUN mkdir libusb-compat-0.1 && cd libusb-compat-0.1 && git init -q . && \
+    git remote add origin https://github.com/libusb/libusb-compat-0.1.git && \
+    git fetch -q --depth 1 origin "$LIBUSB_COMPAT_COMMIT" && \
+    git checkout -q FETCH_HEAD
 WORKDIR /src/libusb-compat-0.1
 
 # Generate configure script for libusb-compat
@@ -79,7 +102,10 @@ RUN /usr/local/bin/build_c_lib.sh libusb-compat "/opt/deps" "" "$TARGETS" "$HOST
 FROM libusb-builder AS libnfc-builder
 
 WORKDIR /src
-RUN git clone --depth 1 https://github.com/nfc-tools/libnfc.git
+RUN mkdir libnfc && cd libnfc && git init -q . && \
+    git remote add origin https://github.com/nfc-tools/libnfc.git && \
+    git fetch -q --depth 1 origin "$LIBNFC_COMMIT" && \
+    git checkout -q FETCH_HEAD
 WORKDIR /src/libnfc
 
 # Generate configure script for libnfc


### PR DESCRIPTION
Started as issue #1400 — a user whose PN532 was never auto-detected, whose log said nothing about why. It turned into five distinct defects, one of which crashes the service outright.

## The crash

`libnfcacr122` shipped with auto-detect on, so `Detect` ran `nfc.ListDevices()` — a full libusb enumeration — on the reader manager's 1 Hz tick, on every Linux device, whether or not an ACR122 was attached. Enumerating while the USB bus changes underneath it kills the process. On a MiSTer, unplugging and replugging a reader produced:

```
thread 1480 panic: member access within misaligned address 0x327ffc4 for
type 'struct libusb_context', which requires 8 byte alignment
```

A hard abort from the cgo side: no Go panic, nothing in `core.log`, nothing in `dmesg`. The process disappears after a completely healthy startup, which is what made it so hard to place — it cost most of a session before the stderr capture below made it visible in one line.

Auto-detect is now off by default for that driver, matching `rs232barcode` and `mqtt`. An ACR122 owner opts back in with a `readers.connect` entry or `readers.drivers.libnfcacr122.auto_detect = true`.

**Confirmed on hardware.** With auto-detect on, unplug/replug killed the service. With it off, the same cycle left the process untouched (same PID, no new panic) and the reader reconnected on its own — including onto a *different* path, `ttyUSB1` → `ttyUSB0`.

This closes #1395, which proposed the same change on performance grounds after measuring the enumeration at roughly 4% of an idle profile. I filed that as "not urgent, worth a decision rather than a fix". That was wrong; the crash makes it a correctness fix rather than a trade-off.

(The commit message for that change misattributes #1395 to the go-pn532 repo. It is a core issue; the reference in the commit is wrong and the one here is right.)

## Why nobody could see it

`Start` spawned the service with nil `Stdout`/`Stderr`, so both went to `/dev/null`. Any panic or runtime fatal error left no trace anywhere — `core.log` just stopped mid-session, indistinguishable from a clean exit that forgot to log.

The service now writes to `core.stderr.log`, appended and stamped per start. Capturing it is not enough on its own: every path that hands a log to a user reads a single file, so a crash in a second file would never reach a bug report. The download API, the TUI upload and the copy to SD all go through `helpers.ReadLogBundle` now.

The bundle is budget-aware, because `logs.zaparoo.org` caps uploads at 1 MB and the log rotates at exactly 1 MB — appending to a full log would push the payload over and lose the upload entirely, taking the crash report with it. The capture is kept whole and the log trimmed from the front, on line boundaries so no broken JSON entry is left at the top.

Verified end to end: `settings.logs.download` returned the panic inside the log, and that payload uploaded to `logs.zaparoo.org` and read back byte-identical.

## The original #1400 path

Four further defects, each of which presents as "auto-detect does not find my reader":

- **The setting only applied at startup.** The detector was built once before the loop, and only if `readers.auto_detect` was on then — so turning it off worked immediately and turning it on did nothing until a restart. On `main`, enabling the toggle left the reader unconnected for 30s until I restarted; with the fix it connects in seconds. A/B'd on the device.
- **One failed open excluded a path forever**, because nothing cleared an entry for a path that had never connected. Now backs off 2s → 60s.
- **Empty paths were tracked as identities.** libnfc's ACR122 fallback returns the bare `libnfcauto:`, and keying the maps on `""` made one pathless driver's state apply to every other. Found on the device as `suppressed_paths:[""]` in the new logging.
- **Nothing said what auto-detect had done.** Ports enumerated, paths skipped and probe results were trace-level or absent, so "never enumerated" and "enumerated and did not answer" looked identical. Both layers now report at info, once per change: a whole session is nine lines, and plugging or unplugging a port adds exactly one.

The go-pn532 v0.24.0 bump carries the matching detection fix — the UART candidate filter could only match macOS device names, so on Linux detection rested on four VID:PIDs and a PN532 on any other bridge was discarded unprobed.

Worth noting for #1400 itself: the test reader is a CH340 (`1a86:7523`), which was already in that allowlist, so **baseline detects it too**. The filter is not what fixes this reporter's case. The new port and VID logging is what will tell us what their hardware actually is.

## Build reproducibility

`libusb`, `libusb-compat` and `libnfc` were cloned from `master` with `--depth 1`, so every release linked whatever upstream HEAD was that day — unrecorded, unreproducible, and able to change under a release with no diff here.

They are now pinned **by commit**, to exactly what the last production image cloned. Release tags would not have worked: `configure.ac` only bumps at release, so master reports the released number no matter how far ahead it is. It was far ahead — the v1.5.0 image picked up libusb **140 commits past `v1.0.30`** and libnfc **79 past `libnfc-1.8.0`**, both still reporting `1.0.30` and `1.8.0`. A tag pin would have silently rolled the C libraries back in every release build while passing every check available, which is about the worst possible unintended change given a libusb fault is what we are chasing.

The pinned commits are what the `zigcc-build` run of 2026-09-03 cloned at 04:07–04:09 UTC. Verified that the run genuinely built rather than skipping on an existing version (`VERSION` was bumped 1.4.0 → 1.5.0 in that same commit, and `Build and push` ran), and that the clone layers executed rather than being restored from the GHA cache — either would have made the timestamps meaningless. `git clone --branch` does not accept a commit, so the Dockerfile fetches the SHA directly. Confirmed by rebuilding the image.

## Validation

Full suite, lint, deadlock, vulncheck and `cross-lint:all` clean. Device testing on a MiSTer covered detection, the runtime toggle with a failing baseline, phantom ports appearing and disappearing, unplug/replug recovery, the log download and a real upload.

Still open, and deliberately not claimed as fixed: whether the misalignment is a libusb bug or a `zig cc` artifact on armv7. Zig's UB handler is what converts it into a hard abort, so a GCC-built libusb may carry the same latent bug and simply not die from it. This removes the trigger; it does not establish the root cause.

Closes #1400.
Closes #1395.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Log downloads, SD exports, and uploads now include captured service error output.
  - Log uploads are automatically trimmed to stay within the supported size limit.
  - Reader auto-detection can now respond to configuration changes without restarting.
  - Failed device paths retry automatically using progressively longer delays.

- **Bug Fixes**
  - Improved reader detection stability and clearer detection status reporting.
  - ACR122 reader auto-detection is now disabled by default to prevent device-disconnection crashes; it can be enabled in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


