### PR TITLE
feat(mister): match arcade gamelists by MRA set name

### DIFF
--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -175,7 +175,7 @@ On MiSTer and MiSTeX, the `gamelist.xml` scraper can bridge these identities usi
 - The matching MRA must be live and uniquely identified within the system currently being scraped. Already-scraped MRAs still count when checking uniqueness; force and resume cannot make a duplicate set appear unique.
 - Multiple MRAs with the same set name are skipped, including alternate-core variants and duplicates sharing one title. Use an exact MRA path to choose a variant instead of relying on ROM-set matching.
 - Existing direct-path and slug records take precedence over set-name fallback records. Unknown set names retain existing slug matching. A known ambiguous set does not fall back to guessing by title.
-- A unique match receives title metadata and media-level artwork. Artwork filename fallback uses the source set name, such as `media/images/pacman.png`, rather than the MRA's display filename.
+- A unique match receives title metadata and media-level artwork. Artwork filename fallback uses the source set name in any supported artwork extension, such as `media/images/pacman.png` or `media/images/pacman.jpg`, rather than the MRA's display filename.
 
 ### Exporting A Scraper Bundle
 

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -207,13 +207,13 @@ Example `Arcade/gamelist.xml`:
 </gameList>
 ```
 
-Index the MRAs first, then run `gamelist.xml` for `Arcade`. For a granular arcade system such as `CPS1`, use a `CPS1` bundle directory and scrape that indexed system. Existing arcade classification determines system membership; the scraper neither creates MRA entries nor guesses membership from catalog titles.
+Index the MRAs first, then run `gamelist.xml` for `Arcade`. For a granular arcade system such as `CPS1`, use a `CPS1` bundle directory and scrape that indexed system; those systems are classified out of `_Arcade` rather than scanned from a folder of their own, so an installed bundle is what makes them scrapable at all. Existing arcade classification determines system membership; the scraper neither creates MRA entries nor guesses membership from catalog titles.
 
 A gamelist in `_Arcade` also supports these ROM/set-name references. Core does **not** automatically discover `games/mame/gamelist.xml` or arbitrary nested gamelists: put the bundle in the configured layout above, or place a gamelist in a configured ROM root.
 
 Regular set-name entries may retain absolute or sibling ROM ZIP paths from the scraper machine, including Windows paths. Core extracts only the basename identity; it never opens or launches those source ZIP paths. Image, video, and manual references keep the existing asset-root restrictions. Custom images must exist at scrape time. Relative Companion ZIP child references also support unique set-name matching; existing Companion path validation and parent metadata behavior remain unchanged.
 
-Unreadable, malformed, oversized (over 256 KiB), or repeated-setname MRA descriptors are not identity sources. No MRA, ROM archive, or launcher configuration is rewritten. AmigaVision `games.txt` and `demos.txt` integration is separate from arcade matching.
+Unreadable or malformed MRA descriptors, and those repeating `<setname>` in their header, are not identity sources. Only the descriptor header up to its first `<rom>` element is read, so the embedded ROM payload of a large MRA costs nothing and does not disqualify it. No MRA, ROM archive, or launcher configuration is rewritten. AmigaVision `games.txt` and `demos.txt` integration is separate from arcade matching.
 
 ## MiSTer Installed Docs Databases
 

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -101,7 +101,7 @@ Path handling for `<game><path>` stays strict:
 | `~/...` | Resolved under the current user's home directory, then rejected unless still under the system ROM root |
 | Absolute path | Cleaned and rejected unless under the system ROM root |
 
-Asset path handling for artwork/video/manual uses the same root-bound behavior by default. On MiSTer and MiSTeX only, absolute or `~/...` asset paths may also resolve under platform root directories from `RootDirs(cfg)`, covering SD, USB, CIFS, network, and configured index roots. This applies only to file-backed asset fields; game paths remain bound to the ROM root. Path traversal outside the ROM root or approved platform roots is rejected.
+Asset path handling for artwork/video/manual uses the same root-bound behavior by default. On MiSTer and MiSTeX only, absolute or `~/...` asset paths may also resolve under platform root directories from `RootDirs(cfg)`, covering SD, USB, CIFS, network, and configured index roots. This applies only to file-backed asset fields; game paths remain bound to the ROM root. Path traversal outside the ROM root or approved platform roots is rejected. The MiSTer arcade set-name fallback below can also interpret a ROM path as an identity without accessing that path; it does not broaden asset access.
 
 Zip-as-directory paths are supported for matching XML entries such as `./Japan/Game.zip` to indexed media stored under that zip path, while nested artwork paths such as `./media/images/Japan/Game.png` remain resolved as asset paths.
 
@@ -164,6 +164,56 @@ For each indexed system, the scraper also checks `<custom_path>/<system ID>/game
 Custom gamelists enrich existing indexed records; they do not create systems, titles, or media rows. For systems that index virtual or non-file-backed entries (where the stored media path does not correspond to a real file), `<path>` must match the exact path the indexer stored for that media row.
 
 `gamelist.xml` deliberately does not scrape user-state fields such as favorite, hidden, or kidgame. It also does not overwrite filename-parser-owned fields such as disc and track.
+
+## MiSTer Arcade Gamelists
+
+MiSTer indexes launchable `.mra` descriptors under `_Arcade`, not MAME ROM ZIPs. A gamelist authored by Skraper against `pacman.zip` therefore cannot identify `Pac-Man (Midway).mra` by its filesystem path alone.
+
+On MiSTer and MiSTeX, the `gamelist.xml` scraper can bridge these identities using the `<setname>` stored inside each indexed MRA:
+
+- A `<game><path>` ending in `.zip` or `.7z`, or containing a bare set name, supplies the set-name key. Keys are case-insensitive; they contain letters, digits, underscores, or hyphens, up to 128 characters.
+- The matching MRA must be live and uniquely identified within the system currently being scraped. Already-scraped MRAs still count when checking uniqueness; force and resume cannot make a duplicate set appear unique.
+- Multiple MRAs with the same set name are skipped, including alternate-core variants and duplicates sharing one title. Use an exact MRA path to choose a variant instead of relying on ROM-set matching.
+- Existing direct-path and slug records take precedence over set-name fallback records. Unknown set names retain existing slug matching. A known ambiguous set does not fall back to guessing by title.
+- A unique match receives title metadata and media-level artwork. Artwork filename fallback uses the source set name, such as `media/images/pacman.png`, rather than the MRA's display filename.
+
+### Exporting A Scraper Bundle
+
+To keep metadata outside `_Arcade`, export or copy the gamelist and its referenced images together into a custom bundle:
+
+```text
+/media/fat/metadata/
+└── Arcade/
+    ├── gamelist.xml
+    └── images/
+        └── pacman.png
+```
+
+```toml
+[scraper.gamelist_xml]
+custom_path = "/media/fat/metadata"
+```
+
+Example `Arcade/gamelist.xml`:
+
+```xml
+<gameList>
+  <game>
+    <path>./pacman.zip</path>
+    <name>Pac-Man</name>
+    <desc>Metadata exported by your scraper.</desc>
+    <image>./images/pacman.png</image>
+  </game>
+</gameList>
+```
+
+Index the MRAs first, then run `gamelist.xml` for `Arcade`. For a granular arcade system such as `CPS1`, use a `CPS1` bundle directory and scrape that indexed system. Existing arcade classification determines system membership; the scraper neither creates MRA entries nor guesses membership from catalog titles.
+
+A gamelist in `_Arcade` also supports these ROM/set-name references. Core does **not** automatically discover `games/mame/gamelist.xml` or arbitrary nested gamelists: put the bundle in the configured layout above, or place a gamelist in a configured ROM root.
+
+Regular set-name entries may retain absolute or sibling ROM ZIP paths from the scraper machine, including Windows paths. Core extracts only the basename identity; it never opens or launches those source ZIP paths. Image, video, and manual references keep the existing asset-root restrictions. Custom images must exist at scrape time. Relative Companion ZIP child references also support unique set-name matching; existing Companion path validation and parent metadata behavior remain unchanged.
+
+Unreadable, malformed, oversized (over 256 KiB), or repeated-setname MRA descriptors are not identity sources. No MRA, ROM archive, or launcher configuration is rewritten. AmigaVision `games.txt` and `demos.txt` integration is separate from arcade matching.
 
 ## MiSTer Installed Docs Databases
 

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -174,7 +174,7 @@ On MiSTer and MiSTeX, the `gamelist.xml` scraper can bridge these identities usi
 - A `<game><path>` ending in `.zip` or `.7z`, or containing a bare set name, supplies the set-name key. Keys are case-insensitive; they contain letters, digits, underscores, or hyphens, up to 128 characters.
 - The matching MRA must be live and uniquely identified within the system currently being scraped. Already-scraped MRAs still count when checking uniqueness; force and resume cannot make a duplicate set appear unique.
 - Multiple MRAs with the same set name are skipped, including alternate-core variants and duplicates sharing one title. Use an exact MRA path to choose a variant instead of relying on ROM-set matching.
-- Existing direct-path and slug records take precedence over set-name fallback records. Unknown set names retain existing slug matching. A known ambiguous set does not fall back to guessing by title.
+- Entries that name the row directly take precedence: an indexed path, or a slug match the entry's own path confirms. A set name outranks a record that only guessed the row from its title, in either XML order, because arcade clone sets routinely share one display name. Unknown set names retain existing slug matching. A known ambiguous set does not fall back to guessing by title.
 - A unique match receives title metadata and media-level artwork. Artwork filename fallback uses the source set name in any supported artwork extension, such as `media/images/pacman.png` or `media/images/pacman.jpg`, rather than the MRA's display filename.
 
 ### Exporting A Scraper Bundle

