### PR TITLE
fix(readers): stop a controller adapter's serial port from blocking PN532 auto-detect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/ZaparooProject/go-gameid v0.2.0
-	github.com/ZaparooProject/go-pn532 v0.24.0
+	github.com/ZaparooProject/go-pn532 v0.25.0
 	github.com/ZaparooProject/go-zapscript v0.19.0
 	github.com/ZaparooProject/zaparoo-core/mister v0.1.0
 	github.com/adrg/xdg v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d h1:2xp1BQbqcDDaik
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
 github.com/ZaparooProject/go-gameid v0.2.0 h1:nYDxozhwsJXacdh/lwHOJofz4SlA609WKTD38UOQy+0=
 github.com/ZaparooProject/go-gameid v0.2.0/go.mod h1:gPQg1jQ4jgkguOJeKUiIqZeucz0GsSR67UQ/JOgYUDI=
-github.com/ZaparooProject/go-pn532 v0.24.0 h1:PkFrB01e3WNit9sBQJ15SWAFzJNahbL7cFwrI3mmRys=
-github.com/ZaparooProject/go-pn532 v0.24.0/go.mod h1:fSidCDd3a43w9TN9sHIpJdl1gQ5CTX/WgtnrniAdV+4=
+github.com/ZaparooProject/go-pn532 v0.25.0 h1:R9pewRLrsPXmTTpMUdTQRcMuHXsXRecr3stjdiHSbBI=
+github.com/ZaparooProject/go-pn532 v0.25.0/go.mod h1:fSidCDd3a43w9TN9sHIpJdl1gQ5CTX/WgtnrniAdV+4=
 github.com/ZaparooProject/go-zapscript v0.19.0 h1:M4t3dlOrfx0g8ZkLuGt7pRhNa5SqWMs5oAgucZpovQE=
 github.com/ZaparooProject/go-zapscript v0.19.0/go.mod h1:ofo4vj6lFW0eUuSyPLt0R0JjJxExhn9eitSmFBWQVoU=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=

--- a/pkg/readers/pn532/detectsummary_test.go
+++ b/pkg/readers/pn532/detectsummary_test.go
@@ -134,6 +134,19 @@ func TestLogDetectionSummary_OmitsExpectedDetectionMiss(t *testing.T) {
 		"an expected miss should not be dressed up as an error")
 }
 
+func TestLogDetectionSummary_ReportsADetectionTimeout(t *testing.T) {
+	// A pass that runs out of time used to be filed with "nothing there" and
+	// vanished at trace level. That hid a controller adapter parking every
+	// probe for months; it now travels in the summary.
+	resetDetectSummary(t)
+	buf := captureDebugLog(t)
+
+	logDetectionSummary([]string{"/dev/ttyACM0", "/dev/ttyUSB0"}, nil, nil, nil, detection.ErrDetectionTimeout)
+
+	require.Len(t, decodeLogEntries(t, buf), 1)
+	assert.Contains(t, buf.String(), detection.ErrDetectionTimeout.Error())
+}
+
 func TestLogDetectionSummary_ReportsUnexpectedDetectionError(t *testing.T) {
 	resetDetectSummary(t)
 	buf := captureDebugLog(t)

--- a/pkg/readers/pn532/pn532.go
+++ b/pkg/readers/pn532/pn532.go
@@ -786,8 +786,12 @@ func logDetectionSummary(
 	event.Msg("PN532 auto-detect")
 }
 
+// isExpectedDetectionMiss reports whether a detection error is the normal
+// "nothing there" answer. A timeout is not: go-pn532 bounds each port's probe
+// on its own, so the pass only runs out of time when something on the bus has
+// parked a probe in the kernel, and that is worth reporting.
 func isExpectedDetectionMiss(err error) bool {
-	return errors.Is(err, detection.ErrNoDevicesFound) || errors.Is(err, detection.ErrDetectionTimeout)
+	return errors.Is(err, detection.ErrNoDevicesFound)
 }
 
 // defaultDetectionTransports limits PN532 auto-detect to transports safe for

--- a/pkg/readers/pn532/pn532_test.go
+++ b/pkg/readers/pn532/pn532_test.go
@@ -84,7 +84,8 @@ func TestIsExpectedDetectionMiss(t *testing.T) {
 	t.Parallel()
 
 	assert.True(t, isExpectedDetectionMiss(detection.ErrNoDevicesFound))
-	assert.True(t, isExpectedDetectionMiss(detection.ErrDetectionTimeout))
+	assert.False(t, isExpectedDetectionMiss(detection.ErrDetectionTimeout),
+		"a timeout means a probe is parked in the kernel, which is worth reporting")
 	assert.False(t, isExpectedDetectionMiss(errors.New("serial permission denied")))
 }
 


### PR DESCRIPTION
Closes #1425. Same fault as #548 and #54, neither of which was root-caused.

## Root cause

A DaemonBite / CTRLDock style controller adapter is an Arduino Pro Micro. Its stock firmware keeps the Arduino CDC serial port enabled and never reads it, so it enumerates `/dev/ttyACM0` beside a HID gamepad interface and stops accepting serial data after ~128 bytes.

go-pn532 probed that port before the reader's (`/sys/class/tty` sorts `ttyACM0` ahead of `ttyUSB0`) because its manufacturer string matches `Arduino`, wrote ~150 bytes at it and called `tcdrain` — which blocks in the kernel with no timeout once the device NAKs, and cannot be interrupted. That consumed Core's whole 15 s detection budget every tick, the PN532 on the next port was never reached, and Core filed the resulting `ErrDetectionTimeout` under "expected miss" at trace level, so the log said nothing. `[readers.drivers.libnfcacr122] auto_detect = false` could not help: the wedge is in the pn532 driver.

## Changes

- **go-pn532 v0.24.0 → v0.25.0** (ZaparooProject/go-pn532#122): a serial port on a USB device that also presents a HID interface is only probed with real PN532 evidence; each probe runs on its own goroutine under its 500 ms deadline and a parked one is skipped on later passes instead of stalling the pass; a timed-out pass returns the devices already found.
- **`pkg/readers/pn532/pn532.go`** — `isExpectedDetectionMiss` no longer includes `ErrDetectionTimeout`. With go-pn532 bounding each probe, a pass only runs out of time when something on the bus has parked a probe, and that now reaches the info-level `PN532 auto-detect` summary and the warn line rather than trace.

Verified on a MiSTer with the PN532 alone: the summary names `/dev/ttyUSB0`, the reader is detected and connected within a second of the reader manager starting. No HID+CDC composite device was available, so the parked-probe path is proven by go-pn532's unit test only; the reporter is the field test.

Workaround for 2.17.1 users until this ships:

```toml
[readers]
auto_detect = false

[[readers.connect]]
driver = "pn532"
path = "/dev/ttyUSB0"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Detection timeouts are now reported as unexpected errors instead of being silently treated as normal missed detections.
  * Detection summaries include timeout details to make reader issues more visible.

* **Chores**
  * Updated the PN532 reader dependency to version 0.25.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->