### PR TITLE
fix(mister): correct shared Game Boy artwork matching

### DIFF
--- a/pkg/database/scraper/gamelistxml/gameboy_test.go
+++ b/pkg/database/scraper/gamelistxml/gameboy_test.go
@@ -37,6 +37,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// misterExtensions mirrors the MiSTer launcher table for systems that share a
+// ROM folder with a sibling using a different format. See CreateLaunchers in
+// pkg/platforms/mister/launchers.go; every launcher there also accepts .mgl.
+func misterExtensions(t *testing.T, systemID string) []string {
+	t.Helper()
+	byID := map[string][]string{
+		systemdefs.SystemGameboy:         {".gb", ".mgl"},
+		systemdefs.SystemGameboyColor:    {".gbc", ".mgl"},
+		systemdefs.SystemMasterSystem:    {".sms", ".mgl"},
+		systemdefs.SystemGameGear:        {".gg", ".mgl"},
+		systemdefs.SystemSG1000:          {".sg", ".mgl"},
+		systemdefs.SystemWonderSwan:      {".ws", ".mgl"},
+		systemdefs.SystemWonderSwanColor: {".wsc", ".mgl"},
+		systemdefs.SystemNES:             {".nes", ".mgl"},
+		systemdefs.SystemFDS:             {".fds", ".mgl"},
+		systemdefs.SystemSuperGrafx:      {".sgx", ".mgl"},
+	}
+	exts, ok := byID[systemID]
+	require.True(t, ok, "no launcher extensions recorded for %s", systemID)
+	return exts
+}
+
 func TestGameboySiblingGamelistPaths(t *testing.T) {
 	t.Parallel()
 	for _, companion := range []bool{false, true} {
@@ -70,7 +92,11 @@ func TestGameboySiblingGamelistPaths(t *testing.T) {
 				if allowed {
 					roots = append(roots, gbRoot)
 				}
-				system := scraper.ScrapeSystem{ID: systemdefs.SystemGameboyColor, ROMPaths: roots}
+				system := scraper.ScrapeSystem{
+					ID:         systemdefs.SystemGameboyColor,
+					ROMPaths:   roots,
+					Extensions: misterExtensions(t, systemdefs.SystemGameboyColor),
+				}
 				s := &GamelistXMLScraper{fs: fs}
 				if companion {
 					_, children := s.loadCompanionEntries(context.Background(), system)
@@ -119,7 +145,9 @@ func TestGameboySiblingArtworkFallback(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, filepath.Join(gbcRoot, "gamelist.xml"), []byte(xml), 0o600))
 	s := &GamelistXMLScraper{fs: fs}
 	records, err := s.LoadRecords(context.Background(), scraper.ScrapeSystem{
-		ID: systemdefs.SystemGameboyColor, ROMPaths: []string{gbRoot, gbcRoot},
+		ID:         systemdefs.SystemGameboyColor,
+		ROMPaths:   []string{gbRoot, gbcRoot},
+		Extensions: misterExtensions(t, systemdefs.SystemGameboyColor),
 	}, mediaByPath(database.Media{DBID: 2, MediaTitleDBID: 1, Path: rom}))
 	require.NoError(t, err)
 	require.Len(t, records, 1)
@@ -215,8 +243,14 @@ func TestGameboyScrapeLayouts(t *testing.T) {
 				gbc, err := db.FindSystemBySystemID(systemdefs.SystemGameboyColor)
 				require.NoError(t, err)
 				systems := []scraper.ScrapeSystem{
-					{ID: gb.SystemID, DBID: gb.DBID, ROMPaths: []string{gbRoot}},
-					{ID: gbc.SystemID, DBID: gbc.DBID, ROMPaths: []string{gbRoot, gbcRoot}},
+					{
+						ID: gb.SystemID, DBID: gb.DBID, ROMPaths: []string{gbRoot},
+						Extensions: misterExtensions(t, gb.SystemID),
+					},
+					{
+						ID: gbc.SystemID, DBID: gbc.DBID, ROMPaths: []string{gbRoot, gbcRoot},
+						Extensions: misterExtensions(t, gbc.SystemID),
+					},
 				}
 				s := &GamelistXMLScraper{fs: fs, db: db}
 				for _, force := range []bool{false, false, true} {
@@ -273,7 +307,10 @@ func TestGameboyRenameReindexForceScrape(t *testing.T) {
 			scantest.IndexMediaPaths(t, db, systemdefs.SystemGameboyColor, oldPath)
 			sys, err := db.FindSystemBySystemID(systemdefs.SystemGameboyColor)
 			require.NoError(t, err)
-			systems := []scraper.ScrapeSystem{{ID: sys.SystemID, DBID: sys.DBID, ROMPaths: []string{root}}}
+			systems := []scraper.ScrapeSystem{{
+				ID: sys.SystemID, DBID: sys.DBID, ROMPaths: []string{root},
+				Extensions: misterExtensions(t, sys.SystemID),
+			}}
 			writeXML := func(name, image string) {
 				xml := fmt.Sprintf(`<gameList><game><path>./%s</path><name>Game</name>
 <image>./covers/%s.png</image></game></gameList>`, name, image)
@@ -333,7 +370,10 @@ func TestGameboySharedFolderDoesNotMatchOtherSystemBySlug(t *testing.T) {
 			indexes := mediaBySlugAndPath("game", &database.MediaTitle{DBID: 1, Slug: "game"},
 				database.Media{DBID: 2, MediaTitleDBID: 1, Path: filepath.Join(root, "Game"+tc.extension)})
 			records, err := (&GamelistXMLScraper{fs: fs}).LoadRecords(context.Background(),
-				scraper.ScrapeSystem{ID: tc.system, ROMPaths: []string{root}}, indexes)
+				scraper.ScrapeSystem{
+					ID: tc.system, ROMPaths: []string{root},
+					Extensions: misterExtensions(t, tc.system),
+				}, indexes)
 			require.NoError(t, err)
 			assert.Empty(t, records, "another system's entry must not write metadata or a scrape sentinel")
 
@@ -342,7 +382,10 @@ func TestGameboySharedFolderDoesNotMatchOtherSystemBySlug(t *testing.T) {
 			xml = `<gameList><game><path>./old/Game` + tc.extension + `</path><name>Game</name></game></gameList>`
 			require.NoError(t, afero.WriteFile(fs, filepath.Join(root, "gamelist.xml"), []byte(xml), 0o600))
 			records, err = (&GamelistXMLScraper{fs: fs}).LoadRecords(context.Background(),
-				scraper.ScrapeSystem{ID: tc.system, ROMPaths: []string{root}}, indexes)
+				scraper.ScrapeSystem{
+					ID: tc.system, ROMPaths: []string{root},
+					Extensions: misterExtensions(t, tc.system),
+				}, indexes)
 			require.NoError(t, err)
 			require.Len(t, records, 1)
 			assert.Equal(t, gamelistMatchSlugOnly, records[0].MatchKind)

--- a/pkg/database/scraper/gamelistxml/gameboy_test.go
+++ b/pkg/database/scraper/gamelistxml/gameboy_test.go
@@ -1,0 +1,352 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package gamelistxml
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/scantest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGameboySiblingGamelistPaths(t *testing.T) {
+	t.Parallel()
+	for _, companion := range []bool{false, true} {
+		for _, allowed := range []bool{false, true} {
+			name := "regular"
+			if companion {
+				name = "companion"
+			}
+			if allowed {
+				name += "/same-system-root"
+			} else {
+				name += "/outside-system-roots"
+			}
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				root := t.TempDir()
+				gbRoot := filepath.Join(root, "GAMEBOY")
+				gbcRoot := filepath.Join(root, "GBC")
+				rom := filepath.Join(gbRoot, "Game.gbc")
+				fs := afero.NewMemMapFs()
+				require.NoError(t, fs.MkdirAll(gbcRoot, 0o755))
+				xml := `<gameList><game><path>../GAMEBOY/Game.gbc</path><name>Display Name</name>
+<image>./covers/image.png</image><box2d>./covers/box.png</box2d></game></gameList>`
+				if companion {
+					xml = `<gameList><game source="ZaparooCompanion" id="123">
+<name>Game</name><image>./covers/image.png</image></game>
+<game source="ZaparooCompanion" parentid="123"><path>../GAMEBOY/Game.gbc</path></game></gameList>`
+				}
+				require.NoError(t, afero.WriteFile(fs, filepath.Join(gbcRoot, "gamelist.xml"), []byte(xml), 0o600))
+				roots := []string{gbcRoot}
+				if allowed {
+					roots = append(roots, gbRoot)
+				}
+				system := scraper.ScrapeSystem{ID: systemdefs.SystemGameboyColor, ROMPaths: roots}
+				s := &GamelistXMLScraper{fs: fs}
+				if companion {
+					_, children := s.loadCompanionEntries(context.Background(), system)
+					if !allowed {
+						assert.Empty(t, children)
+						return
+					}
+					require.Len(t, children, 1)
+					assert.Equal(t, rom, children[0].ResolvedPath)
+					return
+				}
+				indexes := mediaByPath(database.Media{DBID: 2, MediaTitleDBID: 1, Path: rom})
+				records, err := s.LoadRecords(context.Background(), system, indexes)
+				require.NoError(t, err)
+				if !allowed {
+					assert.Empty(t, records)
+					return
+				}
+				require.Len(t, records, 1)
+				assert.Equal(t, int64(2), records[0].MatchedMediaDBID)
+				assert.True(t, records[0].MediaLevelWriteSafe)
+				mapped := s.MapToDB(records[0])
+				for property, filename := range map[tags.TagValue]string{
+					tags.TagPropertyImageImage: "image.png", tags.TagPropertyImageBoxart: "box.png",
+				} {
+					prop, ok := propertyByType(mapped.MediaProps, tags.PropertyTypeTag(property))
+					require.True(t, ok)
+					assert.Equal(t, filepath.ToSlash(filepath.Join(gbcRoot, "covers", filename)), prop.Text)
+				}
+			})
+		}
+	}
+}
+
+func TestGameboySiblingArtworkFallback(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	gbRoot, gbcRoot := filepath.Join(root, "GAMEBOY"), filepath.Join(root, "GBC")
+	rom := filepath.Join(gbRoot, "Sub", "Game.gbc")
+	fs := afero.NewMemMapFs()
+	art := filepath.Join(gbcRoot, "media", "box2d", "Sub", "Game.png")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(art), 0o755))
+	require.NoError(t, afero.WriteFile(fs, art, nil, 0o600))
+	xml := `<gameList><game><path>../GAMEBOY/Sub/Game.gbc</path><name>Game</name>
+<image>../GAMEBOY/outside.png</image></game></gameList>`
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(gbcRoot, "gamelist.xml"), []byte(xml), 0o600))
+	s := &GamelistXMLScraper{fs: fs}
+	records, err := s.LoadRecords(context.Background(), scraper.ScrapeSystem{
+		ID: systemdefs.SystemGameboyColor, ROMPaths: []string{gbRoot, gbcRoot},
+	}, mediaByPath(database.Media{DBID: 2, MediaTitleDBID: 1, Path: rom}))
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	mapped := s.MapToDB(records[0])
+	box, ok := propertyByType(mapped.MediaProps, tags.PropertyTypeTag(tags.TagPropertyImageBoxart))
+	require.True(t, ok)
+	assert.Equal(t, filepath.ToSlash(art), box.Text)
+	_, imageOK := propertyByType(mapped.MediaProps, tags.PropertyTypeTag(tags.TagPropertyImageImage))
+	assert.False(t, imageOK, "ROM root expansion must not relax the asset path boundary")
+}
+
+func TestResolveGamelistROMPathBoundaries(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	gbRoot, gbcRoot := filepath.Join(root, "GAMEBOY"), filepath.Join(root, "GBC")
+	for _, path := range []string{
+		filepath.Join("..", "..", "outside.gbc"),
+		filepath.Join("..", "SNES", "Game.gbc"),
+		filepath.Join("..", "GAMEBOY-other", "Game.gbc"),
+		filepath.Join(root, "outside.gbc"),
+	} {
+		resolved, matchedRoot := resolveGamelistROMPath(path, gbcRoot, []string{gbRoot, gbcRoot})
+		assert.Empty(t, resolved, path)
+		assert.Empty(t, matchedRoot, path)
+	}
+}
+
+func scrapeGameboyFixture(
+	t *testing.T, s *GamelistXMLScraper, db database.MediaDBI, systems []scraper.ScrapeSystem, force bool,
+) {
+	t.Helper()
+	ch := make(chan scraper.ScrapeUpdate, 128)
+	s.scrapeLoop(context.Background(), scraper.ScrapeOptions{
+		Force: force, Pauser: syncutil.NewPauser(),
+	}, systems, db, ch)
+	var done bool
+	for update := range ch {
+		require.NoError(t, update.FatalErr)
+		require.NoError(t, update.Err)
+		done = done || update.Done
+	}
+	require.True(t, done)
+}
+
+func TestGameboyScrapeLayouts(t *testing.T) {
+	t.Parallel()
+	for _, layout := range []string{"shared", "separate", "sibling-reference"} {
+		for _, companion := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/companion=%t", layout, companion), func(t *testing.T) {
+				t.Parallel()
+				db, cleanup := helpers.NewInMemoryMediaDB(t)
+				t.Cleanup(cleanup)
+				fs := afero.NewMemMapFs()
+				root := t.TempDir()
+				gbRoot, gbcRoot := filepath.Join(root, "GAMEBOY"), filepath.Join(root, "GBC")
+				gbcROMRoot, gbcXMLRoot := gbcRoot, gbcRoot
+				gbcXMLPath := "./Game.gbc"
+				if layout != "separate" {
+					gbcROMRoot = gbRoot
+				}
+				if layout == "shared" {
+					gbcXMLRoot = gbRoot
+				}
+				if layout == "sibling-reference" {
+					gbcXMLPath = "../GAMEBOY/Game.gbc"
+				}
+				gbPath, gbcPath := filepath.Join(gbRoot, "Game.gb"), filepath.Join(gbcROMRoot, "Game.gbc")
+				scantest.IndexMediaPaths(t, db, systemdefs.SystemGameboy, gbPath)
+				scantest.IndexMediaPaths(t, db, systemdefs.SystemGameboyColor, gbcPath)
+				entries := func(path, id, prefix string) string {
+					if companion {
+						return fmt.Sprintf(`<game source="ZaparooCompanion" id="%s">
+<name>Game</name><desc>%s description</desc><image>./covers/%s-image.png</image>
+<box2d>./covers/%s-box.png</box2d></game>
+<game source="ZaparooCompanion" parentid="%s"><path>%s</path></game>`, id, prefix, prefix, prefix, id, path)
+					}
+					return fmt.Sprintf(`<game><path>%s</path><name>Game</name><desc>%s description</desc>
+<image>./covers/%s-image.png</image><box2d>./covers/%s-box.png</box2d></game>`, path, prefix, prefix, prefix)
+				}
+				gbXML := entries("./Game.gb", "1", "gb")
+				gbcXML := entries(gbcXMLPath, "2", "gbc")
+				files := map[string]string{gbRoot: gbXML, gbcXMLRoot: gbcXML}
+				if layout == "shared" {
+					files[gbRoot] = gbXML + gbcXML
+				}
+				for dir, contents := range files {
+					require.NoError(t, fs.MkdirAll(dir, 0o755))
+					require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "gamelist.xml"),
+						[]byte("<gameList>"+contents+"</gameList>"), 0o600))
+				}
+				gb, err := db.FindSystemBySystemID(systemdefs.SystemGameboy)
+				require.NoError(t, err)
+				gbc, err := db.FindSystemBySystemID(systemdefs.SystemGameboyColor)
+				require.NoError(t, err)
+				systems := []scraper.ScrapeSystem{
+					{ID: gb.SystemID, DBID: gb.DBID, ROMPaths: []string{gbRoot}},
+					{ID: gbc.SystemID, DBID: gbc.DBID, ROMPaths: []string{gbRoot, gbcRoot}},
+				}
+				s := &GamelistXMLScraper{fs: fs, db: db}
+				for _, force := range []bool{false, false, true} {
+					scrapeGameboyFixture(t, s, db, systems, force)
+					for _, tc := range []struct{ system, prefix, assetRoot string }{
+						{gb.SystemID, "gb", gbRoot}, {gbc.SystemID, "gbc", gbcXMLRoot},
+					} {
+						rows, rowsErr := db.GetMediaBySystemID(tc.system)
+						require.NoError(t, rowsErr)
+						require.Len(t, rows, 1)
+						props, propsErr := db.GetMediaProperties(context.Background(), rows[0].DBID)
+						require.NoError(t, propsErr)
+						titleProps, propsErr := db.GetMediaTitleProperties(context.Background(), rows[0].MediaTitleDBID)
+						require.NoError(t, propsErr)
+						if companion {
+							// Companion parent artwork is shared at title scope.
+							assert.Empty(t, props)
+							props = titleProps
+						}
+						for property, suffix := range map[tags.TagValue]string{
+							tags.TagPropertyImageImage: "-image.png", tags.TagPropertyImageBoxart: "-box.png",
+						} {
+							prop, ok := propertyByType(props, tags.PropertyTypeTag(property))
+							require.True(t, ok, "%s property %s, force=%t", tc.system, property, force)
+							want := filepath.ToSlash(filepath.Join(tc.assetRoot, "covers", tc.prefix+suffix))
+							assert.Equal(t, want, prop.Text)
+						}
+						desc, ok := propertyByType(titleProps, tags.PropertyTypeTag(tags.TagPropertyDescription))
+						require.True(t, ok)
+						assert.Equal(t, tc.prefix+" description", desc.Text)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestGameboyRenameReindexForceScrape(t *testing.T) {
+	t.Parallel()
+	for _, changeTitle := range []bool{false, true} {
+		t.Run(fmt.Sprintf("change-title=%t", changeTitle), func(t *testing.T) {
+			t.Parallel()
+			db, cleanup := helpers.NewInMemoryMediaDB(t)
+			t.Cleanup(cleanup)
+			fs := afero.NewMemMapFs()
+			root := filepath.Join(t.TempDir(), "GAMEBOY")
+			require.NoError(t, fs.MkdirAll(root, 0o755))
+			oldName, newName := "Game (USA).gbc", "Game (Europe).gbc"
+			if changeTitle {
+				newName = "Renamed Game.gbc"
+			}
+			oldPath, newPath := filepath.Join(root, oldName), filepath.Join(root, newName)
+			require.NoError(t, afero.WriteFile(fs, oldPath, nil, 0o600))
+			scantest.IndexMediaPaths(t, db, systemdefs.SystemGameboyColor, oldPath)
+			sys, err := db.FindSystemBySystemID(systemdefs.SystemGameboyColor)
+			require.NoError(t, err)
+			systems := []scraper.ScrapeSystem{{ID: sys.SystemID, DBID: sys.DBID, ROMPaths: []string{root}}}
+			writeXML := func(name, image string) {
+				xml := fmt.Sprintf(`<gameList><game><path>./%s</path><name>Game</name>
+<image>./covers/%s.png</image></game></gameList>`, name, image)
+				require.NoError(t, afero.WriteFile(fs, filepath.Join(root, "gamelist.xml"), []byte(xml), 0o600))
+			}
+			writeXML(oldName, "original")
+			s := &GamelistXMLScraper{fs: fs, db: db}
+			scrapeGameboyFixture(t, s, db, systems, false)
+			require.NoError(t, fs.Rename(oldPath, newPath))
+			scantest.IndexMediaPaths(t, db, sys.SystemID, newPath)
+			xmlName := oldName
+			if changeTitle {
+				xmlName = newName
+			}
+			// A same-title rename can recover through the old XML slug. If the
+			// title changes, the refreshed path must win over the missing title.
+			writeXML(xmlName, "refreshed")
+			scrapeGameboyFixture(t, s, db, systems, true)
+			rows, err := db.GetMediaBySystemID(sys.SystemID)
+			require.NoError(t, err)
+			require.Len(t, rows, 2)
+			for _, row := range rows {
+				props, propsErr := db.GetMediaProperties(context.Background(), row.DBID)
+				require.NoError(t, propsErr)
+				image, ok := propertyByType(props, tags.PropertyTypeTag(tags.TagPropertyImageImage))
+				require.True(t, ok, "artwork missing for %s", row.Path)
+				want := "refreshed.png"
+				if row.Path == filepath.ToSlash(oldPath) {
+					assert.True(t, row.IsMissing)
+					want = "original.png"
+				} else {
+					assert.Equal(t, filepath.ToSlash(newPath), row.Path)
+					assert.False(t, row.IsMissing)
+				}
+				assert.Equal(t, filepath.ToSlash(filepath.Join(root, "covers", want)), image.Text)
+			}
+		})
+	}
+}
+
+func TestGameboySharedFolderDoesNotMatchOtherSystemBySlug(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ system, extension, otherExtension string }{
+		{systemdefs.SystemGameboy, ".gb", ".gbc"},
+		{systemdefs.SystemGameboyColor, ".gbc", ".gb"},
+	} {
+		t.Run(tc.system, func(t *testing.T) {
+			t.Parallel()
+			root := filepath.Join(t.TempDir(), "GAMEBOY")
+			fs := afero.NewMemMapFs()
+			require.NoError(t, fs.MkdirAll(root, 0o755))
+			// An XML entry for the other system must not claim a same-named title,
+			// including when that system's own entry is absent from this gamelist.
+			xml := `<gameList><game><path>./Game` + tc.otherExtension + `</path>
+<name>Game</name><image>./wrong.png</image></game></gameList>`
+			require.NoError(t, afero.WriteFile(fs, filepath.Join(root, "gamelist.xml"), []byte(xml), 0o600))
+			indexes := mediaBySlugAndPath("game", &database.MediaTitle{DBID: 1, Slug: "game"},
+				database.Media{DBID: 2, MediaTitleDBID: 1, Path: filepath.Join(root, "Game"+tc.extension)})
+			records, err := (&GamelistXMLScraper{fs: fs}).LoadRecords(context.Background(),
+				scraper.ScrapeSystem{ID: tc.system, ROMPaths: []string{root}}, indexes)
+			require.NoError(t, err)
+			assert.Empty(t, records, "another system's entry must not write metadata or a scrape sentinel")
+
+			// Rejecting an incompatible entry must not consume the title: a
+			// subsequent valid slug-only entry can still enrich its moved ROM.
+			xml = `<gameList><game><path>./old/Game` + tc.extension + `</path><name>Game</name></game></gameList>`
+			require.NoError(t, afero.WriteFile(fs, filepath.Join(root, "gamelist.xml"), []byte(xml), 0o600))
+			records, err = (&GamelistXMLScraper{fs: fs}).LoadRecords(context.Background(),
+				scraper.ScrapeSystem{ID: tc.system, ROMPaths: []string{root}}, indexes)
+			require.NoError(t, err)
+			require.Len(t, records, 1)
+			assert.Equal(t, gamelistMatchSlugOnly, records[0].MatchKind)
+			assert.Equal(t, int64(2), records[0].MatchedMediaDBID)
+		})
+	}
+}

--- a/pkg/database/scraper/gamelistxml/nestedroot_test.go
+++ b/pkg/database/scraper/gamelistxml/nestedroot_test.go
@@ -1,0 +1,96 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package gamelistxml
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveGamelistROMPathNestedRoots covers configured roots that nest. The
+// ROM belongs to the most specific root, so artwork fallback names stay relative
+// to the media/ directory beside it instead of gaining the nested prefix and
+// matching a same-named file in the outer root.
+func TestResolveGamelistROMPathNestedRoots(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	outer := filepath.Join(base, "GAMEBOY")
+	inner := filepath.Join(outer, "Subset")
+	gbcRoot := filepath.Join(base, "GBC")
+
+	for _, order := range [][]string{
+		{gbcRoot, outer, inner},
+		{gbcRoot, inner, outer},
+	} {
+		resolved, matchedRoot := resolveGamelistROMPath("../GAMEBOY/Subset/Game.gbc", gbcRoot, order)
+		assert.Equal(t, filepath.Join(inner, "Game.gbc"), resolved)
+		assert.Equal(t, inner, matchedRoot, "most specific root must win, order %v", order)
+	}
+
+	resolved, matchedRoot := resolveGamelistROMPath("", gbcRoot, []string{outer})
+	assert.Empty(t, resolved)
+	assert.Empty(t, matchedRoot)
+}
+
+func TestNestedRootArtworkFallback(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	outer := filepath.Join(base, "GAMEBOY")
+	inner := filepath.Join(outer, "Subset")
+	gbcRoot := filepath.Join(base, "GBC")
+	rom := filepath.Join(inner, "Game.gbc")
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll(gbcRoot, 0o755))
+	wanted := filepath.Join(inner, "media", "box2d", "Game.png")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(wanted), 0o755))
+	require.NoError(t, afero.WriteFile(fs, wanted, nil, 0o600))
+	// Treating the outer root as the ROM's root names the artwork
+	// Subset/Game.png, which matches a different game's cover here.
+	decoy := filepath.Join(outer, "media", "box2d", "Subset", "Game.png")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(decoy), 0o755))
+	require.NoError(t, afero.WriteFile(fs, decoy, nil, 0o600))
+
+	xml := `<gameList><game><path>../GAMEBOY/Subset/Game.gbc</path><name>Game</name></game></gameList>`
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(gbcRoot, "gamelist.xml"), []byte(xml), 0o600))
+
+	s := &GamelistXMLScraper{fs: fs}
+	records, err := s.LoadRecords(context.Background(), scraper.ScrapeSystem{
+		ID: systemdefs.SystemGameboyColor, ROMPaths: []string{gbcRoot, outer, inner},
+		Extensions: misterExtensions(t, systemdefs.SystemGameboyColor),
+	}, mediaByPath(database.Media{DBID: 2, MediaTitleDBID: 1, Path: rom}))
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, inner, records[0].ROMRootPath)
+
+	mapped := s.MapToDB(records[0])
+	box, ok := propertyByType(mapped.MediaProps, tags.PropertyTypeTag(tags.TagPropertyImageBoxart))
+	require.True(t, ok)
+	assert.Equal(t, filepath.ToSlash(wanted), box.Text)
+}