--- a/pkg/database/scraper/gamelistxml/arcade.go
+++ b/pkg/database/scraper/gamelistxml/arcade.go
@@ -24,9 +24,11 @@ import (
 	"encoding/xml"
 	"errors"
 	"io"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/rs/zerolog/log"
@@ -68,9 +70,16 @@ func arcadeSetStem(sourcePath string) string {
 // docs artwork lookup, this identity can select a different title's write target,
 // so malformed documents and repeated setname elements must not select a row.
 func readArcadeSetName(fs afero.Fs, filename string) string {
-	info, err := fs.Stat(filename)
+	// Lstat, not Stat: Arcade Organizer aliases the same descriptor under its
+	// category folders, and an alias that reached the index would read as a
+	// second row for one set and block it as ambiguous. Skipping links keeps
+	// the canonical `_Arcade` row as the only identity source.
+	var info os.FileInfo
+	var err error
 	if lstater, ok := fs.(afero.Lstater); ok {
 		info, _, err = lstater.LstatIfPossible(filename)
+	} else {
+		info, err = fs.Stat(filename)
 	}
 	if err != nil || !info.Mode().IsRegular() || info.Size() > maxArcadeMRABytes {
 		return ""
@@ -119,6 +128,10 @@ func readArcadeSetName(fs afero.Fs, filename string) string {
 	return strings.ToLower(setName)
 }
 
+// indexArcadeSets maps each MAME set name referenced by the gamelist to the
+// indexed MRA descriptors that declare it. Only set names the gamelist actually
+// asks for are kept, so a system with no ROM-style entries costs one pass over
+// the parsed games and never touches the filesystem.
 func (g *GamelistXMLScraper) indexArcadeSets(
 	ctx context.Context, rows []database.MediaWithFullPath, parsed parsedGamelistSystem,
 ) (map[string][]database.Media, error) {
@@ -137,6 +150,8 @@ func (g *GamelistXMLScraper) indexArcadeSets(
 	if len(wanted) == 0 {
 		return bySet, nil
 	}
+	start := time.Now()
+	var descriptors, unreadable int
 	// Include already-scraped rows: a previous write cannot turn an ambiguous
 	// set into a unique match on the next run. Missing rows are not launch targets.
 	for _, row := range rows {
@@ -146,7 +161,12 @@ func (g *GamelistXMLScraper) indexArcadeSets(
 		if row.IsMissing || !strings.EqualFold(filepath.Ext(row.Path), ".mra") {
 			continue
 		}
+		descriptors++
 		setName := readArcadeSetName(g.filesystem(), row.Path)
+		if setName == "" {
+			unreadable++
+			continue
+		}
 		if _, ok := wanted[setName]; !ok {
 			continue
 		}
@@ -154,6 +174,15 @@ func (g *GamelistXMLScraper) indexArcadeSets(
 			DBID: row.DBID, MediaTitleDBID: row.MediaTitleDBID, Path: row.Path,
 		})
 	}
+	// A silent zero here is indistinguishable from the feature being off, so
+	// the read cost and the unusable descriptor count are always reported.
+	log.Debug().
+		Int("wanted_sets", len(wanted)).
+		Int("descriptors_read", descriptors).
+		Int("descriptors_unusable", unreadable).
+		Int("indexed_sets", len(bySet)).
+		Dur("duration", time.Since(start)).
+		Msg("gamelistxml: indexed arcade set names")
 	return bySet, nil
 }
 

--- a/pkg/database/scraper/gamelistxml/arcade.go
+++ b/pkg/database/scraper/gamelistxml/arcade.go
@@ -36,7 +36,19 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
-const maxArcadeMRABytes = 256 * 1024
+// maxArcadeMRAHeaderBytes bounds the descriptor header a set name may be read
+// from. It is not a file size limit: MiSTer MRAs embed their ROM payload as
+// base64 <part> data and run to tens of megabytes, and refusing those would
+// leave real arcade games with no identity at all.
+const maxArcadeMRAHeaderBytes = 256 * 1024
+
+const (
+	arcadeMRARootElement    = "misterromdescription"
+	arcadeMRASetNameElement = "setname"
+	// arcadeMRAPayloadElement opens the embedded ROM data. Everything that
+	// identifies the set is written before it.
+	arcadeMRAPayloadElement = "rom"
+)
 
 // arcadeSetStem treats ZIP paths as identities, never as files to open. Source
 // bundles may contain absolute paths from a different machine, including Windows.
@@ -66,9 +78,10 @@ func arcadeSetStem(sourcePath string) string {
 	return base
 }
 
-// readArcadeSetName requires one complete, bounded descriptor. Unlike optional
-// docs artwork lookup, this identity can select a different title's write target,
-// so malformed documents and repeated setname elements must not select a row.
+// readArcadeSetName requires one complete, bounded descriptor header. Unlike
+// optional docs artwork lookup, this identity can select a different title's
+// write target, so malformed documents and repeated setname elements must not
+// select a row.
 func readArcadeSetName(fs afero.Fs, filename string) string {
 	// Lstat, not Stat: Arcade Organizer aliases the same descriptor under its
 	// category folders, and an alias that reached the index would read as a
@@ -81,7 +94,7 @@ func readArcadeSetName(fs afero.Fs, filename string) string {
 	} else {
 		info, err = fs.Stat(filename)
 	}
-	if err != nil || !info.Mode().IsRegular() || info.Size() > maxArcadeMRABytes {
+	if err != nil || !info.Mode().IsRegular() {
 		return ""
 	}
 	file, err := fs.Open(filename)
@@ -89,43 +102,77 @@ func readArcadeSetName(fs afero.Fs, filename string) string {
 		return ""
 	}
 	defer func() { _ = file.Close() }()
-	limited := &io.LimitedReader{R: file, N: maxArcadeMRABytes + 1}
-	decoder := xml.NewDecoder(limited)
+	decoder := xml.NewDecoder(&io.LimitedReader{R: file, N: maxArcadeMRAHeaderBytes})
 	decoder.CharsetReader = charset.NewReaderLabel
-	var mra struct {
-		XMLName  xml.Name `xml:"misterromdescription"`
-		SetNames []string `xml:"setname"`
-	}
-	if err := decoder.Decode(&mra); err != nil || len(mra.SetNames) != 1 {
-		return ""
-	}
-	// Decode only consumes one element; reject additional documents or garbage.
-	for {
-		token, tokenErr := decoder.Token()
-		if errors.Is(tokenErr, io.EOF) {
-			break
-		}
-		if tokenErr != nil {
-			return ""
-		}
-		switch data := token.(type) {
-		case xml.CharData:
-			if strings.TrimSpace(string(data)) != "" {
-				return ""
-			}
-		case xml.Comment, xml.ProcInst:
-		default:
-			return ""
-		}
-	}
-	if limited.N == 0 {
-		return ""
-	}
-	setName := strings.TrimSpace(mra.SetNames[0])
-	if arcadeSetStem(setName) != setName {
+	setName, ok := decodeArcadeSetName(decoder)
+	if !ok || arcadeSetStem(setName) != setName {
 		return ""
 	}
 	return strings.ToLower(setName)
+}
+
+// decodeArcadeSetName returns the descriptor's single <setname>. Every element
+// ahead of the ROM payload is examined, so a repeated, nested or absent set
+// name still yields nothing; parsing then stops rather than reading megabytes
+// of base64 that can carry no identity. A header that is malformed, outruns the
+// read bound, names another root, or is trailed by a second document is not an
+// identity source.
+func decodeArcadeSetName(decoder *xml.Decoder) (setName string, ok bool) {
+	var setNames, depth int
+	var rootClosed bool
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return setName, rootClosed && setNames == 1
+		}
+		if err != nil {
+			return "", false
+		}
+		switch data := token.(type) {
+		case xml.StartElement:
+			if rootClosed {
+				return "", false
+			}
+			depth++
+			switch {
+			case depth == 1:
+				if data.Name.Local != arcadeMRARootElement {
+					return "", false
+				}
+			case depth == 2 && data.Name.Local == arcadeMRAPayloadElement:
+				return setName, setNames == 1
+			case depth == 2 && data.Name.Local == arcadeMRASetNameElement:
+				setNames++
+				if err := decoder.DecodeElement(&setName, &data); err != nil {
+					return "", false
+				}
+				setName = strings.TrimSpace(setName)
+				depth--
+			default:
+				if err := decoder.Skip(); err != nil {
+					return "", false
+				}
+				depth--
+			}
+		case xml.EndElement:
+			depth--
+			if depth == 0 {
+				rootClosed = true
+			}
+		case xml.CharData:
+			if depth == 0 && strings.TrimSpace(string(data)) != "" {
+				return "", false
+			}
+		case xml.Comment, xml.ProcInst:
+		case xml.Directive:
+			// Tolerated only ahead of the document it declares.
+			if rootClosed {
+				return "", false
+			}
+		default:
+			return "", false
+		}
+	}
 }
 
 // indexArcadeSets maps each MAME set name referenced by the gamelist to the

--- a/pkg/database/scraper/gamelistxml/arcade.go
+++ b/pkg/database/scraper/gamelistxml/arcade.go
@@ -1,0 +1,177 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package gamelistxml
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"io"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"golang.org/x/net/html/charset"
+)
+
+const maxArcadeMRABytes = 256 * 1024
+
+// arcadeSetStem treats ZIP paths as identities, never as files to open. Source
+// bundles may contain absolute paths from a different machine, including Windows.
+func arcadeSetStem(sourcePath string) string {
+	if strings.ContainsAny(sourcePath, "\x00\r\n") || strings.Contains(sourcePath, "://") {
+		return ""
+	}
+	base := path.Base(strings.ReplaceAll(strings.TrimSpace(sourcePath), `\`, "/"))
+	ext := path.Ext(base)
+	switch strings.ToLower(ext) {
+	case ".zip", ".7z":
+		base = strings.TrimSuffix(base, ext)
+	case "":
+	default:
+		return ""
+	}
+	if base == "" || len(base) > 128 {
+		return ""
+	}
+	for _, c := range base {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '_', c == '-':
+		default:
+			return ""
+		}
+	}
+	return base
+}
+
+// readArcadeSetName requires one complete, bounded descriptor. Unlike optional
+// docs artwork lookup, this identity can select a different title's write target,
+// so malformed documents and repeated setname elements must not select a row.
+func readArcadeSetName(fs afero.Fs, filename string) string {
+	info, err := fs.Stat(filename)
+	if lstater, ok := fs.(afero.Lstater); ok {
+		info, _, err = lstater.LstatIfPossible(filename)
+	}
+	if err != nil || !info.Mode().IsRegular() || info.Size() > maxArcadeMRABytes {
+		return ""
+	}
+	file, err := fs.Open(filename)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = file.Close() }()
+	limited := &io.LimitedReader{R: file, N: maxArcadeMRABytes + 1}
+	decoder := xml.NewDecoder(limited)
+	decoder.CharsetReader = charset.NewReaderLabel
+	var mra struct {
+		XMLName  xml.Name `xml:"misterromdescription"`
+		SetNames []string `xml:"setname"`
+	}
+	if err := decoder.Decode(&mra); err != nil || len(mra.SetNames) != 1 {
+		return ""
+	}
+	// Decode only consumes one element; reject additional documents or garbage.
+	for {
+		token, tokenErr := decoder.Token()
+		if errors.Is(tokenErr, io.EOF) {
+			break
+		}
+		if tokenErr != nil {
+			return ""
+		}
+		switch data := token.(type) {
+		case xml.CharData:
+			if strings.TrimSpace(string(data)) != "" {
+				return ""
+			}
+		case xml.Comment, xml.ProcInst:
+		default:
+			return ""
+		}
+	}
+	if limited.N == 0 {
+		return ""
+	}
+	setName := strings.TrimSpace(mra.SetNames[0])
+	if arcadeSetStem(setName) != setName {
+		return ""
+	}
+	return strings.ToLower(setName)
+}
+
+func (g *GamelistXMLScraper) indexArcadeSets(
+	ctx context.Context, rows []database.MediaWithFullPath, parsed parsedGamelistSystem,
+) (map[string][]database.Media, error) {
+	bySet := make(map[string][]database.Media)
+	if !g.matchArcadeSets {
+		return bySet, nil
+	}
+	wanted := make(map[string]struct{})
+	for _, file := range parsed.Files {
+		for i := range file.Games {
+			if stem := arcadeSetStem(file.Games[i].Path); stem != "" {
+				wanted[strings.ToLower(stem)] = struct{}{}
+			}
+		}
+	}
+	if len(wanted) == 0 {
+		return bySet, nil
+	}
+	// Include already-scraped rows: a previous write cannot turn an ambiguous
+	// set into a unique match on the next run. Missing rows are not launch targets.
+	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if row.IsMissing || !strings.EqualFold(filepath.Ext(row.Path), ".mra") {
+			continue
+		}
+		setName := readArcadeSetName(g.filesystem(), row.Path)
+		if _, ok := wanted[setName]; !ok {
+			continue
+		}
+		bySet[setName] = append(bySet[setName], database.Media{
+			DBID: row.DBID, MediaTitleDBID: row.MediaTitleDBID, Path: row.Path,
+		})
+	}
+	return bySet, nil
+}
+
+// arcadeMediaForSet reports known even for ambiguous or already-scraped sets so
+// callers cannot turn a failed identity lookup into an unsafe slug/filename guess.
+func arcadeMediaForSet(indexes loadRecordIndexes, sourcePath string) (media database.Media, known bool) {
+	rows := indexes.ArcadeBySetName[strings.ToLower(arcadeSetStem(sourcePath))]
+	if len(rows) == 0 {
+		return database.Media{}, false
+	}
+	if len(rows) != 1 {
+		log.Warn().Str("path", sourcePath).Int("matches", len(rows)).
+			Msg("gamelistxml: ambiguous arcade setname, skipping")
+		return database.Media{}, true
+	}
+	row, ok := indexes.MediaByPathFold[pathFoldKey(rows[0].Path)]
+	if !ok || row.DBID != rows[0].DBID {
+		return database.Media{}, true
+	}
+	return row, true
+}

--- a/pkg/database/scraper/gamelistxml/arcade.go
+++ b/pkg/database/scraper/gamelistxml/arcade.go
@@ -169,8 +169,6 @@ func decodeArcadeSetName(decoder *xml.Decoder) (setName string, ok bool) {
 			if rootClosed {
 				return "", false
 			}
-		default:
-			return "", false
 		}
 	}
 }

--- a/pkg/database/scraper/gamelistxml/arcade_test.go
+++ b/pkg/database/scraper/gamelistxml/arcade_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -227,12 +228,11 @@ func TestArcadeSetStemRejectsNonIdentities(t *testing.T) {
 	assert.Equal(t, strings.Repeat("a", 128), arcadeSetStem(strings.Repeat("a", 128)+".zip"))
 }
 
-// hostileFs reports a file as small and readable but fails or over-delivers on
-// read, standing in for a descriptor that changes between stat and open.
+// hostileFs refuses to open a descriptor that stats cleanly, standing in for a
+// file whose permissions or backing storage fail after the walk saw it.
 type hostileFs struct {
 	afero.Fs
-	openErr    error
-	extraBytes int
+	openErr error
 }
 
 func (h hostileFs) Open(name string) (afero.File, error) {
@@ -241,21 +241,6 @@ func (h hostileFs) Open(name string) (afero.File, error) {
 	}
 	return h.Fs.Open(name) //nolint:wrapcheck // test double forwards verbatim
 }
-
-func (h hostileFs) Stat(name string) (os.FileInfo, error) {
-	info, err := h.Fs.Stat(name)
-	if err != nil || h.extraBytes == 0 {
-		return info, err //nolint:wrapcheck // test double forwards verbatim
-	}
-	return shrunkFileInfo{FileInfo: info, size: info.Size() - int64(h.extraBytes)}, nil
-}
-
-type shrunkFileInfo struct {
-	os.FileInfo
-	size int64
-}
-
-func (s shrunkFileInfo) Size() int64 { return s.size }
 
 func wrapTestFs(wrap func(afero.Fs) afero.Fs, base afero.Fs) afero.Fs {
 	if wrap == nil {
@@ -278,11 +263,9 @@ func TestReadArcadeSetNameRejectsUnreadableDescriptors(t *testing.T) {
 			},
 		},
 		{
-			name:    "content past the reported size",
-			content: valid + strings.Repeat(" ", maxArcadeMRABytes),
-			fs: func(base afero.Fs) afero.Fs {
-				return hostileFs{Fs: base, extraBytes: maxArcadeMRABytes}
-			},
+			name: "header longer than the read bound",
+			content: `<misterromdescription><about>` + strings.Repeat("x", maxArcadeMRAHeaderBytes) +
+				`</about><setname>pacman</setname></misterromdescription>`,
 		},
 		{name: "trailing text", content: valid + "garbage"},
 		{name: "trailing syntax error", content: valid + "<"},
@@ -351,6 +334,32 @@ func TestIndexArcadeSetsSkipsUnusableDescriptors(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, bySet["pacman"], 1, "a descriptor that cannot be parsed must not make its set ambiguous")
 	assert.Equal(t, int64(10), bySet["pacman"][0].DBID)
+}
+
+// TestResolveSystemsKeepsCustomBundleWithoutLauncherPaths covers the granular
+// MiSTer arcade systems: their media is indexed by the arcade classifier rather
+// than by a launcher scan folder, so path discovery finds nothing for them and
+// their bundle would never be read.
+func TestResolveSystemsKeepsCustomBundleWithoutLauncherPaths(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	custom := t.TempDir()
+	bundle := filepath.Join(custom, systemdefs.SystemCPS1, "gamelist.xml")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(bundle), 0o750))
+	require.NoError(t, afero.WriteFile(fs, bundle,
+		[]byte(`<gameList><game><path>./sf2.zip</path><name>Street Fighter II</name></game></gameList>`), 0o600))
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	mdb := helpers.NewMockMediaDBI()
+	mdb.On("IndexedSystems").Return([]string{systemdefs.SystemCPS1, systemdefs.SystemCPS2}, nil)
+	mdb.On("FindSystemBySystemID", systemdefs.SystemCPS1).Return(database.System{DBID: 1}, nil)
+	mdb.On("FindSystemBySystemID", systemdefs.SystemCPS2).Return(database.System{DBID: 2}, nil)
+
+	systems, err := resolveSystemsFromPlatform(t.Context(), newCustomGamelistConfig(t, custom), pl, fs, mdb, nil)
+	require.NoError(t, err)
+	require.Len(t, systems, 1, "only the system with an installed bundle survives having no launcher paths")
+	assert.Equal(t, systemdefs.SystemCPS1, systems[0].ID)
+	assert.Empty(t, systems[0].ROMPaths)
 }
 
 func TestArcadeArtworkFallbackExtensions(t *testing.T) {
@@ -522,7 +531,14 @@ func TestReadArcadeSetName(t *testing.T) {
 		{"nested set", `<misterromdescription><rom><setname>pacman</setname></rom></misterromdescription>`, ""},
 		{"unsafe set", `<misterromdescription><setname>../pacman.zip</setname></misterromdescription>`, ""},
 		{"extra document", `<misterromdescription><setname>pacman</setname></misterromdescription><extra/>`, ""},
-		{"oversized", strings.Repeat(" ", maxArcadeMRABytes+1), ""},
+		{"unterminated header past the read bound", strings.Repeat(" ", maxArcadeMRAHeaderBytes+1), ""},
+		{"payload stops the header scan", `<misterromdescription><setname>pacman</setname>` +
+			`<rom index="0"><part>` + strings.Repeat("A", maxArcadeMRAHeaderBytes*2) +
+			`</part></rom></misterromdescription>`, "pacman"},
+		{"set name after the payload is not a duplicate", `<misterromdescription><setname>pacman</setname>` +
+			`<rom index="0"/><setname>puckman</setname></misterromdescription>`, "pacman"},
+		{"payload before any set name", `<misterromdescription><rom index="0"/>` +
+			`<setname>pacman</setname></misterromdescription>`, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -627,7 +643,7 @@ func FuzzArcadeSetIdentity(f *testing.F) {
 		`<setname>two</setname></misterromdescription>`), "../two.7z")
 	f.Add([]byte(`<misterromdescription>`), `C:\roms\pacman.zip`)
 	f.Fuzz(func(t *testing.T, data []byte, source string) {
-		if len(data) > maxArcadeMRABytes+1 || len(source) > 4096 {
+		if len(data) > maxArcadeMRAHeaderBytes+1 || len(source) > 4096 {
 			t.Skip()
 		}
 		fs := afero.NewMemMapFs()

--- a/pkg/database/scraper/gamelistxml/arcade_test.go
+++ b/pkg/database/scraper/gamelistxml/arcade_test.go
@@ -1,0 +1,359 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package gamelistxml
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapeLoop_ArcadeSetNameBundle(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	root := filepath.Join(t.TempDir(), "_Arcade")
+	custom := t.TempDir()
+	bundle := filepath.Join(custom, systemdefs.SystemArcade)
+	mra := filepath.Join(root, "Pac-Man (Midway).mra")
+	image := filepath.Join(bundle, "images", "pacman.png")
+	for path, content := range map[string]string{
+		mra:   "<misterromdescription><setname>pacman</setname></misterromdescription>",
+		image: "image",
+		filepath.Join(bundle, "gamelist.xml"): `<gameList><game><path>./pacman.zip</path>
+<name>Different catalog title</name><desc>Arcade metadata</desc><image>./images/pacman.png</image>
+</game></gameList>`,
+	} {
+		require.NoError(t, fs.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, afero.WriteFile(fs, path, []byte(content), 0o600))
+	}
+	mdb := helpers.NewMockMediaDBI()
+	mdb.On("GetTitlesBySystemID", systemdefs.SystemArcade).Return([]database.TitleWithSystem{{
+		DBID: 1, Slug: "pacman", Name: "Pac-Man", SystemDBID: 100,
+	}}, nil)
+	mdb.On("GetMediaBySystemID", systemdefs.SystemArcade).Return([]database.MediaWithFullPath{{
+		DBID: 10, MediaTitleDBID: 1, Path: mra,
+	}}, nil)
+	mdb.On("ApplyScrapeResult", mock.Anything, int64(10), int64(1),
+		mock.MatchedBy(func(w *database.ScrapeWrite) bool {
+			prop, ok := propertyByType(w.MediaProps, "property:image-image")
+			return assert.True(t, ok) && assert.Equal(t, filepath.ToSlash(image), prop.Text)
+		})).Return(nil).Once()
+	s := &GamelistXMLScraper{db: mdb, fs: fs, cfg: newCustomGamelistConfig(t, custom), matchArcadeSets: true}
+	ch := make(chan scraper.ScrapeUpdate, 128)
+	s.scrapeLoop(t.Context(), scraper.ScrapeOptions{Force: true, Pauser: syncutil.NewPauser()},
+		[]scraper.ScrapeSystem{{ID: systemdefs.SystemArcade, DBID: 100, ROMPaths: []string{root}}}, mdb, ch)
+	var done scraper.ScrapeUpdate
+	for update := range ch {
+		require.NoError(t, update.FatalErr)
+		if update.Done {
+			done = update
+		}
+	}
+	assert.Equal(t, 1, done.Matched)
+	mdb.AssertExpectations(t)
+}
+
+func TestArcadeMatching(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, sourcePath, extraGame, secondSet      string
+		want                                        int
+		duplicateTitle, consumed, missing, disabled bool
+	}{
+		{name: "zip identity", sourcePath: "./pacman.zip", want: 1},
+		{name: "set name", sourcePath: "pacman", want: 1},
+		{name: "7z and case", sourcePath: "./PACMAN.7Z", want: 1},
+		{name: "foreign absolute source", sourcePath: "/other/mame/pacman.zip", want: 1},
+		{name: "foreign windows source", sourcePath: `C:\roms\pacman.zip`, want: 1},
+		{name: "sibling source identity only", sourcePath: "../mame/pacman.zip", want: 1},
+		{name: "duplicate set", sourcePath: "pacman.zip", secondSet: "pacman"},
+		{name: "same title duplicate", sourcePath: "pacman.zip", secondSet: "pacman", duplicateTitle: true},
+		{name: "scraped duplicate stays ambiguous", sourcePath: "pacman.zip", secondSet: "pacman", consumed: true},
+		{name: "missing duplicate not a target", sourcePath: "pacman.zip", secondSet: "pacman", missing: true, want: 1},
+		{name: "already scraped set", sourcePath: "pacman.zip", consumed: true},
+		{name: "unrelated set", sourcePath: "pacman.zip", secondSet: "puckman", want: 1},
+		{name: "non MiSTer unchanged", sourcePath: "pacman.zip", disabled: true},
+		{
+			name: "exact MRA wins", sourcePath: "pacman.zip", want: 1,
+			extraGame: `<game><path>./Pac-Man.mra</path><desc>Exact path</desc></game>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			root := filepath.Join(t.TempDir(), "_Arcade")
+			require.NoError(t, fs.MkdirAll(root, 0o750))
+			first := database.Media{DBID: 10, MediaTitleDBID: 1, Path: filepath.Join(root, "Pac-Man.mra")}
+			second := database.Media{DBID: 20, MediaTitleDBID: 2, Path: filepath.Join(root, "Alternate.mra")}
+			if tc.duplicateTitle {
+				second.MediaTitleDBID = first.MediaTitleDBID
+			}
+			indexes := mediaByPath(first)
+			rows := []database.MediaWithFullPath{{
+				DBID: first.DBID, MediaTitleDBID: first.MediaTitleDBID, Path: first.Path,
+			}}
+			require.NoError(t, afero.WriteFile(fs, first.Path,
+				[]byte(`<misterromdescription><setname>pacman</setname></misterromdescription>`), 0o600))
+			if tc.secondSet != "" {
+				indexes = mediaByPath(first, second)
+				rows = append(rows, database.MediaWithFullPath{
+					DBID: second.DBID, MediaTitleDBID: second.MediaTitleDBID, Path: second.Path, IsMissing: tc.missing,
+				})
+				require.NoError(t, afero.WriteFile(fs, second.Path,
+					[]byte(`<misterromdescription><setname>`+tc.secondSet+`</setname></misterromdescription>`), 0o600))
+			}
+			if tc.consumed {
+				delete(indexes.MediaByPathFold, pathFoldKey(first.Path))
+			}
+			gl, err := esapi.ParseGameListXML([]byte(`<gameList><game><path>` + tc.sourcePath +
+				`</path><name>Catalog title</name><desc>Set metadata</desc></game>` + tc.extraGame + `</gameList>`))
+			require.NoError(t, err)
+			parsed := parsedGamelistSystem{Files: []parsedGamelistFile{{RootPath: root, Games: gl.Games}}}
+			s := &GamelistXMLScraper{fs: fs, matchArcadeSets: !tc.disabled}
+			indexes.ArcadeBySetName, err = s.indexArcadeSets(t.Context(), rows, parsed)
+			require.NoError(t, err)
+			// A title slug must not rescue a known ambiguous or consumed set.
+			if tc.secondSet == "pacman" || tc.consumed {
+				indexes.TitlesBySlug["catalogtitle"] = database.MediaTitle{DBID: 1, Slug: "catalogtitle"}
+			}
+			records, err := s.loadRecordsFromParsed(t.Context(), scraper.ScrapeSystem{
+				ID: systemdefs.SystemArcade, ROMPaths: []string{root},
+			}, indexes, parsed)
+			require.NoError(t, err)
+			require.Len(t, records, tc.want)
+			if tc.want == 0 {
+				return
+			}
+			assert.Equal(t, first.DBID, records[0].MatchedMediaDBID)
+			assert.True(t, records[0].MediaLevelWriteSafe)
+			if tc.extraGame != "" {
+				assert.Equal(t, "Exact path", records[0].Game.Desc)
+			} else {
+				assert.Equal(t, gamelistMatchArcadeSet, records[0].MatchKind)
+			}
+		})
+	}
+}
+
+func TestArcadeUnknownSetPreservesSlugMatch(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	media := database.Media{DBID: 10, MediaTitleDBID: 1, Path: filepath.Join(root, "Pac-Man.mra")}
+	indexes := mediaBySlugAndPath("pacman", &database.MediaTitle{DBID: 1, Slug: "pacman"}, media)
+	indexes.ArcadeBySetName = map[string][]database.Media{"pacman": {media}}
+	records, err := (&GamelistXMLScraper{}).loadRecordsFromParsed(t.Context(),
+		scraper.ScrapeSystem{ID: systemdefs.SystemArcade, ROMPaths: []string{root}}, indexes,
+		parsedGamelistSystem{Files: []parsedGamelistFile{{RootPath: root, Games: []esapi.Game{{
+			Path: "unknown.zip", Name: "Pac-Man",
+		}}}}})
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, gamelistMatchSlugOnly, records[0].MatchKind)
+	assert.Equal(t, media.DBID, records[0].MatchedMediaDBID)
+}
+
+func TestArcadeArtworkFallbackAndBoundary(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	root := t.TempDir()
+	bundle := filepath.Join(t.TempDir(), "Arcade")
+	image := filepath.Join(bundle, "media", "images", "pacman.png")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(image), 0o750))
+	require.NoError(t, afero.WriteFile(fs, image, []byte("art"), 0o600))
+	s := &GamelistXMLScraper{fs: fs}
+	mapped := s.MapToDB(&GamelistRecord{
+		SystemRootPath: root, AssetRootPath: bundle, MatchKind: gamelistMatchArcadeSet,
+		MediaLevelWriteSafe: true, RequireExistingImage: true,
+		MediaDirsByRoot: []map[string]string{statMediaDirsFS(fs, bundle)},
+		Game: esapi.Game{
+			Path: "/foreign/roms/PACMAN.ZIP", Image: "../../private.png", Manual: "../../secret.pdf",
+		},
+	})
+	prop, ok := propertyByType(mapped.MediaProps, "property:image-image")
+	require.True(t, ok)
+	assert.Equal(t, filepath.ToSlash(image), prop.Text)
+	_, ok = propertyByType(mapped.MediaProps, "property:manual")
+	assert.False(t, ok, "identity matching must not broaden asset path permissions")
+}
+
+func TestReadArcadeSetName(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, xml, want string }{
+		{"valid", `<misterromdescription><setname> PACMAN </setname></misterromdescription>`, "pacman"},
+		{"legacy encoding", `<?xml version="1.0" encoding="ISO-8859-1"?><misterromdescription>` +
+			`<name>Caf` + "\xe9" + `</name><setname>pacman</setname></misterromdescription>`, "pacman"},
+		{"trailing comment", `<misterromdescription><setname>pacman</setname>` +
+			`</misterromdescription><!--ok-->`, "pacman"},
+		{"missing", `<misterromdescription/>`, ""},
+		{"malformed", `<misterromdescription><setname>pacman</setname>`, ""},
+		{"wrong root", `<game><setname>pacman</setname></game>`, ""},
+		{"duplicate", `<misterromdescription><setname>pacman</setname>` +
+			`<setname>puckman</setname></misterromdescription>`, ""},
+		{"nested set", `<misterromdescription><rom><setname>pacman</setname></rom></misterromdescription>`, ""},
+		{"unsafe set", `<misterromdescription><setname>../pacman.zip</setname></misterromdescription>`, ""},
+		{"extra document", `<misterromdescription><setname>pacman</setname></misterromdescription><extra/>`, ""},
+		{"oversized", strings.Repeat(" ", maxArcadeMRABytes+1), ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			filename := filepath.Join(t.TempDir(), "test.mra")
+			require.NoError(t, fs.MkdirAll(filepath.Dir(filename), 0o750))
+			require.NoError(t, afero.WriteFile(fs, filename, []byte(tc.xml), 0o600))
+			assert.Equal(t, tc.want, readArcadeSetName(fs, filename))
+		})
+	}
+}
+
+func TestArcadeBundleSQLiteRepeatAndForce(t *testing.T) {
+	t.Parallel()
+	for _, systemID := range []string{systemdefs.SystemArcade, systemdefs.SystemCPS1} {
+		t.Run(systemID, func(t *testing.T) {
+			t.Parallel()
+			mdb, cleanup := helpers.NewInMemoryMediaDB(t)
+			t.Cleanup(cleanup)
+			ctx := t.Context()
+			require.NoError(t, mediascanner.SeedCanonicalTags(ctx, mdb))
+			system, err := mdb.FindOrInsertSystem(database.System{SystemID: systemID, Name: systemID})
+			require.NoError(t, err)
+			title, err := mdb.InsertMediaTitle(&database.MediaTitle{
+				SystemDBID: system.DBID, Slug: "pacman", Name: "Pac-Man",
+			})
+			require.NoError(t, err)
+			fs := afero.NewMemMapFs()
+			root := filepath.Join(t.TempDir(), "_Arcade")
+			custom := t.TempDir()
+			bundle := filepath.Join(custom, systemID)
+			mra := filepath.Join(root, "Pac-Man.mra")
+			image := filepath.Join(bundle, "images", "pacman.png")
+			for filename, content := range map[string]string{
+				mra:   `<misterromdescription><setname>pacman</setname></misterromdescription>`,
+				image: "art",
+				filepath.Join(bundle, "gamelist.xml"): `<gameList><game><path>./pacman.zip</path>` +
+					`<name>Catalog name</name><desc>Arcade description</desc>` +
+					`<image>./images/pacman.png</image></game></gameList>`,
+			} {
+				require.NoError(t, fs.MkdirAll(filepath.Dir(filename), 0o750))
+				require.NoError(t, afero.WriteFile(fs, filename, []byte(content), 0o600))
+			}
+			media, err := mdb.InsertMedia(database.Media{
+				MediaTitleDBID: title.DBID, SystemDBID: system.DBID, Path: mra,
+			})
+			require.NoError(t, err)
+			s := &GamelistXMLScraper{db: mdb, fs: fs, matchArcadeSets: true, cfg: newCustomGamelistConfig(t, custom)}
+			for i, force := range []bool{false, false, true} {
+				ch := make(chan scraper.ScrapeUpdate, 128)
+				s.scrapeLoop(ctx, scraper.ScrapeOptions{Force: force, Pauser: syncutil.NewPauser()},
+					[]scraper.ScrapeSystem{{ID: systemID, DBID: system.DBID, ROMPaths: []string{root}}}, mdb, ch)
+				var done scraper.ScrapeUpdate
+				for update := range ch {
+					require.NoError(t, update.Err)
+					require.NoError(t, update.FatalErr)
+					if update.Done {
+						done = update
+					}
+				}
+				wantMatched := 1
+				if i == 1 {
+					wantMatched = 0
+				}
+				assert.Equal(t, wantMatched, done.Matched)
+				props, propsErr := mdb.GetMediaProperties(ctx, media.DBID)
+				require.NoError(t, propsErr)
+				prop, ok := propertyByType(props, "property:image-image")
+				require.True(t, ok)
+				assert.Equal(t, filepath.ToSlash(image), prop.Text)
+				assert.Len(t, props, 1, "repeated scrapes must not duplicate artwork properties")
+				titleProps, titleErr := mdb.GetMediaTitleProperties(ctx, title.DBID)
+				require.NoError(t, titleErr)
+				desc, ok := propertyByType(titleProps, "property:description")
+				require.True(t, ok)
+				assert.Equal(t, "Arcade description", desc.Text)
+				scraped, scrapeErr := mdb.GetScrapedMediaIDs(ctx, "gamelist.xml", system.DBID)
+				require.NoError(t, scrapeErr)
+				assert.Contains(t, scraped, media.DBID)
+			}
+		})
+	}
+}
+
+func TestArcadeCompanionSetMatch(t *testing.T) {
+	t.Parallel()
+	media := database.Media{DBID: 10, MediaTitleDBID: 1, Path: filepath.Join(t.TempDir(), "Pac-Man.mra")}
+	indexes := mediaByPath(media)
+	indexes.ArcadeBySetName = map[string][]database.Media{"pacman": {media}}
+	child := companionChild{ResolvedPath: filepath.Join(t.TempDir(), "pacman.zip")}
+	system := scraper.ScrapeSystem{ID: systemdefs.SystemArcade}
+	matched := matchCompanionChildMedia(system, child, indexes, nil)
+	require.Equal(t, []database.Media{media}, matched.Media)
+	assert.True(t, matched.MediaLevelWriteSafe)
+	indexes.ArcadeBySetName["pacman"] = append(indexes.ArcadeBySetName["pacman"], database.Media{DBID: 20})
+	assert.Empty(t, matchCompanionChildMedia(system, child, indexes, nil).Media)
+}
+
+func FuzzArcadeSetIdentity(f *testing.F) {
+	f.Add([]byte(`<misterromdescription><setname>pacman</setname></misterromdescription>`), "./pacman.zip")
+	f.Add([]byte(`<misterromdescription><setname>one</setname>`+
+		`<setname>two</setname></misterromdescription>`), "../two.7z")
+	f.Add([]byte(`<misterromdescription>`), `C:\roms\pacman.zip`)
+	f.Fuzz(func(t *testing.T, data []byte, source string) {
+		if len(data) > maxArcadeMRABytes+1 || len(source) > 4096 {
+			t.Skip()
+		}
+		fs := afero.NewMemMapFs()
+		filename := filepath.Join("arcade", "test.mra")
+		require.NoError(t, fs.MkdirAll(filepath.Dir(filename), 0o750))
+		require.NoError(t, afero.WriteFile(fs, filename, data, 0o600))
+		set := readArcadeSetName(fs, filename)
+		if set != "" {
+			assert.Equal(t, set, strings.ToLower(set))
+			assert.Equal(t, set, arcadeSetStem(set))
+		}
+		stem := arcadeSetStem(source)
+		if stem != "" {
+			assert.NotContains(t, stem, "/")
+			assert.NotContains(t, stem, `\`)
+			assert.LessOrEqual(t, len(stem), 128)
+		}
+	})
+}
+
+func TestIndexArcadeSetsCanceled(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := (&GamelistXMLScraper{matchArcadeSets: true}).indexArcadeSets(ctx,
+		[]database.MediaWithFullPath{{Path: "missing.mra"}},
+		parsedGamelistSystem{Files: []parsedGamelistFile{{Games: []esapi.Game{{Path: "pacman.zip"}}}}})
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/pkg/database/scraper/gamelistxml/arcade_test.go
+++ b/pkg/database/scraper/gamelistxml/arcade_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
@@ -360,6 +361,12 @@ func TestResolveSystemsKeepsCustomBundleWithoutLauncherPaths(t *testing.T) {
 	require.Len(t, systems, 1, "only the system with an installed bundle survives having no launcher paths")
 	assert.Equal(t, systemdefs.SystemCPS1, systems[0].ID)
 	assert.Empty(t, systems[0].ROMPaths)
+
+	plain, err := config.NewConfig(t.TempDir(), config.BaseDefaults)
+	require.NoError(t, err)
+	systems, err = resolveSystemsFromPlatform(t.Context(), plain, pl, fs, mdb, nil)
+	require.NoError(t, err)
+	assert.Empty(t, systems, "without a configured bundle directory the systems are still skipped")
 }
 
 func TestArcadeArtworkFallbackExtensions(t *testing.T) {

--- a/pkg/database/scraper/gamelistxml/arcade_test.go
+++ b/pkg/database/scraper/gamelistxml/arcade_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -367,6 +369,46 @@ func TestResolveSystemsKeepsCustomBundleWithoutLauncherPaths(t *testing.T) {
 	systems, err = resolveSystemsFromPlatform(t.Context(), plain, pl, fs, mdb, nil)
 	require.NoError(t, err)
 	assert.Empty(t, systems, "without a configured bundle directory the systems are still skipped")
+}
+
+// TestPlatformScraperGatesArcadeSetsByPlatform pins the wiring: set-name
+// matching reads MRA descriptors off the scrape path, so it must stay off for
+// platforms that have no `_Arcade` to read.
+func TestPlatformScraperGatesArcadeSetsByPlatform(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		platformID string
+		want       bool
+	}{
+		{platformID: ids.Mister, want: true},
+		{platformID: ids.Mistex, want: true},
+		{platformID: ids.Batocera, want: false},
+		{platformID: "mock-platform", want: false},
+	} {
+		t.Run(tc.platformID, func(t *testing.T) {
+			t.Parallel()
+			pl := mocks.NewMockPlatform()
+			pl.SetupBasicMock()
+			pl.ExpectedCalls = nil
+			pl.On("ID").Return(tc.platformID)
+			pl.On("RootDirs", mock.Anything).Return([]string{})
+			pl.On("Launchers", mock.Anything).Return([]platforms.Launcher{})
+			mdb := helpers.NewMockMediaDBI()
+			mdb.On("IndexedSystems").Return([]string{}, nil)
+			cfg, err := config.NewConfig(t.TempDir(), config.BaseDefaults)
+			require.NoError(t, err)
+			ch := make(chan scraper.ScrapeUpdate, 8)
+			require.NoError(t, NewPlatformScraper().Scrape(t.Context(), cfg, pl, afero.NewMemMapFs(),
+				&database.Database{MediaDB: mdb}, scraper.ScrapeOptions{Pauser: syncutil.NewPauser()}, nil, ch))
+			var last scraper.ScrapeUpdate
+			for update := range ch {
+				require.NoError(t, update.FatalErr)
+				last = update
+			}
+			assert.True(t, last.Done)
+			assert.Equal(t, tc.want, arcadeSetMatchingEnabled(pl))
+		})
+	}
 }
 
 func TestArcadeArtworkFallbackExtensions(t *testing.T) {

--- a/pkg/database/scraper/gamelistxml/arcade_test.go
+++ b/pkg/database/scraper/gamelistxml/arcade_test.go
@@ -427,6 +427,86 @@ func TestArcadeSetNameWinsOverCompetingSlug(t *testing.T) {
 	assert.Equal(t, gamelistMatchArcadeSet, records[0].MatchKind)
 }
 
+// TestArcadeSetNameOutranksTitleGuess reproduces what a Skraper arcade bundle
+// does on real hardware: MAME clone sets share one display name, so an entry
+// with no indexed set of its own slug-matches the title and takes the canonical
+// MRA from the entry that named that set exactly.
+func TestArcadeSetNameOutranksTitleGuess(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, gamelist string
+	}{
+		{
+			name: "guess read first",
+			gamelist: `<game><path>./rtypeclone.zip</path><name>R-Type</name><desc>GUESS</desc></game>` +
+				`<game><path>./rtype.zip</path><name>R-Type</name><desc>SET</desc></game>`,
+		},
+		{
+			name: "guess read last",
+			gamelist: `<game><path>./rtype.zip</path><name>R-Type</name><desc>SET</desc></game>` +
+				`<game><path>./rtypeclone.zip</path><name>R-Type</name><desc>GUESS</desc></game>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			root := filepath.Join(t.TempDir(), "_Arcade")
+			require.NoError(t, fs.MkdirAll(root, 0o750))
+			media := database.Media{DBID: 10, MediaTitleDBID: 1, Path: filepath.Join(root, "R-Type (World).mra")}
+			require.NoError(t, afero.WriteFile(fs, media.Path,
+				[]byte(`<misterromdescription><setname>rtype</setname></misterromdescription>`), 0o600))
+			indexes := mediaBySlugAndPath("rtype", &database.MediaTitle{DBID: 1, Slug: "rtype"}, media)
+			gl, err := esapi.ParseGameListXML([]byte(`<gameList>` + tc.gamelist + `</gameList>`))
+			require.NoError(t, err)
+			parsed := parsedGamelistSystem{Files: []parsedGamelistFile{{RootPath: root, Games: gl.Games}}}
+			s := &GamelistXMLScraper{fs: fs, matchArcadeSets: true}
+			indexes.ArcadeBySetName, err = s.indexArcadeSets(t.Context(), []database.MediaWithFullPath{{
+				DBID: media.DBID, MediaTitleDBID: media.MediaTitleDBID, Path: media.Path,
+			}}, parsed)
+			require.NoError(t, err)
+			records, err := s.loadRecordsFromParsed(t.Context(),
+				scraper.ScrapeSystem{ID: systemdefs.SystemArcade, ROMPaths: []string{root}}, indexes, parsed)
+			require.NoError(t, err)
+			require.Len(t, records, 1)
+			assert.Equal(t, media.DBID, records[0].MatchedMediaDBID)
+			assert.Equal(t, "SET", records[0].Game.Desc,
+				"a clone sharing the display name must not displace the exact set-name match")
+			assert.Equal(t, gamelistMatchArcadeSet, records[0].MatchKind)
+			assert.True(t, records[0].MediaLevelWriteSafe)
+		})
+	}
+}
+
+// TestArcadeSetNameYieldsToPathMatch keeps the other half of the rule: a record
+// that named the row by path is at least as exact as the set name, so it holds
+// the row and the set entry is dropped.
+func TestArcadeSetNameYieldsToPathMatch(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	root := filepath.Join(t.TempDir(), "_Arcade")
+	require.NoError(t, fs.MkdirAll(root, 0o750))
+	media := database.Media{DBID: 10, MediaTitleDBID: 1, Path: filepath.Join(root, "R-Type.mra")}
+	require.NoError(t, afero.WriteFile(fs, media.Path,
+		[]byte(`<misterromdescription><setname>rtype</setname></misterromdescription>`), 0o600))
+	indexes := mediaBySlugAndPath("rtype", &database.MediaTitle{DBID: 1, Slug: "rtype"}, media)
+	gl, err := esapi.ParseGameListXML([]byte(`<gameList>` +
+		`<game><path>./rtype.zip</path><name>R-Type</name><desc>SET</desc></game>` +
+		`<game><path>./R-Type.mra</path><name>R-Type</name><desc>PATH</desc></game>` +
+		`</gameList>`))
+	require.NoError(t, err)
+	parsed := parsedGamelistSystem{Files: []parsedGamelistFile{{RootPath: root, Games: gl.Games}}}
+	s := &GamelistXMLScraper{fs: fs, matchArcadeSets: true}
+	indexes.ArcadeBySetName, err = s.indexArcadeSets(t.Context(), []database.MediaWithFullPath{{
+		DBID: media.DBID, MediaTitleDBID: media.MediaTitleDBID, Path: media.Path,
+	}}, parsed)
+	require.NoError(t, err)
+	records, err := s.loadRecordsFromParsed(t.Context(),
+		scraper.ScrapeSystem{ID: systemdefs.SystemArcade, ROMPaths: []string{root}}, indexes, parsed)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "PATH", records[0].Game.Desc)
+}
+
 func TestArcadeCompanionSetMatchThroughIndex(t *testing.T) {
 	t.Parallel()
 	fs := afero.NewMemMapFs()

--- a/pkg/database/scraper/gamelistxml/arcade_test.go
+++ b/pkg/database/scraper/gamelistxml/arcade_test.go
@@ -21,6 +21,7 @@ package gamelistxml
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -204,6 +205,305 @@ func TestArcadeArtworkFallbackAndBoundary(t *testing.T) {
 	assert.Equal(t, filepath.ToSlash(image), prop.Text)
 	_, ok = propertyByType(mapped.MediaProps, "property:manual")
 	assert.False(t, ok, "identity matching must not broaden asset path permissions")
+}
+
+func TestArcadeSetStemRejectsNonIdentities(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, sourcePath string }{
+		{"nul byte", "pac\x00man.zip"},
+		{"newline", "pacman\n.zip"},
+		{"carriage return", "pacman\r.zip"},
+		{"url", "http://example.com/pacman.zip"},
+		{"archive with empty stem", "./.zip"},
+		{"over length limit", strings.Repeat("a", 129) + ".zip"},
+		{"space", "Pac Man.zip"},
+		{"unsupported extension", "pacman.md"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Empty(t, arcadeSetStem(tc.sourcePath))
+		})
+	}
+	assert.Equal(t, strings.Repeat("a", 128), arcadeSetStem(strings.Repeat("a", 128)+".zip"))
+}
+
+// hostileFs reports a file as small and readable but fails or over-delivers on
+// read, standing in for a descriptor that changes between stat and open.
+type hostileFs struct {
+	afero.Fs
+	openErr    error
+	extraBytes int
+}
+
+func (h hostileFs) Open(name string) (afero.File, error) {
+	if h.openErr != nil {
+		return nil, h.openErr
+	}
+	return h.Fs.Open(name) //nolint:wrapcheck // test double forwards verbatim
+}
+
+func (h hostileFs) Stat(name string) (os.FileInfo, error) {
+	info, err := h.Fs.Stat(name)
+	if err != nil || h.extraBytes == 0 {
+		return info, err //nolint:wrapcheck // test double forwards verbatim
+	}
+	return shrunkFileInfo{FileInfo: info, size: info.Size() - int64(h.extraBytes)}, nil
+}
+
+type shrunkFileInfo struct {
+	os.FileInfo
+	size int64
+}
+
+func (s shrunkFileInfo) Size() int64 { return s.size }
+
+func wrapTestFs(wrap func(afero.Fs) afero.Fs, base afero.Fs) afero.Fs {
+	if wrap == nil {
+		return base
+	}
+	return wrap(base)
+}
+
+func TestReadArcadeSetNameRejectsUnreadableDescriptors(t *testing.T) {
+	t.Parallel()
+	valid := `<misterromdescription><setname>pacman</setname></misterromdescription>`
+	for _, tc := range []struct {
+		fs            func(afero.Fs) afero.Fs
+		name, content string
+	}{
+		{
+			name: "unopenable", content: valid,
+			fs: func(base afero.Fs) afero.Fs {
+				return hostileFs{Fs: base, openErr: os.ErrPermission}
+			},
+		},
+		{
+			name:    "content past the reported size",
+			content: valid + strings.Repeat(" ", maxArcadeMRABytes),
+			fs: func(base afero.Fs) afero.Fs {
+				return hostileFs{Fs: base, extraBytes: maxArcadeMRABytes}
+			},
+		},
+		{name: "trailing text", content: valid + "garbage"},
+		{name: "trailing syntax error", content: valid + "<"},
+		{name: "trailing directive", content: valid + "<!DOCTYPE mra>"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			base := afero.NewMemMapFs()
+			filename := filepath.Join(t.TempDir(), "test.mra")
+			require.NoError(t, base.MkdirAll(filepath.Dir(filename), 0o750))
+			require.NoError(t, afero.WriteFile(base, filename, []byte(tc.content), 0o600))
+			assert.Empty(t, readArcadeSetName(wrapTestFs(tc.fs, base), filename))
+		})
+	}
+}
+
+func TestReadArcadeSetNameSkipsSymlinkedDescriptors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "Pac-Man.mra")
+	require.NoError(t, os.WriteFile(target,
+		[]byte(`<misterromdescription><setname>pacman</setname></misterromdescription>`), 0o600))
+	alias := filepath.Join(dir, "alias.mra")
+	require.NoError(t, os.Symlink(target, alias))
+	fs := afero.NewOsFs()
+	assert.Equal(t, "pacman", readArcadeSetName(fs, target))
+	assert.Empty(t, readArcadeSetName(fs, alias),
+		"an Arcade Organizer alias must not read as a second row for the same set")
+}
+
+func TestIndexArcadeSetsWithoutSetReferences(t *testing.T) {
+	t.Parallel()
+	s := &GamelistXMLScraper{
+		fs:              hostileFs{Fs: afero.NewMemMapFs(), openErr: os.ErrPermission},
+		matchArcadeSets: true,
+	}
+	bySet, err := s.indexArcadeSets(t.Context(),
+		[]database.MediaWithFullPath{{DBID: 10, Path: filepath.Join("_Arcade", "Pac-Man.mra")}},
+		parsedGamelistSystem{Files: []parsedGamelistFile{{Games: []esapi.Game{
+			{Path: "./Pac Man.rom"}, {Path: ""},
+		}}}})
+	require.NoError(t, err)
+	assert.Empty(t, bySet, "no set-name references means no descriptor reads at all")
+}
+
+func TestIndexArcadeSetsSkipsUnusableDescriptors(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	root := filepath.Join(t.TempDir(), "_Arcade")
+	require.NoError(t, fs.MkdirAll(root, 0o750))
+	good := filepath.Join(root, "Pac-Man.mra")
+	truncated := filepath.Join(root, "Truncated.mra")
+	require.NoError(t, afero.WriteFile(fs, good,
+		[]byte(`<misterromdescription><setname>pacman</setname></misterromdescription>`), 0o600))
+	require.NoError(t, afero.WriteFile(fs, truncated, []byte(`<misterromdescription><setname>pac`), 0o600))
+	bySet, err := (&GamelistXMLScraper{fs: fs, matchArcadeSets: true}).indexArcadeSets(t.Context(),
+		[]database.MediaWithFullPath{
+			{DBID: 10, MediaTitleDBID: 1, Path: good},
+			{DBID: 20, MediaTitleDBID: 2, Path: truncated},
+			{DBID: 30, MediaTitleDBID: 3, Path: filepath.Join(root, "Absent.mra")},
+			{DBID: 40, MediaTitleDBID: 4, Path: filepath.Join(root, "Not a descriptor.txt")},
+		},
+		parsedGamelistSystem{Files: []parsedGamelistFile{{
+			RootPath: root, Games: []esapi.Game{{Path: "./pacman.zip"}},
+		}}})
+	require.NoError(t, err)
+	require.Len(t, bySet["pacman"], 1, "a descriptor that cannot be parsed must not make its set ambiguous")
+	assert.Equal(t, int64(10), bySet["pacman"][0].DBID)
+}
+
+func TestArcadeArtworkFallbackExtensions(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, sourcePath, artwork string }{
+		{"png", "./pacman.zip", "pacman.png"},
+		{"jpg", "./pacman.zip", "pacman.jpg"},
+		{"jpeg", "./pacman.zip", "pacman.jpeg"},
+		{"webp", "./pacman.zip", "pacman.webp"},
+		{"upper case source keeps its own casing", "./PACMAN.ZIP", "PACMAN.jpg"},
+		{"upper case source falls back to lower", "./PACMAN.ZIP", "pacman.jpg"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			bundle := filepath.Join(t.TempDir(), "Arcade")
+			image := filepath.Join(bundle, "media", "images", tc.artwork)
+			require.NoError(t, fs.MkdirAll(filepath.Dir(image), 0o750))
+			require.NoError(t, afero.WriteFile(fs, image, []byte("art"), 0o600))
+			mapped := (&GamelistXMLScraper{fs: fs}).MapToDB(&GamelistRecord{
+				SystemRootPath: t.TempDir(), AssetRootPath: bundle, MatchKind: gamelistMatchArcadeSet,
+				MediaLevelWriteSafe: true,
+				MediaDirsByRoot:     []map[string]string{statMediaDirsFS(fs, bundle)},
+				Game:                esapi.Game{Path: tc.sourcePath},
+			})
+			prop, ok := propertyByType(mapped.MediaProps, "property:image-image")
+			require.True(t, ok, "set-name artwork must use the same extensions as every other match")
+			assert.Equal(t, filepath.ToSlash(image), prop.Text)
+		})
+	}
+}
+
+// TestArcadeSetNameWinsOverCompetingSlug pins the precedence that makes clone
+// sets safe: `<setname>` is the arcade ROM's identity, while a catalog <name>
+// is only a label several sets can share. Ranking the slug first would send a
+// clone's metadata to the parent's MRA.
+func TestArcadeSetNameWinsOverCompetingSlug(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	root := filepath.Join(t.TempDir(), "_Arcade")
+	require.NoError(t, fs.MkdirAll(root, 0o750))
+	midway := database.Media{DBID: 10, MediaTitleDBID: 1, Path: filepath.Join(root, "Pac-Man (Midway).mra")}
+	japan := database.Media{DBID: 20, MediaTitleDBID: 2, Path: filepath.Join(root, "PuckMan (Japan).mra")}
+	for path, setName := range map[string]string{midway.Path: "pacman", japan.Path: "puckman"} {
+		require.NoError(t, afero.WriteFile(fs, path,
+			[]byte(`<misterromdescription><setname>`+setName+`</setname></misterromdescription>`), 0o600))
+	}
+	indexes := mediaBySlugAndPath("pacman", &database.MediaTitle{DBID: 1, Slug: "pacman"}, midway, japan)
+	gl, err := esapi.ParseGameListXML([]byte(
+		`<gameList><game><path>./puckman.zip</path><name>Pac-Man</name><desc>Japan set</desc></game></gameList>`))
+	require.NoError(t, err)
+	parsed := parsedGamelistSystem{Files: []parsedGamelistFile{{RootPath: root, Games: gl.Games}}}
+	s := &GamelistXMLScraper{fs: fs, matchArcadeSets: true}
+	indexes.ArcadeBySetName, err = s.indexArcadeSets(t.Context(), []database.MediaWithFullPath{
+		{DBID: midway.DBID, MediaTitleDBID: midway.MediaTitleDBID, Path: midway.Path},
+		{DBID: japan.DBID, MediaTitleDBID: japan.MediaTitleDBID, Path: japan.Path},
+	}, parsed)
+	require.NoError(t, err)
+	records, err := s.loadRecordsFromParsed(t.Context(),
+		scraper.ScrapeSystem{ID: systemdefs.SystemArcade, ROMPaths: []string{root}}, indexes, parsed)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, japan.DBID, records[0].MatchedMediaDBID,
+		"the entry named its set, so the slug of its display name must not redirect the write")
+	assert.Equal(t, gamelistMatchArcadeSet, records[0].MatchKind)
+}
+
+func TestArcadeCompanionSetMatchThroughIndex(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	root := filepath.Join(t.TempDir(), "_Arcade")
+	require.NoError(t, fs.MkdirAll(root, 0o750))
+	media := database.Media{DBID: 10, MediaTitleDBID: 1, Path: filepath.Join(root, "Pac-Man.mra")}
+	require.NoError(t, afero.WriteFile(fs, media.Path,
+		[]byte(`<misterromdescription><setname>pacman</setname></misterromdescription>`), 0o600))
+	gl, err := esapi.ParseGameListXML([]byte(`<gameList>` +
+		`<game source="ZaparooCompanion" id="42"><name>Pac-Man</name><desc>Parent</desc></game>` +
+		`<game source="ZaparooCompanion" parentid="42"><path>./pacman.zip</path><region>jp</region></game>` +
+		`</gameList>`))
+	require.NoError(t, err)
+	parsed := parsedGamelistSystem{Files: []parsedGamelistFile{{RootPath: root, Games: gl.Games}}}
+	indexes := mediaByPath(media)
+	s := &GamelistXMLScraper{fs: fs, matchArcadeSets: true}
+	indexes.ArcadeBySetName, err = s.indexArcadeSets(t.Context(), []database.MediaWithFullPath{{
+		DBID: media.DBID, MediaTitleDBID: media.MediaTitleDBID, Path: media.Path,
+	}}, parsed)
+	require.NoError(t, err)
+	require.Contains(t, indexes.ArcadeBySetName, "pacman",
+		"companion child ROM references must contribute the set names the index reads")
+	_, children := companionEntriesFromParsed(t.Context(), scraper.ScrapeSystem{ID: systemdefs.SystemArcade}, parsed)
+	require.Len(t, children, 1)
+	matched := matchCompanionChildMedia(scraper.ScrapeSystem{ID: systemdefs.SystemArcade}, children[0], indexes, nil)
+	require.Equal(t, []database.Media{media}, matched.Media)
+	assert.True(t, matched.MediaLevelWriteSafe)
+}
+
+func TestScrapeLoop_ArcadeIndexCanceled(t *testing.T) {
+	t.Parallel()
+	base := afero.NewMemMapFs()
+	root := filepath.Join(t.TempDir(), "_Arcade")
+	custom := t.TempDir()
+	bundle := filepath.Join(custom, systemdefs.SystemArcade)
+	rows := make([]database.MediaWithFullPath, 0, 2)
+	for i, name := range []string{"Pac-Man.mra", "Ms. Pac-Man.mra"} {
+		path := filepath.Join(root, name)
+		require.NoError(t, base.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, afero.WriteFile(base, path,
+			[]byte(`<misterromdescription><setname>pacman</setname></misterromdescription>`), 0o600))
+		rows = append(rows, database.MediaWithFullPath{DBID: int64(10 + i), MediaTitleDBID: 1, Path: path})
+	}
+	glPath := filepath.Join(bundle, "gamelist.xml")
+	require.NoError(t, base.MkdirAll(bundle, 0o750))
+	require.NoError(t, afero.WriteFile(base, glPath,
+		[]byte(`<gameList><game><path>./pacman.zip</path><name>Pac-Man</name></game></gameList>`), 0o600))
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	mdb := helpers.NewMockMediaDBI()
+	mdb.On("GetTitlesBySystemID", systemdefs.SystemArcade).Return([]database.TitleWithSystem{{
+		DBID: 1, Slug: "pacman", Name: "Pac-Man", SystemDBID: 100,
+	}}, nil)
+	mdb.On("GetMediaBySystemID", systemdefs.SystemArcade).Return(rows, nil)
+	s := &GamelistXMLScraper{
+		db: mdb, fs: cancelOnOpenFs{Fs: base, suffix: ".mra", cancel: cancel},
+		cfg: newCustomGamelistConfig(t, custom), matchArcadeSets: true,
+	}
+	ch := make(chan scraper.ScrapeUpdate, 128)
+	s.scrapeLoop(ctx, scraper.ScrapeOptions{Force: true, Pauser: syncutil.NewPauser()},
+		[]scraper.ScrapeSystem{{ID: systemdefs.SystemArcade, DBID: 100, ROMPaths: []string{root}}}, mdb, ch)
+	var done scraper.ScrapeUpdate
+	for update := range ch {
+		require.NoError(t, update.FatalErr, "cancellation is not a scrape failure")
+		if update.Done {
+			done = update
+		}
+	}
+	assert.True(t, done.Done)
+	assert.Equal(t, 0, done.Matched)
+	mdb.AssertNotCalled(t, "ApplyScrapeResult", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// cancelOnOpenFs cancels the scrape the first time a matching file is opened,
+// standing in for a user stopping a scrape while descriptors are being read.
+type cancelOnOpenFs struct {
+	afero.Fs
+	cancel context.CancelFunc
+	suffix string
+}
+
+func (c cancelOnOpenFs) Open(name string) (afero.File, error) {
+	if strings.HasSuffix(strings.ToLower(name), c.suffix) {
+		c.cancel()
+	}
+	return c.Fs.Open(name) //nolint:wrapcheck // test double forwards verbatim
 }
 
 func TestReadArcadeSetName(t *testing.T) {

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -455,22 +455,23 @@ func (g *GamelistXMLScraper) LoadRecords(
 }
 
 // arcadeSetOutranks reports whether a MiSTer arcade set name is better evidence
-// for a media row than the record already holding it. Only a title guess is: a
-// path match, a slug match its own path confirmed, and another set name all
-// named the row directly. Without this an arcade gamelist's clone entries,
-// which routinely share one display name, can take the canonical MRA from the
-// entry that identified it exactly and then write less to it.
+// for a media row than the record already holding it. It beats a title guess
+// and nothing else: a path match, a slug match the entry's own path confirmed,
+// and another set name all named the row directly. Without this, the clone
+// entries in an arcade gamelist, which routinely share one display name, take
+// the canonical MRA from the entry that identified it exactly and then write
+// less to it than that entry would have.
 func arcadeSetOutranks(record *GamelistRecord) bool {
 	return record.MatchKind == gamelistMatchSlugOnly || record.MatchKind == gamelistMatchSlugConflict
 }
 
 // loadRecordsFromParsed pairs every gamelist <game> and <folder> entry with the
-// media row it should write to. Entries are matched in descending order of
-// evidence: an indexed path, the container a directory entry collapses to, a
-// MiSTer arcade set name, then the title slug. Each row is claimed once, and
-// set-name records are held back until every file has been walked so a direct
-// match anywhere in them still wins the row, and so a set name still outranks
-// a title guess that happened to be read first.
+// media row it should write to. An entry that names the row directly wins it:
+// an indexed path, the container a directory entry collapses to, or a slug
+// whose own path agrees. A MiSTer arcade set name comes next, and a title slug
+// alone last. Each row is claimed once, and set-name records are held back
+// until every file has been walked, so neither of those two rankings depends
+// on the order the entries happen to appear in.
 func (g *GamelistXMLScraper) loadRecordsFromParsed(
 	ctx context.Context,
 	system scraper.ScrapeSystem,
@@ -519,7 +520,11 @@ outer:
 			if resolved != "" {
 				pathMedia, matchedPathKey, pathOK = g.canonicalMediaForResolvedPath(indexes, resolved)
 				if !pathOK {
-					// Directory entries retain the same collapsed-container rule as browse.
+					// ES-DE writes <game> entries whose path is a directory when the
+					// folder name carries a ROM extension, so a disc folder reads as
+					// one game. Resolve those through the same container rule browse
+					// uses, otherwise the entry falls back to a slug-only match and
+					// its artwork is dropped as unsafe for media scope.
 					pathMedia, matchedPathKey, pathOK = containerMediaForDir(indexes, resolved)
 					if pathOK {
 						containerPathResolutions++
@@ -958,6 +963,8 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		var arcadeErr error
 		indexes.ArcadeBySetName, arcadeErr = g.indexArcadeSets(ctx, allMedia, parsed)
 		if arcadeErr != nil {
+			// The only failure is cancellation: an unreadable descriptor is
+			// counted and skipped rather than raised, so nothing here is fatal.
 			sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
 			return
 		}
@@ -1311,13 +1318,14 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 		assetRoot = root
 	}
 
-	// fallbackNames are ROM-relative PNG filenames used to locate matching
-	// artwork files under media/ sub-directories.
+	// fallbackNames are ROM-relative artwork filenames used to locate matching
+	// files under media/ sub-directories.
 	fallbackNames := artworkFallbackNames(game.Path, record.SystemRootPath)
 	if record.MatchKind == gamelistMatchArcadeSet {
 		// Set-name entries commonly carry a foreign or sibling ROM path that
-		// resolves to nothing, so the ROM-relative names are empty. Artwork is
-		// named after the set instead, in either case the scraper wrote it.
+		// resolves to nothing, leaving no ROM-relative names at all. Artwork a
+		// scraper wrote for those is named after the set, in whichever case it
+		// used.
 		if stem := arcadeSetStem(game.Path); stem != "" {
 			names := fallbackArtworkNames(stem)
 			if lower := strings.ToLower(stem); lower != stem {

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -229,7 +229,7 @@ func NewPlatformScraper() platforms.Scraper {
 				fs:                 fs,
 				cfg:                cfg,
 				externalAssetRoots: externalAssetRootsForPlatform(cfg, pl),
-				matchArcadeSets:    pl.ID() == ids.Mister || pl.ID() == ids.Mistex,
+				matchArcadeSets:    arcadeSetMatchingEnabled(pl),
 			}
 			go s.scrapeLoop(ctx, opts, systems, db.MediaDB, ch)
 			return nil
@@ -261,6 +261,13 @@ func orderedScrapeSystemIDs(indexed, requested []string) []string {
 		ordered = append(ordered, id)
 	}
 	return ordered
+}
+
+// arcadeSetMatchingEnabled reports whether set-name matching applies. It reads
+// MRA descriptors off the scrape path, so it is limited to the platforms that
+// index `_Arcade` in the first place.
+func arcadeSetMatchingEnabled(pl platforms.Platform) bool {
+	return pl.ID() == ids.Mister || pl.ID() == ids.Mistex
 }
 
 // customBundleExists reports whether a per-system metadata bundle is installed

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -270,9 +270,6 @@ func customBundleExists(fs afero.Fs, customBase, systemID string) bool {
 	if customBase == "" {
 		return false
 	}
-	if fs == nil {
-		fs = afero.NewOsFs()
-	}
 	exists, err := afero.Exists(fs, filepath.Join(customBase, systemID, "gamelist.xml"))
 	return err == nil && exists
 }
@@ -464,14 +461,7 @@ func (g *GamelistXMLScraper) LoadRecords(
 // which routinely share one display name, can take the canonical MRA from the
 // entry that identified it exactly and then write less to it.
 func arcadeSetOutranks(record *GamelistRecord) bool {
-	switch record.MatchKind {
-	case gamelistMatchSlugOnly, gamelistMatchSlugConflict:
-		return true
-	case gamelistMatchSlugPath, gamelistMatchPathOnly, gamelistMatchArcadeSet:
-		return false
-	default:
-		return false
-	}
+	return record.MatchKind == gamelistMatchSlugOnly || record.MatchKind == gamelistMatchSlugConflict
 }
 
 // loadRecordsFromParsed pairs every gamelist <game> and <folder> entry with the

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -438,6 +438,12 @@ func (g *GamelistXMLScraper) LoadRecords(
 	return g.loadRecordsFromParsed(ctx, system, indexes, parsed)
 }
 
+// loadRecordsFromParsed pairs every gamelist <game> and <folder> entry with the
+// media row it should write to. Entries are matched in descending order of
+// evidence: an indexed path, the container a directory entry collapses to, a
+// MiSTer arcade set name, then the title slug. Each row is claimed once, and
+// set-name records are held back until the file has been walked so a direct
+// match anywhere in it still wins the row.
 func (g *GamelistXMLScraper) loadRecordsFromParsed(
 	ctx context.Context,
 	system scraper.ScrapeSystem,
@@ -452,6 +458,7 @@ func (g *GamelistXMLScraper) loadRecordsFromParsed(
 	var gamelistFiles, gamelistEntries, companionEntriesSkipped, invalidPaths int
 	var slugMatches, slugPathSelections, slugFirstMediaFallbacks, pathOnlyFallbacks, unmatchedRecords int
 	var containerPathResolutions, folderEntries, folderMatches, folderUnmatched int
+	var arcadeSetsUnresolved, arcadeSetsSuperseded int
 
 outer:
 	for _, file := range parsed.Files {
@@ -494,15 +501,20 @@ outer:
 			}
 			if !pathOK {
 				if media, known := arcadeMediaForSet(indexes, game.Path); known {
-					if media.DBID != 0 {
-						arcadeRecords = append(arcadeRecords, &GamelistRecord{
-							SystemRootPath: file.RootPath, AssetRootPath: file.AssetRootPath,
-							MediaDirsByRoot: fileMediaDirsByRoot, Game: *game,
-							MatchKind: gamelistMatchArcadeSet, MatchedTitleDBID: media.MediaTitleDBID,
-							MatchedMediaDBID: media.DBID, MediaLevelWriteSafe: true,
-							RequireExistingImage: file.RequireExistingImage,
-						})
+					if media.DBID == 0 {
+						// The set exists but has no single writable row, so the
+						// entry is dropped rather than guessed at by title.
+						arcadeSetsUnresolved++
+						unmatchedRecords++
+						continue
 					}
+					arcadeRecords = append(arcadeRecords, &GamelistRecord{
+						SystemRootPath: file.RootPath, AssetRootPath: file.AssetRootPath,
+						MediaDirsByRoot: fileMediaDirsByRoot, Game: *game,
+						MatchKind: gamelistMatchArcadeSet, MatchedTitleDBID: media.MediaTitleDBID,
+						MatchedMediaDBID: media.DBID, MediaLevelWriteSafe: true,
+						RequireExistingImage: file.RequireExistingImage,
+					})
 					continue
 				}
 			}
@@ -655,6 +667,7 @@ outer:
 	var arcadeSetMatches int
 	for _, record := range arcadeRecords {
 		if _, exists := claimed[record.MatchedMediaDBID]; exists {
+			arcadeSetsSuperseded++
 			continue
 		}
 		claimed[record.MatchedMediaDBID] = struct{}{}
@@ -665,6 +678,8 @@ outer:
 	log.Info().
 		Str("system", system.ID).
 		Int("arcade_set_matches", arcadeSetMatches).
+		Int("arcade_sets_unresolved", arcadeSetsUnresolved).
+		Int("arcade_sets_superseded", arcadeSetsSuperseded).
 		Int("candidate_titles", candidateTitles).
 		Int("candidate_media", candidateMedia).
 		Int("gamelist_files", gamelistFiles).
@@ -1267,10 +1282,15 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 	// artwork files under media/ sub-directories.
 	fallbackNames := artworkFallbackNames(game.Path, record.SystemRootPath)
 	if record.MatchKind == gamelistMatchArcadeSet {
-		stem := arcadeSetStem(game.Path)
-		fallbackNames = []string{stem + ".png"}
-		if lower := strings.ToLower(stem); lower != stem {
-			fallbackNames = append(fallbackNames, lower+".png")
+		// Set-name entries commonly carry a foreign or sibling ROM path that
+		// resolves to nothing, so the ROM-relative names are empty. Artwork is
+		// named after the set instead, in either case the scraper wrote it.
+		if stem := arcadeSetStem(game.Path); stem != "" {
+			names := fallbackArtworkNames(stem)
+			if lower := strings.ToLower(stem); lower != stem {
+				names = append(names, fallbackArtworkNames(lower)...)
+			}
+			fallbackNames = append(names, fallbackNames...)
 		}
 	}
 
@@ -2478,6 +2498,11 @@ func logScrapeWriteStats(message, systemID string, stats *scrapeWriteStats) {
 		Msg(message)
 }
 
+// matchCompanionChildMedia resolves a companion child reference to the media
+// rows its parent's metadata should be written to. A ".slug" reference selects
+// every row of the named title; otherwise an indexed path, a MiSTer arcade set
+// name and finally a unique filename are tried in that order. An empty result
+// means the child is unmatched or too ambiguous to write.
 func matchCompanionChildMedia(
 	system scraper.ScrapeSystem,
 	child companionChild,

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -220,7 +220,7 @@ func NewPlatformScraper() platforms.Scraper {
 			_ platforms.ScraperCustomOptions,
 			ch chan<- scraper.ScrapeUpdate,
 		) error {
-			systems, err := resolveSystemsFromPlatform(ctx, cfg, pl, db.MediaDB, opts.Systems)
+			systems, err := resolveSystemsFromPlatform(ctx, cfg, pl, fs, db.MediaDB, opts.Systems)
 			if err != nil {
 				return fmt.Errorf("gamelistxml: resolve systems: %w", err)
 			}
@@ -263,6 +263,20 @@ func orderedScrapeSystemIDs(indexed, requested []string) []string {
 	return ordered
 }
 
+// customBundleExists reports whether a per-system metadata bundle is installed
+// for systemID. It is only consulted for systems whose launchers scan no
+// folders, so an ordinary scrape pays one stat at most per such system.
+func customBundleExists(fs afero.Fs, customBase, systemID string) bool {
+	if customBase == "" {
+		return false
+	}
+	if fs == nil {
+		fs = afero.NewOsFs()
+	}
+	exists, err := afero.Exists(fs, filepath.Join(customBase, systemID, "gamelist.xml"))
+	return err == nil && exists
+}
+
 // resolveSystemsFromPlatform builds the list of ScrapeSystem values by
 // querying the indexed systems from mdb, looking up their definitions, and
 // resolving ROM root paths via the platform launcher configuration.
@@ -270,6 +284,7 @@ func resolveSystemsFromPlatform(
 	ctx context.Context,
 	cfg *config.Instance,
 	pl platforms.Platform,
+	fs afero.Fs,
 	mdb database.MediaDBI,
 	systemIDs []string,
 ) ([]scraper.ScrapeSystem, error) {
@@ -302,10 +317,14 @@ func resolveSystemsFromPlatform(
 		pathsBySystem[pathResult.System.ID] = append(pathsBySystem[pathResult.System.ID], pathResult.Path)
 	}
 
+	customBase := cfg.ScraperGamelistXMLCustomPath()
 	result := make([]scraper.ScrapeSystem, 0, len(sysDefs))
 	for _, sys := range sysDefs {
 		romPaths := pathsBySystem[sys.ID]
-		if len(romPaths) == 0 {
+		if len(romPaths) == 0 && !customBundleExists(fs, customBase, sys.ID) {
+			// A system indexed by a launcher with no scan folders of its own,
+			// such as the granular MiSTer arcade systems, still has media rows
+			// worth enriching from a custom bundle.
 			log.Debug().Str("system", sys.ID).Msg("resolveSystemsFromPlatform: no launcher paths found, skipping")
 			continue
 		}

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -457,12 +457,30 @@ func (g *GamelistXMLScraper) LoadRecords(
 	return g.loadRecordsFromParsed(ctx, system, indexes, parsed)
 }
 
+// arcadeSetOutranks reports whether a MiSTer arcade set name is better evidence
+// for a media row than the record already holding it. Only a title guess is: a
+// path match, a slug match its own path confirmed, and another set name all
+// named the row directly. Without this an arcade gamelist's clone entries,
+// which routinely share one display name, can take the canonical MRA from the
+// entry that identified it exactly and then write less to it.
+func arcadeSetOutranks(record *GamelistRecord) bool {
+	switch record.MatchKind {
+	case gamelistMatchSlugOnly, gamelistMatchSlugConflict:
+		return true
+	case gamelistMatchSlugPath, gamelistMatchPathOnly, gamelistMatchArcadeSet:
+		return false
+	default:
+		return false
+	}
+}
+
 // loadRecordsFromParsed pairs every gamelist <game> and <folder> entry with the
 // media row it should write to. Entries are matched in descending order of
 // evidence: an indexed path, the container a directory entry collapses to, a
 // MiSTer arcade set name, then the title slug. Each row is claimed once, and
-// set-name records are held back until the file has been walked so a direct
-// match anywhere in it still wins the row.
+// set-name records are held back until every file has been walked so a direct
+// match anywhere in them still wins the row, and so a set name still outranks
+// a title guess that happened to be read first.
 func (g *GamelistXMLScraper) loadRecordsFromParsed(
 	ctx context.Context,
 	system scraper.ScrapeSystem,
@@ -677,19 +695,25 @@ outer:
 		}
 	}
 
-	// Identity fallbacks run last so direct path/slug entries win regardless of
-	// XML ordering. Remaining duplicates follow the configured source order.
-	claimed := make(map[int64]struct{}, len(records))
-	for _, record := range records {
-		claimed[record.MatchedMediaDBID] = struct{}{}
+	// Identity fallbacks are resolved last so an entry that named the row by
+	// path wins it regardless of XML ordering, and so a set name outranks a
+	// title guess whichever order the two entries appear in.
+	claimedBy := make(map[int64]int, len(records))
+	for i, record := range records {
+		claimedBy[record.MatchedMediaDBID] = i
 	}
 	var arcadeSetMatches int
 	for _, record := range arcadeRecords {
-		if _, exists := claimed[record.MatchedMediaDBID]; exists {
-			arcadeSetsSuperseded++
+		if i, exists := claimedBy[record.MatchedMediaDBID]; exists {
+			if !arcadeSetOutranks(records[i]) {
+				arcadeSetsSuperseded++
+				continue
+			}
+			records[i] = record
+			arcadeSetMatches++
 			continue
 		}
-		claimed[record.MatchedMediaDBID] = struct{}{}
+		claimedBy[record.MatchedMediaDBID] = len(records)
 		records = append(records, record)
 		arcadeSetMatches++
 	}

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -75,6 +75,7 @@ const (
 	gamelistMatchSlugOnly     gamelistMatchKind = "slug_only"
 	gamelistMatchSlugConflict gamelistMatchKind = "slug_conflict"
 	gamelistMatchPathOnly     gamelistMatchKind = "path_only"
+	gamelistMatchArcadeSet    gamelistMatchKind = "arcade_setname"
 )
 
 type slugMediaSelection struct {
@@ -91,6 +92,7 @@ type GamelistXMLScraper struct {
 	fs                 afero.Fs
 	cfg                *config.Instance
 	externalAssetRoots []string
+	matchArcadeSets    bool
 }
 
 type companionStats struct {
@@ -173,6 +175,7 @@ type loadRecordIndexes struct {
 	MediaByPathFold  map[string]database.Media
 	MediaByTitleDBID map[int64][]database.Media
 	MediaByFilename  map[string][]database.Media
+	ArcadeBySetName  map[string][]database.Media
 	// Containers resolves directory paths to the single media row they collapse
 	// to, matching what browse shows for the same folder. It is built over every
 	// indexed row, including already-scraped ones, because a directory holding
@@ -226,6 +229,7 @@ func NewPlatformScraper() platforms.Scraper {
 				fs:                 fs,
 				cfg:                cfg,
 				externalAssetRoots: externalAssetRootsForPlatform(cfg, pl),
+				matchArcadeSets:    pl.ID() == ids.Mister || pl.ID() == ids.Mistex,
 			}
 			go s.scrapeLoop(ctx, opts, systems, db.MediaDB, ch)
 			return nil
@@ -441,6 +445,7 @@ func (g *GamelistXMLScraper) loadRecordsFromParsed(
 	parsed parsedGamelistSystem,
 ) ([]*GamelistRecord, error) {
 	var records []*GamelistRecord
+	var arcadeRecords []*GamelistRecord
 	mediaDirsByRoot := g.orderedMediaDirsForSystem(system)
 	candidateMedia := len(indexes.MediaByPathFold)
 	candidateTitles := len(indexes.TitlesBySlug)
@@ -474,6 +479,33 @@ outer:
 			}
 
 			resolved := esmedia.ResolvePath(game.Path, file.RootPath)
+			var pathMedia database.Media
+			var matchedPathKey string
+			var pathOK bool
+			if resolved != "" {
+				pathMedia, matchedPathKey, pathOK = g.canonicalMediaForResolvedPath(indexes, resolved)
+				if !pathOK {
+					// Directory entries retain the same collapsed-container rule as browse.
+					pathMedia, matchedPathKey, pathOK = containerMediaForDir(indexes, resolved)
+					if pathOK {
+						containerPathResolutions++
+					}
+				}
+			}
+			if !pathOK {
+				if media, known := arcadeMediaForSet(indexes, game.Path); known {
+					if media.DBID != 0 {
+						arcadeRecords = append(arcadeRecords, &GamelistRecord{
+							SystemRootPath: file.RootPath, AssetRootPath: file.AssetRootPath,
+							MediaDirsByRoot: fileMediaDirsByRoot, Game: *game,
+							MatchKind: gamelistMatchArcadeSet, MatchedTitleDBID: media.MediaTitleDBID,
+							MatchedMediaDBID: media.DBID, MediaLevelWriteSafe: true,
+							RequireExistingImage: file.RequireExistingImage,
+						})
+					}
+					continue
+				}
+			}
 			if resolved == "" {
 				invalidPaths++
 				continue
@@ -486,19 +518,6 @@ outer:
 				NoExt:        true,
 				ProvidedName: game.Name,
 			})
-
-			pathMedia, matchedPathKey, pathOK := g.canonicalMediaForResolvedPath(indexes, resolved)
-			if !pathOK {
-				// ES-DE writes <game> entries whose path is a directory when the
-				// folder name carries a ROM extension, so a disc folder reads as
-				// one game. Resolve those through the same container rule browse
-				// uses, otherwise the entry falls back to a slug-only match and
-				// its artwork is dropped as unsafe for media scope.
-				pathMedia, matchedPathKey, pathOK = containerMediaForDir(indexes, resolved)
-				if pathOK {
-					containerPathResolutions++
-				}
-			}
 
 			title, titleOK := indexes.TitlesBySlug[pf.Slug]
 			switch {
@@ -627,8 +646,25 @@ outer:
 		}
 	}
 
+	// Identity fallbacks run last so direct path/slug entries win regardless of
+	// XML ordering. Remaining duplicates follow the configured source order.
+	claimed := make(map[int64]struct{}, len(records))
+	for _, record := range records {
+		claimed[record.MatchedMediaDBID] = struct{}{}
+	}
+	var arcadeSetMatches int
+	for _, record := range arcadeRecords {
+		if _, exists := claimed[record.MatchedMediaDBID]; exists {
+			continue
+		}
+		claimed[record.MatchedMediaDBID] = struct{}{}
+		records = append(records, record)
+		arcadeSetMatches++
+	}
+
 	log.Info().
 		Str("system", system.ID).
+		Int("arcade_set_matches", arcadeSetMatches).
 		Int("candidate_titles", candidateTitles).
 		Int("candidate_media", candidateMedia).
 		Int("gamelist_files", gamelistFiles).
@@ -868,6 +904,13 @@ func (g *GamelistXMLScraper) scrapeLoop(
 				return
 			}
 			sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, FatalErr: parseErr, Done: true})
+			return
+		}
+
+		var arcadeErr error
+		indexes.ArcadeBySetName, arcadeErr = g.indexArcadeSets(ctx, allMedia, parsed)
+		if arcadeErr != nil {
+			sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
 			return
 		}
 
@@ -1223,6 +1266,13 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 	// fallbackNames are ROM-relative PNG filenames used to locate matching
 	// artwork files under media/ sub-directories.
 	fallbackNames := artworkFallbackNames(game.Path, record.SystemRootPath)
+	if record.MatchKind == gamelistMatchArcadeSet {
+		stem := arcadeSetStem(game.Path)
+		fallbackNames = []string{stem + ".png"}
+		if lower := strings.ToLower(stem); lower != stem {
+			fallbackNames = append(fallbackNames, lower+".png")
+		}
+	}
 
 	if game.Desc != "" {
 		titleProps = append(titleProps,
@@ -2458,6 +2508,13 @@ func matchCompanionChildMedia(
 	}
 
 	if media, _, ok := matchMediaByResolvedPath(indexes, child.ResolvedPath); ok {
+		return companionMediaMatch{Media: []database.Media{media}, MediaLevelWriteSafe: true}
+	}
+
+	if media, known := arcadeMediaForSet(indexes, child.ResolvedPath); known {
+		if media.DBID == 0 {
+			return companionMediaMatch{}
+		}
 		return companionMediaMatch{Media: []database.Media{media}, MediaLevelWriteSafe: true}
 	}
 


### PR DESCRIPTION
Closes #913

- Match ROM ZIP/set-name gamelist entries to unique indexed MiSTer MRAs using their `<setname>`, including externally stored custom bundles.
- Preserve existing direct-path and slug behavior; reject ambiguous sets even when some variants were already scraped. Keep asset path restrictions unchanged.
- Add bounded MRA parsing, regular/Companion matching coverage, SQLite repeat/force regressions, and parser fuzzing.
- Document MRA-based indexing, external bundle layout, and explicit paths for alternate-core variants.

Based directly on main; does not include or depend on #1436.

## Fixes from on-device review

Verified against the real `_Arcade` library on the MiSTer test device (15,438 MRA files, 3,137 indexed as `Arcade`). Four problems the unit tests could not see:

**Artwork fallback was PNG-only.** Set-name records replaced the fallback names with a single `<set>.png`, so a bundle whose images are JPG, JPEG or WebP found nothing while the same files matched for every other kind of record. Now built from the shared extension list, with the ROM-relative names kept as a lower-priority fallback.

**The 256 KiB descriptor bound excluded real games.** MRAs embed their ROM payload as base64 and reach 25 MB; 50 of the 3,137 indexed arcade descriptors are over 256 KiB, including Zaxxon, Carnival, Cosmic Alien and the CPS2 hacks. Parsing now stops at the first `<rom>` element, which every descriptor in the corpus writes after its set name, and the file size limit is gone. Repeated, nested and missing set names in the header are still rejected, as are malformed documents, trailing documents and headers that outrun the read bound. This is also faster than the original: **3.2s** to read all 3,137 descriptors, against 8.5s for the 256 KiB whole-file bound and 40.6s at a 32 MiB one.

**Granular arcade systems were never scraped.** `CPS1`, `IremM72` and the rest are classified out of `_Arcade` rather than walked, so path discovery resolves zero ROM paths for them and `resolveSystemsFromPlatform` skipped them — the bundle layout the documentation asks users to set up was silently ignored. A system with no launcher scan folders is now kept when a custom bundle is installed for it.

**A title guess could displace an exact set-name match.** MAME clone sets share one display name, so an arcade gamelist normally holds several entries called "R-Type". An entry whose own set is not indexed slug-matched the title, took the MRA the set-name entry had claimed, and then wrote nothing at media level because a first-media slug fallback is not media-level safe: a scrape left the canonical `R-Type (World).mra` with no metadata at all. Evidence is now ranked — indexed path or container, then a slug the entry's own path confirms, then `<setname>`, then a slug alone — and compared in the deferred merge pass, so the outcome no longer depends on which entry the parser reached first. This is the reverse of CodeRabbit's suggested ordering; see the review thread for why that direction sends a clone's metadata to the parent's MRA.

Also: read each descriptor with one stat rather than a stat plus an lstat, count unresolvable and superseded set entries in the record-load summary, and log what the set-name index read so a run that matches nothing is distinguishable from the feature being off.

## Verification

A Skraper-style bundle covering nine entries — relative `.zip`, `.7z`, uppercase `.ZIP`, a foreign absolute POSIX path, a Windows path, artwork found by `media/` fallback, and one entry with no indexed set — scraped against the device's real library: 8/8 set entries matched their exact MRA, 0 superseded, artwork resolved from `.png`, `.jpg` and `.webp`. Both `mister-vm` scenarios (`launch`, `service`) pass. Full test suite with race detection, `task lint`, `task cross-lint:all` and `task vulncheck` clean; the arcade parser fuzz target ran 4.5M executions without a failure.
