### PR TITLE
fix(ci): make the release gate start and pass on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,12 @@ jobs:
       contents: read
       pull-requests: read
       packages: read
+      # lint-and-test.yml declares this at workflow level for its SARIF
+      # upload. The gate skips that upload, but a caller must still grant
+      # every permission the called workflow declares or the run fails at
+      # startup before any job exists, which is how the first v2.17.2 tag
+      # build ended.
+      security-events: write
 
   create-release:
     needs: lint-and-test

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -58,11 +58,23 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
+      # A release gate runs Linux on ubuntu-latest, not Ubicloud. SignPath
+      # refuses to sign an artifact if any job upstream of it ran on a runner
+      # outside the "GitHub Actions" group, and since build.yml's build job
+      # depends on this workflow, the v2.17.2 signing request was rejected
+      # for this job alone. Everything else here already uses GitHub-hosted
+      # runners; Cross Lint is PR-only.
       matrix:
         include: >-
           ${{
             github.event_name == 'pull_request'
               && fromJSON('[{"os":"ubuntu","runner":"ubicloud-standard-4"}]')
+              || inputs.release_gate
+              && fromJSON('[
+                   {"os":"ubuntu","runner":"ubuntu-latest"},
+                   {"os":"macos","runner":"macos-latest"},
+                   {"os":"windows","runner":"windows-latest"}
+                 ]')
               || fromJSON('[
                    {"os":"ubuntu","runner":"ubicloud-standard-4"},
                    {"os":"macos","runner":"macos-latest"},

--- a/pkg/database/scraper/misterdocs/scraper_test.go
+++ b/pkg/database/scraper/misterdocs/scraper_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -251,8 +252,10 @@ func TestScrapeLoop_AccumulatesSourceLoadFailures(t *testing.T) {
 	}
 	require.Len(t, updates, 2)
 	require.Error(t, updates[0].Err)
-	require.ErrorContains(t, updates[0].Err, firstSource)
-	require.ErrorContains(t, updates[0].Err, secondSource)
+	// The error quotes each path with %q, which escapes the backslashes in a
+	// Windows path, so compare against the quoted form.
+	require.ErrorContains(t, updates[0].Err, strconv.Quote(firstSource))
+	require.ErrorContains(t, updates[0].Err, strconv.Quote(secondSource))
 	mediaDB.AssertExpectations(t)
 }
 


### PR DESCRIPTION
- The first v2.17.2 tag build ended in `startup_failure` with no jobs run. GitHub rejected build.yml with: "Error calling workflow 'lint-and-test.yml'. The workflow is requesting 'security-events: write', but is only allowed 'security-events: none'."
- lint-and-test.yml declares `security-events: write` at workflow level for its govulncheck SARIF upload. The release gate job added in #1409 calls it granting only `contents`, `pull-requests` and `packages` read, and GitHub validates a called workflow's declared permissions against the caller's grant before any job starts, whether or not the step that uses them will run.
- Grant `security-events: write` on the gate job. Nothing in a gate run uses it, because the `release_gate` input already skips the SARIF upload.
- With the gate running, its Windows job failed on `TestScrapeLoop_AccumulatesSourceLoadFailures` from #1429. `scrapeLoop` formats each failed source path with `%q`, which escapes the backslashes in a Windows path, while the test searched the error for the raw path. The assertion now compares against `strconv.Quote` of the path, which is what `%q` produces.
- With the gate passing and every target built, Windows signing was rejected: SignPath accepts an artifact only when every job upstream of it ran in the "GitHub Actions" runner group, and the gate's Linux job runs on `ubicloud-standard-4`. Before #1409 the build job had no dependency on lint-and-test.yml, so that runner was never in a release's chain. The gate now runs its Linux job on `ubuntu-latest`; pull requests and pushes to main keep the Ubicloud runner.
- The gate had never run on a real tag before this: #1409 landed after v2.17.1, and the weekly build-check workflow, which calls build.yml the same way, has been failing at startup on main since 2026-08-31 for a reason not yet looked at.
- All three commits are cherry-picked from `release/v2.17.2`, where the v2.17.2 tag points at the last one.