--- a/pkg/database/scraper/gamelistxml/nestedroot_test.go
+++ b/pkg/database/scraper/gamelistxml/nestedroot_test.go
@@ -53,7 +53,12 @@ func TestResolveGamelistROMPathNestedRoots(t *testing.T) {
 		assert.Equal(t, inner, matchedRoot, "most specific root must win, order %v", order)
 	}
 
-	resolved, matchedRoot := resolveGamelistROMPath("", gbcRoot, []string{outer})
+	// A blank configured root is ignored rather than treated as a container.
+	resolved, matchedRoot := resolveGamelistROMPath("../GAMEBOY/Subset/Game.gbc", gbcRoot, []string{"", inner})
+	assert.Equal(t, filepath.Join(inner, "Game.gbc"), resolved)
+	assert.Equal(t, inner, matchedRoot)
+
+	resolved, matchedRoot = resolveGamelistROMPath("", gbcRoot, []string{outer})
 	assert.Empty(t, resolved)
 	assert.Empty(t, matchedRoot)
 }

--- a/pkg/database/scraper/gamelistxml/resolvesystems_test.go
+++ b/pkg/database/scraper/gamelistxml/resolvesystems_test.go
@@ -1,0 +1,109 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package gamelistxml
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/scantest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// The scrape systems carry the extensions each system's launchers index, which
+// is what stops a shared ROM folder handing one system's gamelist entries to
+// another. A system whose launchers accept files through a Test function has no
+// stateable set and must be left unknown rather than partially listed.
+func TestResolveSystemsFromPlatformCarriesLauncherExtensions(t *testing.T) {
+	t.Parallel()
+
+	db, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	root := t.TempDir()
+	gbDir := filepath.Join(root, "GAMEBOY")
+	gbcDir := filepath.Join(root, "GBC")
+	atariDir := filepath.Join(root, "ATARI7800")
+	for _, dir := range []string{gbDir, gbcDir, atariDir} {
+		require.NoError(t, os.MkdirAll(dir, 0o750))
+	}
+	scantest.IndexMediaPaths(t, db, systemdefs.SystemGameboy, filepath.Join(gbDir, "Game.gb"))
+	scantest.IndexMediaPaths(t, db, systemdefs.SystemGameboyColor, filepath.Join(gbDir, "Game.gbc"))
+	scantest.IndexMediaPaths(t, db, systemdefs.SystemAtari2600, filepath.Join(atariDir, "Game.a26"))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.BaseDefaults)
+	require.NoError(t, err)
+
+	pl := &mocks.MockPlatform{}
+	pl.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{root})
+	pl.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{
+			ID: "Gameboy", SystemID: systemdefs.SystemGameboy,
+			Folders: []string{"GAMEBOY"}, Extensions: []string{".gb", ".mgl"},
+		},
+		{ID: "RAGameboy", SystemID: systemdefs.SystemGameboy},
+		{
+			ID: "GameboyColor", SystemID: systemdefs.SystemGameboyColor,
+			Folders: []string{"GAMEBOY", "GBC"}, Extensions: []string{".gbc", ".mgl"},
+		},
+		{
+			ID: "Atari2600", SystemID: systemdefs.SystemAtari2600,
+			Folders: []string{"ATARI7800"}, Extensions: []string{".a26"},
+			Test: func(*config.Instance, string) bool { return false },
+		},
+	})
+
+	systems, err := resolveSystemsFromPlatform(context.Background(), cfg, pl, db, nil)
+	require.NoError(t, err)
+
+	byID := make(map[string]struct {
+		roots []string
+		exts  []string
+	}, len(systems))
+	for _, system := range systems {
+		byID[system.ID] = struct {
+			roots []string
+			exts  []string
+		}{system.ROMPaths, system.Extensions}
+	}
+
+	gb, ok := byID[systemdefs.SystemGameboy]
+	require.True(t, ok)
+	assert.Equal(t, []string{gbDir}, gb.roots)
+	assert.Equal(t, []string{".gb", ".mgl"}, gb.exts)
+
+	gbc, ok := byID[systemdefs.SystemGameboyColor]
+	require.True(t, ok)
+	assert.Equal(t, []string{gbDir, gbcDir}, gbc.roots)
+	assert.Equal(t, []string{".gbc", ".mgl"}, gbc.exts)
+
+	atari, ok := byID[systemdefs.SystemAtari2600]
+	require.True(t, ok)
+	assert.Empty(t, atari.exts, "a Test function leaves the set unknown, not partial")
+}

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -59,6 +59,7 @@ import (
 type GamelistRecord struct {
 	MediaDirsByRoot      []map[string]string
 	SystemRootPath       string
+	ROMRootPath          string
 	AssetRootPath        string
 	MatchKind            gamelistMatchKind
 	Game                 esapi.Game
@@ -473,7 +474,7 @@ outer:
 				continue
 			}
 
-			resolved := esmedia.ResolvePath(game.Path, file.RootPath)
+			resolved, romRoot := resolveGamelistROMPath(game.Path, file.RootPath, system.ROMPaths)
 			if resolved == "" {
 				invalidPaths++
 				continue
@@ -508,6 +509,7 @@ outer:
 					slugPathSelections++
 					records = append(records, &GamelistRecord{
 						SystemRootPath:       file.RootPath,
+						ROMRootPath:          romRoot,
 						AssetRootPath:        file.AssetRootPath,
 						MediaDirsByRoot:      fileMediaDirsByRoot,
 						Game:                 *game,
@@ -527,9 +529,11 @@ outer:
 						Str("system", system.ID).
 						Str("slug", pf.Slug).
 						Int64("mediaTitleDBID", title.DBID).
-						Msg("gamelistxml: slug matched title but no media row found, skipping")
+						Msg("gamelistxml: slug matched title but no compatible media row found, skipping")
 					unmatchedRecords++
-					delete(indexes.TitlesBySlug, pf.Slug)
+					if len(indexes.MediaByTitleDBID[title.DBID]) == 0 {
+						delete(indexes.TitlesBySlug, pf.Slug)
+					}
 					continue
 				}
 
@@ -545,6 +549,7 @@ outer:
 				}
 				records = append(records, &GamelistRecord{
 					SystemRootPath:       file.RootPath,
+					ROMRootPath:          romRoot,
 					AssetRootPath:        file.AssetRootPath,
 					MediaDirsByRoot:      fileMediaDirsByRoot,
 					Game:                 *game,
@@ -568,6 +573,7 @@ outer:
 					Msg("gamelistxml: path-only fallback matched record")
 				records = append(records, &GamelistRecord{
 					SystemRootPath:       file.RootPath,
+					ROMRootPath:          romRoot,
 					AssetRootPath:        file.AssetRootPath,
 					MediaDirsByRoot:      fileMediaDirsByRoot,
 					Game:                 *game,
@@ -600,7 +606,7 @@ outer:
 		// the folder's launch target always wins the row.
 		for i := range file.Folders {
 			folder := &file.Folders[i]
-			resolved := esmedia.ResolvePath(folder.Path, file.RootPath)
+			resolved, romRoot := resolveGamelistROMPath(folder.Path, file.RootPath, system.ROMPaths)
 			if resolved == "" {
 				invalidPaths++
 				continue
@@ -614,6 +620,7 @@ outer:
 			folderMatches++
 			records = append(records, &GamelistRecord{
 				SystemRootPath:       file.RootPath,
+				ROMRootPath:          romRoot,
 				AssetRootPath:        file.AssetRootPath,
 				MediaDirsByRoot:      fileMediaDirsByRoot,
 				Game:                 folderAsGame(folder),
@@ -840,6 +847,11 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		containerRows := make([]database.Media, 0, len(allMedia))
 		for i := range allMedia {
 			m := &allMedia[i]
+			// Reindexing retains renamed/deleted paths as missing rows. They
+			// must not claim XML entries or make a live slug match ambiguous.
+			if m.IsMissing {
+				continue
+			}
 			media := database.Media{
 				DBID:           m.DBID,
 				MediaTitleDBID: m.MediaTitleDBID,
@@ -858,6 +870,11 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			}
 		}
 		indexes.Containers = container.NewIndex(containerRows)
+		for slug, title := range titlesBySlug {
+			if len(indexes.MediaByTitleDBID[title.DBID]) == 0 {
+				delete(titlesBySlug, slug)
+			}
+		}
 
 		parseStart := time.Now()
 		parsed, parseErr := g.loadParsedGamelistSystem(ctx, system)
@@ -1223,6 +1240,12 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 	// fallbackNames are ROM-relative PNG filenames used to locate matching
 	// artwork files under media/ sub-directories.
 	fallbackNames := artworkFallbackNames(game.Path, record.SystemRootPath)
+	if record.ROMRootPath != "" && record.ROMRootPath != record.SystemRootPath {
+		resolved, ok := esmedia.ResolvePathAbs(game.Path, record.SystemRootPath)
+		if ok {
+			fallbackNames = artworkFallbackNames(resolved, record.ROMRootPath)
+		}
+	}
 
 	if game.Desc != "" {
 		titleProps = append(titleProps,
@@ -1404,6 +1427,25 @@ func appendNormalizedTag(tagInfos []database.TagInfo, tagType, raw, label string
 	return append(tagInfos, database.TagInfo{Type: tagType, Tag: normalized, Label: label})
 }
 
+// resolveGamelistROMPath allows a gamelist to refer to another configured ROM
+// root of the same system, but never to an arbitrary sibling directory. Asset
+// paths keep their separate policy and remain relative to the gamelist root.
+func resolveGamelistROMPath(esPath, root string, romRoots []string) (path, matchedRoot string) {
+	resolved, ok := esmedia.ResolvePathAbs(esPath, root)
+	if !ok {
+		return "", ""
+	}
+	if esmedia.PathWithinRoot(resolved, root) {
+		return resolved, root
+	}
+	for _, romRoot := range romRoots {
+		if esmedia.PathWithinRoot(resolved, romRoot) {
+			return resolved, romRoot
+		}
+	}
+	return "", ""
+}
+
 // pathPropFS resolves esPath to an absolute path and returns a MediaProperty
 // for typeTag. When requireExists is true, unresolved and missing paths are
 // skipped so another artwork source can provide the property.
@@ -1578,16 +1620,26 @@ func selectMediaForSlugMatch(
 			Msg("gamelistxml: slug match path points at different title, writing title metadata only")
 	}
 
-	mediaRows := indexes.MediaByTitleDBID[mediaTitleDBID]
-	if len(mediaRows) == 0 {
-		return slugMediaSelection{matchKind: matchKind}
+	var first database.Media
+	var candidates int
+	ext := strings.ToLower(filepath.Ext(resolved))
+	for _, row := range indexes.MediaByTitleDBID[mediaTitleDBID] {
+		// GB and GBC share ROM roots on MiSTer, but a name match must never
+		// transfer metadata between their distinct ROM formats. Exact paths
+		// above still support launchers that deliberately index both formats.
+		rowExt := strings.ToLower(filepath.Ext(row.Path))
+		if (ext == ".gb" && rowExt == ".gbc") || (ext == ".gbc" && rowExt == ".gb") {
+			continue
+		}
+		if candidates == 0 {
+			first = row
+		}
+		candidates++
 	}
-	// A pure slug-only match with exactly one media row is unambiguous: there is
-	// only one place the artwork can go, so media-level writes are safe.
-	// slug_conflict (path points at a different title) and multi-row titles stay
-	// unsafe to avoid attaching art to the wrong regional variant.
-	mediaLevelSafe := matchKind == gamelistMatchSlugOnly && len(mediaRows) == 1
-	return slugMediaSelection{media: mediaRows[0], matchKind: matchKind, mediaLevelSafe: mediaLevelSafe}
+	// A pure slug-only match with exactly one compatible media row is
+	// unambiguous. Conflicting paths and multiple variants stay unsafe.
+	mediaLevelSafe := matchKind == gamelistMatchSlugOnly && candidates == 1
+	return slugMediaSelection{media: first, matchKind: matchKind, mediaLevelSafe: mediaLevelSafe}
 }
 
 // containerMediaForDir resolves a directory path to the unscraped media row it
@@ -1930,7 +1982,7 @@ func companionEntriesFromParsed(
 					RequireExistingImage: file.RequireExistingImage,
 				})
 			case game.ParentIDAttr != "" && game.Path != "":
-				resolved := esmedia.ResolvePath(game.Path, file.RootPath)
+				resolved, _ := resolveGamelistROMPath(game.Path, file.RootPath, system.ROMPaths)
 				if resolved == "" {
 					unresolvedChildPaths++
 					continue

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -1481,15 +1481,28 @@ func resolveGamelistROMPath(esPath, root string, romRoots []string) (path, match
 	if !ok {
 		return "", ""
 	}
-	if esmedia.PathWithinRoot(resolved, root) {
-		return resolved, root
-	}
-	for _, romRoot := range romRoots {
-		if esmedia.PathWithinRoot(resolved, romRoot) {
-			return resolved, romRoot
+	// Configured roots may nest, so the first container is not necessarily the
+	// right one. The most specific root owns the ROM: artwork fallback names are
+	// relative to it, and an outer root would prefix them with the nested
+	// directory and miss the media/ directory beside the ROM.
+	depth := -1
+	consider := func(candidate string) {
+		if candidate == "" || !esmedia.PathWithinRoot(resolved, candidate) {
+			return
+		}
+		if abs, err := filepath.Abs(candidate); err == nil && len(filepath.Clean(abs)) > depth {
+			depth = len(filepath.Clean(abs))
+			matchedRoot = candidate
 		}
 	}
-	return "", ""
+	consider(root)
+	for _, romRoot := range romRoots {
+		consider(romRoot)
+	}
+	if matchedRoot == "" {
+		return "", ""
+	}
+	return resolved, matchedRoot
 }
 
 // pathPropFS resolves esPath to an absolute path and returns a MediaProperty

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -30,6 +30,7 @@ import (
 	"math"
 	"path/filepath"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -298,6 +299,7 @@ func resolveSystemsFromPlatform(
 	for _, pathResult := range mediascanner.GetSystemPaths(ctx, cfg, pl, pl.RootDirs(cfg), sysDefs) {
 		pathsBySystem[pathResult.System.ID] = append(pathsBySystem[pathResult.System.ID], pathResult.Path)
 	}
+	extsBySystem := indexedExtensionsBySystem(pl.Launchers(cfg))
 
 	result := make([]scraper.ScrapeSystem, 0, len(sysDefs))
 	for _, sys := range sysDefs {
@@ -307,12 +309,56 @@ func resolveSystemsFromPlatform(
 			continue
 		}
 		result = append(result, scraper.ScrapeSystem{
-			DBID:     dbSystems[sys.ID].DBID,
-			ID:       sys.ID,
-			ROMPaths: romPaths,
+			DBID:       dbSystems[sys.ID].DBID,
+			ID:         sys.ID,
+			ROMPaths:   romPaths,
+			Extensions: extsBySystem[sys.ID],
 		})
 	}
 	return result, nil
+}
+
+// indexedExtensionsBySystem collects, per system, the extensions its launchers
+// accept. A launcher with a Test function can accept a file its extension list
+// does not name, so any such launcher makes the system's set unknown and the
+// entry is left out rather than reported as a partial list.
+func indexedExtensionsBySystem(launchers []platforms.Launcher) map[string][]string {
+	unknown := make(map[string]struct{})
+	seen := make(map[string]map[string]struct{})
+	for i := range launchers {
+		launcher := &launchers[i]
+		if launcher.SystemID == "" {
+			continue
+		}
+		if launcher.Test != nil {
+			unknown[launcher.SystemID] = struct{}{}
+			continue
+		}
+		for _, ext := range launcher.Extensions {
+			normalized := strings.ToLower(ext)
+			if normalized == "" {
+				continue
+			}
+			if seen[launcher.SystemID] == nil {
+				seen[launcher.SystemID] = make(map[string]struct{})
+			}
+			seen[launcher.SystemID][normalized] = struct{}{}
+		}
+	}
+
+	result := make(map[string][]string, len(seen))
+	for systemID, exts := range seen {
+		if _, skip := unknown[systemID]; skip {
+			continue
+		}
+		ordered := make([]string, 0, len(exts))
+		for ext := range exts {
+			ordered = append(ordered, ext)
+		}
+		slices.Sort(ordered)
+		result[systemID] = ordered
+	}
+	return result
 }
 
 type parsedGamelistFile struct {
@@ -523,7 +569,7 @@ outer:
 					continue
 				}
 
-				selection := selectMediaForSlugMatch(indexes, title.DBID, resolved)
+				selection := selectMediaForSlugMatch(indexes, title.DBID, resolved, system.Extensions)
 				if selection.media.DBID == 0 {
 					log.Debug().
 						Str("system", system.ID).
@@ -1603,6 +1649,7 @@ func selectMediaForSlugMatch(
 	indexes loadRecordIndexes,
 	mediaTitleDBID int64,
 	resolved string,
+	systemExtensions []string,
 ) slugMediaSelection {
 	media, matchedKey, ok := matchMediaByResolvedPath(indexes, resolved)
 	if ok && media.MediaTitleDBID == mediaTitleDBID {
@@ -1620,26 +1667,39 @@ func selectMediaForSlugMatch(
 			Msg("gamelistxml: slug match path points at different title, writing title metadata only")
 	}
 
-	var first database.Media
-	var candidates int
-	ext := strings.ToLower(filepath.Ext(resolved))
-	for _, row := range indexes.MediaByTitleDBID[mediaTitleDBID] {
-		// GB and GBC share ROM roots on MiSTer, but a name match must never
-		// transfer metadata between their distinct ROM formats. Exact paths
-		// above still support launchers that deliberately index both formats.
-		rowExt := strings.ToLower(filepath.Ext(row.Path))
-		if (ext == ".gb" && rowExt == ".gbc") || (ext == ".gbc" && rowExt == ".gb") {
-			continue
-		}
-		if candidates == 0 {
-			first = row
-		}
-		candidates++
+	if !systemIndexesExtension(systemExtensions, resolved) {
+		return slugMediaSelection{matchKind: matchKind}
 	}
-	// A pure slug-only match with exactly one compatible media row is
-	// unambiguous. Conflicting paths and multiple variants stay unsafe.
-	mediaLevelSafe := matchKind == gamelistMatchSlugOnly && candidates == 1
-	return slugMediaSelection{media: first, matchKind: matchKind, mediaLevelSafe: mediaLevelSafe}
+
+	mediaRows := indexes.MediaByTitleDBID[mediaTitleDBID]
+	if len(mediaRows) == 0 {
+		return slugMediaSelection{matchKind: matchKind}
+	}
+	// A pure slug-only match with exactly one media row is unambiguous: there is
+	// only one place the artwork can go, so media-level writes are safe.
+	// slug_conflict (path points at a different title) and multi-row titles stay
+	// unsafe to avoid attaching art to the wrong regional variant.
+	mediaLevelSafe := matchKind == gamelistMatchSlugOnly && len(mediaRows) == 1
+	return slugMediaSelection{media: mediaRows[0], matchKind: matchKind, mediaLevelSafe: mediaLevelSafe}
+}
+
+// systemIndexesExtension reports whether resolved names a file this system's
+// launchers would index. MiSTer systems share ROM folders with siblings that use
+// a different format — GAMEBOY holds .gb, .gbc and MegaDuck .bin; SMS holds
+// .sms, .gg and .sg; NES holds .nes, .fds and .nsf — so one system's gamelist
+// routinely describes another's ROMs. Those entries must not reach the name
+// based fallback, or the sibling's metadata and artwork land on this system's
+// media row. An exact path match is checked before this and still wins, so a
+// launcher that deliberately indexes several formats is unaffected.
+func systemIndexesExtension(systemExtensions []string, resolved string) bool {
+	if len(systemExtensions) == 0 {
+		return true
+	}
+	ext := strings.ToLower(filepath.Ext(resolved))
+	if ext == "" {
+		return true
+	}
+	return slices.Contains(systemExtensions, ext)
 }
 
 // containerMediaForDir resolves a directory path to the unscraped media row it

--- a/pkg/database/scraper/gamelistxml/sharedfolder_test.go
+++ b/pkg/database/scraper/gamelistxml/sharedfolder_test.go
@@ -104,6 +104,7 @@ func TestIndexedExtensionsBySystem(t *testing.T) {
 			Test: func(*config.Instance, string) bool { return true },
 		},
 		{ID: "NoSystem", Extensions: []string{".zip"}},
+		{ID: "Blank", SystemID: systemdefs.SystemGameboy, Extensions: []string{""}},
 	}
 	got := indexedExtensionsBySystem(launchers)
 	assert.Equal(t, []string{".gb", ".mgl"}, got[systemdefs.SystemGameboy])

--- a/pkg/database/scraper/gamelistxml/sharedfolder_test.go
+++ b/pkg/database/scraper/gamelistxml/sharedfolder_test.go
@@ -1,0 +1,141 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package gamelistxml
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSharedFolderSiblingSystemsBySlug covers the MiSTer folders shared by
+// systems that use different ROM formats. Game Boy is the reported case, but
+// SMS, WonderSwan, NES and TGFX16 have the same shape, so the guard is driven by
+// each system's launcher extensions rather than a Game Boy special case.
+func TestSharedFolderSiblingSystemsBySlug(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ folder, system, extension, sibling string }{
+		{"GAMEBOY", systemdefs.SystemGameboy, ".gb", ".gbc"},
+		{"GAMEBOY", systemdefs.SystemGameboyColor, ".gbc", ".gb"},
+		{"SMS", systemdefs.SystemMasterSystem, ".sms", ".gg"},
+		{"SMS", systemdefs.SystemGameGear, ".gg", ".sg"},
+		{"WonderSwan", systemdefs.SystemWonderSwan, ".ws", ".wsc"},
+		{"NES", systemdefs.SystemNES, ".nes", ".fds"},
+		{"TGFX16", systemdefs.SystemSuperGrafx, ".sgx", ".pce"},
+	} {
+		t.Run(tc.folder+"/"+tc.system, func(t *testing.T) {
+			t.Parallel()
+			root := filepath.Join(t.TempDir(), tc.folder)
+			fs := afero.NewMemMapFs()
+			require.NoError(t, fs.MkdirAll(root, 0o755))
+			system := scraper.ScrapeSystem{
+				ID: tc.system, ROMPaths: []string{root},
+				Extensions: misterExtensions(t, tc.system),
+			}
+			indexes := mediaBySlugAndPath("game", &database.MediaTitle{DBID: 1, Slug: "game"},
+				database.Media{DBID: 2, MediaTitleDBID: 1, Path: filepath.Join(root, "Game"+tc.extension)})
+
+			xml := `<gameList><game><path>./Game` + tc.sibling + `</path>
+<name>Game</name><image>./wrong.png</image></game></gameList>`
+			require.NoError(t, afero.WriteFile(fs, filepath.Join(root, "gamelist.xml"), []byte(xml), 0o600))
+			records, err := (&GamelistXMLScraper{fs: fs}).LoadRecords(context.Background(), system, indexes)
+			require.NoError(t, err)
+			assert.Empty(t, records, "a sibling system's entry must not claim this system's title")
+
+			// The rejection must not consume the title: this system's own entry
+			// still recovers its moved ROM through the slug.
+			xml = `<gameList><game><path>./old/Game` + tc.extension + `</path><name>Game</name></game></gameList>`
+			require.NoError(t, afero.WriteFile(fs, filepath.Join(root, "gamelist.xml"), []byte(xml), 0o600))
+			records, err = (&GamelistXMLScraper{fs: fs}).LoadRecords(context.Background(), system, indexes)
+			require.NoError(t, err)
+			require.Len(t, records, 1)
+			assert.Equal(t, gamelistMatchSlugOnly, records[0].MatchKind)
+			assert.Equal(t, int64(2), records[0].MatchedMediaDBID)
+		})
+	}
+}
+
+// TestSystemIndexesExtensionUnknownSet keeps the guard fail-open. A system whose
+// launchers accept files through a Test function has no exact extension list, so
+// filtering on a partial list would drop entries the scanner did index.
+func TestSystemIndexesExtensionUnknownSet(t *testing.T) {
+	t.Parallel()
+	assert.True(t, systemIndexesExtension(nil, "/roms/GAMEBOY/Game.gbc"))
+	assert.True(t, systemIndexesExtension([]string{".gb"}, "/roms/GAMEBOY/DiscFolder"))
+	assert.True(t, systemIndexesExtension([]string{".gb", ".mgl"}, "/roms/GAMEBOY/Game.GB"))
+	assert.False(t, systemIndexesExtension([]string{".gb", ".mgl"}, "/roms/GAMEBOY/Game.gbc"))
+}
+
+func TestIndexedExtensionsBySystem(t *testing.T) {
+	t.Parallel()
+	launchers := []platforms.Launcher{
+		{ID: "Gameboy", SystemID: systemdefs.SystemGameboy, Extensions: []string{".GB", ".mgl"}},
+		{ID: "RAGameboy", SystemID: systemdefs.SystemGameboy},
+		{ID: "GameboyColor", SystemID: systemdefs.SystemGameboyColor, Extensions: []string{".gbc"}},
+		{ID: "Custom", SystemID: systemdefs.SystemGameboyColor, Extensions: []string{".mgl"}},
+		{
+			ID: "Arcade", SystemID: systemdefs.SystemArcade, Extensions: []string{".mra"},
+			Test: func(*config.Instance, string) bool { return true },
+		},
+		{ID: "NoSystem", Extensions: []string{".zip"}},
+	}
+	got := indexedExtensionsBySystem(launchers)
+	assert.Equal(t, []string{".gb", ".mgl"}, got[systemdefs.SystemGameboy])
+	assert.Equal(t, []string{".gbc", ".mgl"}, got[systemdefs.SystemGameboyColor])
+	assert.NotContains(t, got, systemdefs.SystemArcade, "a Test function makes the set unknown")
+	assert.NotContains(t, got, "")
+}
+
+// TestSlugWithoutMediaRowsIsReleased covers the title with no media rows at all:
+// the slug is dropped so a later entry naming the same title can still match by
+// path instead of being shadowed.
+func TestSlugWithoutMediaRowsIsReleased(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), "GAMEBOY")
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll(root, 0o755))
+	xml := `<gameList><game><path>./Missing.gb</path><name>Game</name></game>
+<game><path>./Other.gb</path><name>Game</name><image>./art.png</image></game></gameList>`
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(root, "gamelist.xml"), []byte(xml), 0o600))
+
+	// The slug resolves to title 1, which owns no media rows. The only indexed
+	// row belongs to a different title.
+	indexes := mediaBySlugAndPath("game", &database.MediaTitle{DBID: 1, Slug: "game"},
+		database.Media{DBID: 5, MediaTitleDBID: 9, Path: filepath.Join(root, "Other.gb")})
+
+	records, err := (&GamelistXMLScraper{fs: fs}).LoadRecords(context.Background(), scraper.ScrapeSystem{
+		ID: systemdefs.SystemGameboy, ROMPaths: []string{root},
+		Extensions: misterExtensions(t, systemdefs.SystemGameboy),
+	}, indexes)
+	require.NoError(t, err)
+	assert.NotContains(t, indexes.TitlesBySlug, "game", "a title with no media rows must release its slug")
+	require.Len(t, records, 1)
+	assert.Equal(t, gamelistMatchPathOnly, records[0].MatchKind)
+	assert.Equal(t, int64(5), records[0].MatchedMediaDBID)
+}

--- a/pkg/database/scraper/scraper.go
+++ b/pkg/database/scraper/scraper.go
@@ -82,5 +82,11 @@ type MatchResult struct {
 type ScrapeSystem struct {
 	ID       string
 	ROMPaths []string
-	DBID     int64
+	// Extensions is the union of file extensions the platform's launchers index
+	// for this system, lower-cased and dot-prefixed. It is empty when the set
+	// cannot be stated exactly, which happens when a launcher accepts files
+	// through a Test function instead of an extension list. Consumers must treat
+	// an empty slice as "unknown", never as "indexes nothing".
+	Extensions []string
+	DBID       int64
 }

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -24,6 +24,7 @@ package mister
 import (
 	"archive/zip"
 	"context"
+	"encoding/xml"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/catalog"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mgls"
 	platformshared "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/stretchr/testify/assert"
@@ -892,6 +894,73 @@ func TestRetroAchievementsSetNameMapping(t *testing.T) {
 			got, ok := retroAchievementsSetName(launcherID)
 			require.True(t, ok)
 			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestGameboyLaunchMGLPaths(t *testing.T) {
+	t.Parallel()
+	byID := make(map[string]platforms.Launcher)
+	for _, launcher := range CreateLaunchers(NewPlatform()) {
+		byID[launcher.ID] = launcher
+	}
+	for _, tc := range []struct {
+		id, system, extension, setName string
+		ra, sameDir                    bool
+	}{
+		{id: "Gameboy", system: "Gameboy", extension: ".gb"},
+		{id: "GameboyColor", system: "GameboyColor", extension: ".gbc", setName: "GBC"},
+		{id: "RAGameboy", system: "Gameboy", extension: ".gb", setName: "RA_Gameboy", ra: true, sameDir: true},
+		{id: "RAGameboyColor", system: "GameboyColor", extension: ".gbc", setName: "RA_GBC", ra: true},
+	} {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+			launcher, ok := byID[tc.id]
+			require.True(t, ok)
+			assert.Equal(t, tc.system, launcher.SystemID)
+			require.NotNil(t, launcher.Launch)
+			base, err := cores.GetCore(tc.system)
+			require.NoError(t, err)
+			core := *base
+			if tc.ra {
+				setName, found := retroAchievementsSetName(tc.id)
+				require.True(t, found)
+				require.NoError(t, configureAltCoreWithDefaultSetName(
+					&core, tc.id, "_RA_Cores/Cores/Gameboy", setName, tc.sameDir, nil,
+				))
+			}
+			folders := []string{"GAMEBOY"}
+			if tc.system == "GameboyColor" {
+				folders = append(folders, "GBC")
+			}
+			for _, folder := range folders {
+				assert.Contains(t, byID[tc.system].Folders, folder)
+				assert.Contains(t, byID[tc.system].Extensions, tc.extension)
+				rom := filepath.Join(string(filepath.Separator), "media", "fat", "games", folder, "Game"+tc.extension)
+				document, genErr := mgls.GenerateMgl(&core, core.RBF, rom, "")
+				require.NoError(t, genErr)
+				type setNameElement struct {
+					Name    string `xml:",chardata"`
+					SameDir string `xml:"same_dir,attr"`
+				}
+				type fileElement struct {
+					Path  string `xml:"path,attr"`
+					Index int    `xml:"index,attr"`
+				}
+				var decoded struct {
+					SetName setNameElement `xml:"setname"`
+					File    fileElement    `xml:"file"`
+				}
+				require.NoError(t, xml.Unmarshal([]byte(document), &decoded))
+				assert.Equal(t, "../../../../.."+rom, decoded.File.Path)
+				assert.Equal(t, 1, decoded.File.Index)
+				assert.Equal(t, tc.setName, decoded.SetName.Name)
+				if tc.sameDir {
+					assert.Equal(t, "1", decoded.SetName.SameDir)
+				} else {
+					assert.Empty(t, decoded.SetName.SameDir)
+				}
+			}
 		})
 	}
 }

--- a/pkg/platforms/mister/tracker/lookupcorename_test.go
+++ b/pkg/platforms/mister/tracker/lookupcorename_test.go
@@ -1,0 +1,72 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package tracker
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A CORENAME is not a system ID. generateNameMap adds alternate cores such as
+// RA_GBC precisely so the tracker can place them, so validating the core name
+// instead of the system it maps to discarded every one of them and left a
+// running RetroAchievements core unidentified.
+func TestLookupCoreNameAlternateCores(t *testing.T) {
+	t.Parallel()
+
+	tr := &Tracker{NameMap: []NameMapping{
+		{CoreName: "GBC", System: systemdefs.SystemGameboyColor, Name: systemdefs.SystemGameboyColor},
+		{CoreName: "RA_GBC", System: systemdefs.SystemGameboyColor, Name: systemdefs.SystemGameboyColor},
+		{CoreName: "Gameboy_LLAPI", System: systemdefs.SystemGameboy, Name: systemdefs.SystemGameboy},
+		{CoreName: "SonicBoom", System: ArcadeSystem, Name: ArcadeSystem, ArcadeName: "Sonic Boom"},
+		{CoreName: "Bogus", System: "NotASystem", Name: "NotASystem"},
+	}}
+
+	for _, tc := range []struct {
+		name, core, wantSystem string
+	}{
+		{name: "stock core", core: "GBC", wantSystem: systemdefs.SystemGameboyColor},
+		{name: "retroachievements core", core: "RA_GBC", wantSystem: systemdefs.SystemGameboyColor},
+		{name: "llapi core", core: "Gameboy_LLAPI", wantSystem: systemdefs.SystemGameboy},
+		{name: "case insensitive", core: "ra_gbc", wantSystem: systemdefs.SystemGameboyColor},
+		{name: "arcade set name", core: "SonicBoom", wantSystem: ArcadeSystem},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mapping := tr.LookupCoreName(tc.core)
+			require.NotNil(t, mapping, "core %q must resolve", tc.core)
+			assert.Equal(t, tc.wantSystem, mapping.System)
+		})
+	}
+
+	for _, tc := range []struct{ name, core string }{
+		{name: "empty", core: ""},
+		{name: "unmapped core", core: "Utility"},
+		{name: "mapping to an unknown system", core: "Bogus"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Nil(t, tr.LookupCoreName(tc.core))
+		})
+	}
+}

--- a/pkg/platforms/mister/tracker/lookupcorename_test.go
+++ b/pkg/platforms/mister/tracker/lookupcorename_test.go
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 
+//go:build linux
+
 package tracker
 
 import (

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -246,9 +246,14 @@ func (tr *Tracker) LookupCoreName(name string) *NameMapping {
 			return &tr.NameMap[i]
 		}
 
-		_, err := systemdefs.LookupSystem(name)
+		// The name map deliberately carries alternate core names such as RA_GBC
+		// and the LLAPI and DB9 variants, which are CORENAME values rather than
+		// system IDs. Validating the core name rejected every one of them, so
+		// the mapped system is what has to resolve.
+		_, err := systemdefs.LookupSystem(mapping.System)
 		if err != nil {
-			log.Error().Msgf("error getting system: %s", err)
+			log.Error().Err(err).Str("core", name).Str("system", mapping.System).
+				Msg("tracker: name map entry does not resolve to a known system")
 			continue
 		}
 

--- a/pkg/platforms/shared/esapi/gamelist.go
+++ b/pkg/platforms/shared/esapi/gamelist.go
@@ -175,6 +175,24 @@ type Game struct {
 	KidGame             bool     `xml:"kidgame,omitempty"`
 }
 
+// UnmarshalXML accepts the ZapScraper box2d alias while keeping boxart2d as
+// the canonical field and serialized tag. An explicit canonical value wins.
+func (g *Game) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type GameXML Game
+	var decoded struct {
+		Box2D string `xml:"box2d"`
+		GameXML
+	}
+	if err := d.DecodeElement(&decoded, &start); err != nil {
+		return fmt.Errorf("decode gamelist game: %w", err)
+	}
+	if decoded.Boxart2D == "" {
+		decoded.Boxart2D = decoded.Box2D
+	}
+	*g = Game(decoded.GameXML)
+	return nil
+}
+
 // Folder represents a <folder> entry in the gamelist. Folders support a
 // smaller set of metadata than games. Most path-based media fields follow
 // the same fork differences as in Game — see Game field comments.

--- a/pkg/platforms/shared/esapi/gamelist_fuzz_test.go
+++ b/pkg/platforms/shared/esapi/gamelist_fuzz_test.go
@@ -24,6 +24,8 @@ import "testing"
 func FuzzParseGameListXML(f *testing.F) {
 	f.Add([]byte(`<gameList><game><name>Game</name><path>./game.rom</path></game></gameList>`))
 	f.Add([]byte(`<gameList><folder><name>Folder</name><path>./folder</path></folder></gameList>`))
+	f.Add([]byte(`<gameList><game><path>../GAMEBOY/Game.gbc</path><box2d>./box.png</box2d></game></gameList>`))
+	f.Add([]byte(`<gameList><game><boxart2d>./cover.png</boxart2d><box2d>./alias.png</box2d></game></gameList>`))
 	f.Add([]byte(`<gameList>`))
 	f.Add([]byte(`not xml`))
 

--- a/pkg/platforms/shared/esapi/gamelist_test.go
+++ b/pkg/platforms/shared/esapi/gamelist_test.go
@@ -35,6 +35,45 @@ import (
 // TestUnmarshalGameIDVariants verifies that both the XML attribute form
 // (ScreenScraperIDAttr) and the element form (ScreenScraperID) of the "id"
 // field parse correctly in isolation and together.
+func TestGameBox2DAlias(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		fields string
+		want   string
+	}{
+		{name: "alias", fields: "<box2d>./covers/alias.png</box2d>", want: "./covers/alias.png"},
+		{name: "canonical", fields: "<boxart2d>./covers/canonical.png</boxart2d>", want: "./covers/canonical.png"},
+		{
+			name:   "canonical wins",
+			fields: "<boxart2d>./covers/canonical.png</boxart2d><box2d>./covers/alias.png</box2d>",
+			want:   "./covers/canonical.png",
+		},
+		{
+			name:   "alias first",
+			fields: "<box2d>./covers/alias.png</box2d><boxart2d>./covers/canonical.png</boxart2d>",
+			want:   "./covers/canonical.png",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			data := []byte("<gameList><game><path>./Game.gbc</path><image>./image.png</image>" +
+				tc.fields + "</game></gameList>")
+			gl, err := ParseGameListXML(data)
+			require.NoError(t, err)
+			require.Len(t, gl.Games, 1)
+			assert.Equal(t, tc.want, gl.Games[0].Boxart2D)
+			assert.Equal(t, "./image.png", gl.Games[0].Image)
+			assert.Equal(t, "./Game.gbc", gl.Games[0].Path)
+			encoded, err := xml.Marshal(gl)
+			require.NoError(t, err)
+			assert.Contains(t, string(encoded), "<boxart2d>"+tc.want+"</boxart2d>")
+			assert.NotContains(t, string(encoded), "<box2d>")
+		})
+	}
+}
+
 func TestUnmarshalGameIDVariants(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/shared/esapi/gamelist_test.go
+++ b/pkg/platforms/shared/esapi/gamelist_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestUnmarshalGameIDVariants verifies that both the XML attribute form
-// (ScreenScraperIDAttr) and the element form (ScreenScraperID) of the "id"
-// field parse correctly in isolation and together.
+// TestGameBox2DAlias verifies that the ZapScraper box2d alias decodes into the
+// canonical Boxart2D field, that an explicit boxart2d value wins regardless of
+// element order, and that marshalling only ever emits boxart2d.
 func TestGameBox2DAlias(t *testing.T) {
 	t.Parallel()
 
@@ -74,6 +74,22 @@ func TestGameBox2DAlias(t *testing.T) {
 	}
 }
 
+// TestGameDecodeErrorPropagates covers the alias decoder's error path: a
+// malformed numeric element must surface as a parse failure rather than a
+// silently zeroed game, since gamelist.xml is untrusted input.
+func TestGameDecodeErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseGameListXML([]byte(
+		`<gameList><game><path>./Game.gb</path><playcount>many</playcount></game></gameList>`,
+	))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode gamelist game")
+}
+
+// TestUnmarshalGameIDVariants verifies that both the XML attribute form
+// (ScreenScraperIDAttr) and the element form (ScreenScraperID) of the "id"
+// field parse correctly in isolation and together.
 func TestUnmarshalGameIDVariants(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #1261

- Resolve sibling ROM references within configured roots for the same system without relaxing artwork path boundaries. Where configured roots nest, the most specific one owns the ROM, so artwork names stay relative to the `media/` directory beside it.
- Accept `<box2d>` alongside `<boxart2d>` when decoding gamelist entries. `boxart2d` stays canonical and is the only form marshalled.
- Stop a gamelist entry describing one system's ROM from claiming a same-named title of another system that shares its ROM folder. The guard is driven by the extensions each system's launchers index, so it covers every shared MiSTer folder — `GAMEBOY` (`.gb`, `.gbc`, MegaDuck `.bin`), `SMS` (`.sms`, `.gg`, `.sg`), `WonderSwan` (`.ws`, `.wsc`, `.pc2`), `NES` (`.nes`, `.fds`, `.nsf`), `SNES`, `TGFX16`, `Coleco`, `ATARI7800` and `Jaguar` — instead of a Game Boy special case. A launcher accepting files through a `Test` function leaves the set unknown and the guard stays open.
- Resolve alternate MiSTer core names to their mapped system. `generateNameMap` adds CORENAME values such as `RA_GBC` so the tracker can place a game running on an alternate core, but `LookupCoreName` validated the CORENAME itself against `systemdefs`, which only knows system IDs, so every one of them was discarded.
- Ignore missing media during scraping so rename, reindex, and forced scrape recover artwork.
- Add regular/Companion layout, shared-folder, nested-root, rename recovery, path safety, scrape-system resolution, and standard/RetroAchievements launcher-output regressions.

Verified on the MiSTer test device against a `GAMEBOY` folder holding `Alpha.gb`, `Alpha.gbc` and `Beta.gbc`, with a `GBC` gamelist referencing `../GAMEBOY/Beta.gbc`. On v2.17.2 the Game Boy media took the Game Boy Color entry's description, no `box2d` artwork was written at all, and the sibling-root reference matched nothing. On this branch each media takes its own description and cover, and the sibling reference resolves to the `GBC` root's artwork. A full Gameboy and GameboyColor gamelist scrape over the real 4,200-title library matched the same rows as before. Launching a `.gbc` from the shared folder through `RAGameboyColor` loads the core and now logs `found mapping: RA_GBC -> GameboyColor` in place of `error getting system: unknown system: RA_GBC`.

FPGA behaviour beyond core load, HDMI output and physical readers remain unverified.
