### PR TITLE
perf(media): poll only the corrupt marker in the recovery watcher

### DIFF
--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -291,6 +291,13 @@ type mediaDBGenerateFunc func(
 // UserDB), so recovery discards the corrupt file rather than attempting an unreliable
 // in-process repair, then triggers a full reindex. The durable sidecar marker is the
 // authoritative signal because the in-DB status write can itself fail on a malformed file.
+//
+// This entry point also trusts a persisted corrupt indexing status when the marker is
+// absent, covering a marker that could not be written or was removed. Every writer of
+// that status writes the marker first, and the status write is followed by a
+// media-indexing notification, a direct call here, or at worst the next startup check,
+// so those triggers use this form. The periodic poll uses
+// checkAndRecoverMarkedCorruptMediaDB instead.
 func checkAndRecoverCorruptMediaDB(
 	pl platforms.Platform,
 	cfg *config.Instance,
@@ -298,7 +305,35 @@ func checkAndRecoverCorruptMediaDB(
 	st *state.State,
 	pauser *syncutil.Pauser,
 ) {
-	checkAndRecoverCorruptMediaDBWithGenerator(pl, cfg, db, st, pauser, methods.GenerateMediaDBWithLease)
+	checkAndRecoverCorruptMediaDBWithGenerator(pl, cfg, db, st, pauser, methods.GenerateMediaDBWithLease, true)
+}
+
+// checkAndRecoverMarkedCorruptMediaDB is the cheap form used by the periodic poll. It keys
+// on the sidecar marker alone, a single stat when the database is healthy, and never
+// queries the persisted indexing status.
+func checkAndRecoverMarkedCorruptMediaDB(
+	pl platforms.Platform,
+	cfg *config.Instance,
+	db *database.Database,
+	st *state.State,
+	pauser *syncutil.Pauser,
+) {
+	checkAndRecoverCorruptMediaDBWithGenerator(pl, cfg, db, st, pauser, methods.GenerateMediaDBWithLease, false)
+}
+
+// mediaDBFlaggedCorrupt reports whether recovery should run. The sidecar marker is the
+// authoritative signal because every corruption detection writes it. trustPersistedStatus
+// also accepts a persisted corrupt indexing status, which covers a marker that could not
+// be written or was removed.
+func mediaDBFlaggedCorrupt(mediaDB database.MediaDBI, trustPersistedStatus bool) bool {
+	if mediaDB.IsMarkedCorrupt() {
+		return true
+	}
+	if !trustPersistedStatus {
+		return false
+	}
+	status, err := mediaDB.GetIndexingStatus()
+	return err == nil && status == mediadb.IndexingStatusCorrupt
 }
 
 func checkAndRecoverCorruptMediaDBWithGenerator(
@@ -308,6 +343,7 @@ func checkAndRecoverCorruptMediaDBWithGenerator(
 	st *state.State,
 	pauser *syncutil.Pauser,
 	generate mediaDBGenerateFunc,
+	trustPersistedStatus bool,
 ) {
 	if db == nil || db.MediaDB == nil {
 		return
@@ -320,14 +356,7 @@ func checkAndRecoverCorruptMediaDBWithGenerator(
 	}
 	defer mediaDBRecovering.Store(false)
 
-	corrupt := db.MediaDB.IsMarkedCorrupt()
-	if !corrupt {
-		// Backstop: trust a persisted corrupt status even if the marker is missing.
-		if status, err := db.MediaDB.GetIndexingStatus(); err == nil && status == mediadb.IndexingStatusCorrupt {
-			corrupt = true
-		}
-	}
-	if !corrupt {
+	if !mediaDBFlaggedCorrupt(db.MediaDB, trustPersistedStatus) {
 		return
 	}
 
@@ -517,7 +546,10 @@ func mediaDBCorruptionRecoveryBlocked(mediaDB database.MediaDBI) bool {
 // watchForCorruptMediaDBRecovery triggers recovery at runtime once an indexing or
 // optimization operation completes. It also polls the durable marker so corruption first
 // observed by a foreground query self-heals without requiring an unrelated indexing event
-// or service restart. The marker check is a cheap stat when no corruption is present.
+// or service restart. The poll is a single stat when no corruption is present. The
+// persisted corrupt status is a fallback for a marker that could not be written, consulted
+// only at startup and on media-indexing notifications; every writer of that status writes
+// the marker first, so the timer never needs to query the database.
 func watchForCorruptMediaDBRecovery(
 	ctx context.Context,
 	b *broker.Broker,
@@ -560,7 +592,7 @@ func watchForCorruptMediaDBRecoveryAtInterval(
 			checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)
 			retryDurableMediaWriteOperations(ctx, pl, cfg, db, st, indexPauser, scrapePauser)
 		case <-ticker.C:
-			checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)
+			checkAndRecoverMarkedCorruptMediaDB(pl, cfg, db, st, indexPauser)
 			retryDurableMediaWriteOperations(ctx, pl, cfg, db, st, indexPauser, scrapePauser)
 		}
 	}

--- a/pkg/service/media_recovery_test.go
+++ b/pkg/service/media_recovery_test.go
@@ -158,7 +158,7 @@ func TestCheckAndRecoverCorruptMediaDB_ReindexFailureFinishesNotification(t *tes
 		) error {
 			generateCalled = true
 			return errors.New("injected reindex failure")
-		})
+		}, true)
 
 	started := <-ns
 	finished := <-ns
@@ -199,7 +199,7 @@ func TestCheckAndRecoverCorruptMediaDB_TransfersRecoveryLeaseToReindex(t *testin
 		) error {
 			transferred = lease
 			return nil
-		})
+		}, true)
 
 	require.NotNil(t, transferred)
 	assert.True(t, transferred.ValidFor(database.MediaWriteOperationIndexing))
