### PR TITLE
fix(api): drop request timeout from WebSocket upgrade routes

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -513,6 +513,33 @@ func legacyAdmissionMiddleware(platformID string) func(http.Handler) http.Handle
 	}
 }
 
+// mountWebSocketRoutes registers the WebSocket upgrade routes on r behind
+// rateLimit. The group carries no request timeout: the upgrade handler
+// returns only when the connection closes, and chi's Timeout middleware
+// writes a 504 header on return whenever its deadline has passed, which on
+// a hijacked connection is discarded by net/http with a warning on stderr.
+// Per-message deadlines are applied in handleWSMessage instead.
+func mountWebSocketRoutes(
+	r chi.Router,
+	rateLimit func(http.Handler) http.Handler,
+	handle func(w http.ResponseWriter, r *http.Request, version string),
+) {
+	r.Group(func(r chi.Router) {
+		r.Use(rateLimit)
+		r.Use(middleware.NoCache)
+
+		r.Get("/api", func(w http.ResponseWriter, r *http.Request) {
+			handle(w, r, "latest")
+		})
+		r.Get("/api/v0", func(w http.ResponseWriter, r *http.Request) {
+			handle(w, r, "v0")
+		})
+		r.Get("/api/v0.1", func(w http.ResponseWriter, r *http.Request) {
+			handle(w, r, "v0.1")
+		})
+	})
+}
+
 // apiMethodManagesRestoreAccess lists methods that coordinate with the
 // backup-restore gate themselves instead of taking the shared read lock:
 // the restore methods hold the write side, and media.active.update resolves
@@ -2094,21 +2121,7 @@ func StartWithReady(
 	// WebSocket routes — open to remote clients regardless of AllowedIPs.
 	// Encryption (when enabled) or API key auth (when disabled) is the
 	// security mechanism here.
-	r.Group(func(r chi.Router) {
-		r.Use(apiRateLimitMiddleware)
-		r.Use(middleware.NoCache)
-		r.Use(middleware.Timeout(config.APIRequestTimeout))
-
-		r.Get("/api", func(w http.ResponseWriter, r *http.Request) {
-			wsHandler(w, r, "latest")
-		})
-		r.Get("/api/v0", func(w http.ResponseWriter, r *http.Request) {
-			wsHandler(w, r, "v0")
-		})
-		r.Get("/api/v0.1", func(w http.ResponseWriter, r *http.Request) {
-			wsHandler(w, r, "v0.1")
-		})
-	})
+	mountWebSocketRoutes(r, apiRateLimitMiddleware, wsHandler)
 
 	// Non-WebSocket API routes (HTTP POST + REST GET) — restricted to
 	// localhost by default; remote access requires explicit AllowedIPs.

--- a/pkg/api/server_ws_routes_test.go
+++ b/pkg/api/server_ws_routes_test.go
@@ -1,0 +1,70 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWebSocketRoutesHaveNoRequestDeadline pins that the WebSocket upgrade
+// routes are not wrapped in a request timeout. The upgrade handler returns
+// only when the connection closes, and chi's Timeout middleware writes a 504
+// header on return whenever its deadline has passed. On a hijacked connection
+// net/http discards that write and logs a warning to stderr, which is captured
+// into every log bundle.
+func TestWebSocketRoutesHaveNoRequestDeadline(t *testing.T) {
+	t.Parallel()
+
+	passthrough := func(next http.Handler) http.Handler { return next }
+
+	type probe struct {
+		version     string
+		called      bool
+		hasDeadline bool
+	}
+	var got probe
+	r := chi.NewRouter()
+	mountWebSocketRoutes(r, passthrough, func(_ http.ResponseWriter, req *http.Request, version string) {
+		_, hasDeadline := req.Context().Deadline()
+		got = probe{version: version, called: true, hasDeadline: hasDeadline}
+	})
+
+	routes := map[string]string{
+		"/api":      "latest",
+		"/api/v0":   "v0",
+		"/api/v0.1": "v0.1",
+	}
+	for path, version := range routes {
+		got = probe{}
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, http.NoBody)
+		r.ServeHTTP(httptest.NewRecorder(), req)
+
+		require.True(t, got.called, "%s: upgrade handler must be routed", path)
+		assert.Equal(t, version, got.version, "%s: version passed to the upgrade handler", path)
+		assert.False(t, got.hasDeadline,
+			"%s: upgrade request context must carry no deadline; the handler runs for the life of the connection", path)
+	}
+}


### PR DESCRIPTION
- The WebSocket route group wrapped the upgrade handler in chi's `Timeout` middleware. The handler returns only when the connection closes, so every session older than 30s ended with a 504 header written to the hijacked connection and a `http: response.WriteHeader on hijacked connection` warning on stderr. Since #1424 that stderr is captured into `core.stderr.log` and shipped with every log bundle.
- Nothing on the WebSocket path reads the upgrade request's context: melody ignores it and per-message deadlines come from the dispatcher's own context. The group now matches the SSE group, which already carries no request timeout. The pairing and REST-run groups keep theirs.
- The group moves into `mountWebSocketRoutes` so the real wiring can be tested, and a regression test asserts the upgrade request context carries no deadline on `/api`, `/api/v0` and `/api/v0.1`. It fails with the middleware in place.

Closes #1430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection handling by preventing request timeouts from interrupting active connections.
  * Applied consistent rate limiting and cache-control behavior to WebSocket endpoints.

* **Tests**
  * Added coverage verifying WebSocket routes remain available without request deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->