@@ -256,7 +256,7 @@ func TestCheckAndRecoverCorruptMediaDB_ReleasesGateBeforeReindex(t *testing.T) {
 				targetDB.MediaDB.BackgroundOperationDone()
 				close(reindexRegistered)
 				return errors.New("stop after background registration")
-			})
+			}, true)
 	}()
 
 	select {
@@ -511,4 +511,127 @@ func TestWatchForCorruptMediaDBRecovery(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("watcher did not exit after context cancellation")
 	}
+}
+
+// TestWatchForCorruptMediaDBRecovery_TickDoesNotQueryIndexingStatus verifies the periodic
+// poll costs a single marker stat when the database is healthy. Every writer of the
+// persisted corrupt status also writes the marker and is followed by a media-indexing
+// notification or a direct recovery check, so the timer never needs to query the database.
+func TestWatchForCorruptMediaDBRecovery_TickDoesNotQueryIndexingStatus(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	const ticks = 3
+	checked := make(chan struct{}, ticks)
+	mockDB.On("IsMarkedCorrupt").Return(false).Run(func(mock.Arguments) {
+		select {
+		case checked <- struct{}{}:
+		default:
+		}
+	})
+	// The mock only records calls for methods with an expectation; without this the
+	// AssertNotCalled below would pass vacuously.
+	mockDB.On("GetIndexingStatus").Return("", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	source := make(chan models.Notification, 1)
+	b := broker.NewBroker(ctx, source)
+	b.Start()
+	t.Cleanup(b.Stop)
+
+	done := make(chan struct{})
+	go func() {
+		watchForCorruptMediaDBRecoveryAtInterval(
+			ctx, b, nil, nil, &database.Database{MediaDB: mockDB}, nil, nil, nil, 10*time.Millisecond,
+		)
+		close(done)
+	}()
+
+	for range ticks {
+		select {
+		case <-checked:
+		case <-time.After(2 * time.Second):
+			t.Fatal("recovery watcher stopped polling the corruption marker")
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not exit after context cancellation")
+	}
+
+	mockDB.AssertNotCalled(t, "GetIndexingStatus")
+}
+
+// TestWatchForCorruptMediaDBRecovery_NotificationRunsStatusBackstop verifies the
+// media-indexing notification branch still trusts a persisted corrupt status when the
+// marker is missing, which is where that backstop lives now that the poll is marker-only.
+func TestWatchForCorruptMediaDBRecovery_NotificationRunsStatusBackstop(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("IsMarkedCorrupt").Return(false)
+	mockDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCorrupt, nil)
+	// The backstop detects corruption; a running scrape then defers recovery, which keeps
+	// the test off the reindex path and gives the deferral a call to observe.
+	mockDB.On("HasBackgroundOperations").Return(true)
+	deferred := make(chan struct{}, 1)
+	mockDB.On("GetScrapingStatus").Return(mediadb.IndexingStatusRunning, nil).Run(func(mock.Arguments) {
+		select {
+		case deferred <- struct{}{}:
+		default:
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	source := make(chan models.Notification, 10)
+	b := broker.NewBroker(ctx, source)
+	b.Start()
+	t.Cleanup(b.Stop)
+
+	done := make(chan struct{})
+	go func() {
+		// A poll interval far beyond the test's lifetime, so only the notification can
+		// trigger a check.
+		watchForCorruptMediaDBRecoveryAtInterval(
+			ctx, b, nil, nil, &database.Database{MediaDB: mockDB}, nil, nil, nil, time.Hour,
+		)
+		close(done)
+	}()
+
+	// Re-publish until the watcher has subscribed and run a check; each check is idempotent.
+	require.Eventually(t, func() bool {
+		select {
+		case source <- models.Notification{Method: models.NotificationMediaIndexing}:
+		default:
+		}
+		select {
+		case <-deferred:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not exit after context cancellation")
+	}
+	mockDB.AssertNotCalled(t, "Recreate", mock.Anything)
+}
+
+// TestCheckAndRecoverMarkedCorruptMediaDB_IgnoresPersistedStatus verifies the marker-only
+// form used by the poll neither queries the persisted status nor starts recovery from it.
+func TestCheckAndRecoverMarkedCorruptMediaDB_IgnoresPersistedStatus(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("IsMarkedCorrupt").Return(false)
+	mockDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCorrupt, nil)
+	mockDB.On("HasBackgroundOperations").Return(false)
+
+	checkAndRecoverMarkedCorruptMediaDB(nil, nil, &database.Database{MediaDB: mockDB}, nil, nil)
+
+	mockDB.AssertNotCalled(t, "GetIndexingStatus")
+	mockDB.AssertNotCalled(t, "HasBackgroundOperations")
+	mockDB.AssertNotCalled(t, "Recreate", mock.Anything)
 }


### PR DESCRIPTION
- The corrupt-DB recovery watcher ticks every 5s and, when the sidecar marker said clean, still ran a `SELECT` against DBConfig as a status backstop. Its doc comment described the tick as a cheap stat, and an idle service ran 17,280 of those queries a day.
- Detection is now split: the ticker checks the marker only, while startup and the media-indexing notification branch keep the marker-or-persisted-status check. Every writer of the corrupt status writes the marker first and is followed by a notification, a direct recovery call, or the next startup check, so the timer no longer needs the query.
- The doc comments on the watcher and the recovery entry point now describe where the persisted status is consulted.
- Adds a regression test asserting the tick never calls `GetIndexingStatus` (fails on main), plus tests that the notification branch still trusts a persisted corrupt status and that the marker-only form ignores it.

Closes #1394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media database corruption recovery by distinguishing between marker-based detection and persisted status checks.
  * Periodic recovery checks now rely only on the corruption marker, while startup and notification-based recovery retain the persisted-status fallback.
  * Added coverage for recovery behavior when markers or persisted status information are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->