### PR TITLE
test(mister): add disposable VM integration rig

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -481,6 +481,7 @@ func TestTokenProcessing(t *testing.T) {
 - **[Time-Based Testing](pkg/testing/TIME_TESTING.md)** - Deterministic time testing with clockwork (fake clocks, tickers, timeouts)
 - **[Fuzz Testing](pkg/testing/FUZZ_TESTING.md)** - Native Go fuzzing for discovering edge cases in parsing and validation
 - **[Property-Based Testing](pkg/testing/PROPERTY_TESTING.md)** - Rapid property-based testing for verifying code invariants
+- **[MiSTer VM Integration Rig](scripts/mister-vm/README.md)** - Headless ARM VM running an unmodified MiSTer build against stock userspace; opt-in, not part of `task test`
 
 ## Best Practices
 

--- a/pkg/service/scan_behavior_test.go
+++ b/pkg/service/scan_behavior_test.go
@@ -1339,6 +1339,11 @@ scan_mode = "hold"`))
 	env.waitForSoftwareTokenUID(t, "game1")
 	env.sendRemovalOn(testReaderID)
 	env.waitForStop(t)
+	// StopActiveLauncher is observed before timedExit queues its final owner
+	// clear. Wait for that clear so it cannot erase the next tap's owner.
+	require.Eventually(t, func() bool {
+		return env.st.GetSoftwareToken() == nil
+	}, behaviorTimeout, time.Millisecond, "hold-reader exit cleanup did not finish")
 
 	// From then on the tap reader must keep reloading on every tap.
 	for range 2 {

--- a/scripts/mister-vm/.gitignore
+++ b/scripts/mister-vm/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.venv/

--- a/scripts/mister-vm/README.md
+++ b/scripts/mister-vm/README.md
@@ -122,7 +122,7 @@ python3 scripts/mister-vm/test_unit.py
 python3 scripts/mister-vm/test_integration.py
 ```
 
-12 unit tests cover simulator parsing and checksum-cache behavior without network/VM dependencies. Six integration tests cover parallel local/release launch, published-release persistence, invalid input, wrong version, timeout and termination. Intentional `FAIL:` run lines are expected; unittest's final `OK` determines suite success. Integration tests require setup, pinned release download and local `_build/mister_arm/zaparoo.sh`; override `--assets` / `--binary` when needed.
+12 unit tests cover simulator parsing and checksum-cache behavior without network/VM dependencies. Seven integration tests cover parallel local/release launch, published-release persistence, invalid input, wrong version, timeout, termination and propagation of unrelated `SystemExit` exceptions. Intentional `FAIL:` run lines are expected; unittest's final `OK` determines suite success. Integration tests require setup, pinned release download and local `_build/mister_arm/zaparoo.sh`; override `--assets` / `--binary` when needed.
 
 Tests verify process exit, released ports (accounting for TCP TIME_WAIT), immutable base/kernel and disk cleanup. One integration case intentionally retains disks per suite execution.
 

--- a/scripts/mister-vm/README.md
+++ b/scripts/mister-vm/README.md
@@ -105,7 +105,7 @@ Options:
 
 Artifacts under `<assets>/runs/<unique-id>/`:
 
-- `run.json`: overall outcome, input/source hashes, QEMU version, port, process exits, base integrity and cleanup evidence.
+- `run.json`: overall outcome, input/source hashes, QEMU version, port, process exits, base integrity and cleanup evidence. Base and kernel are checked against setup's `ready.json` record before boot, so a run cannot pass against replaced assets.
 - `results.json`, `notifications.json`: scenario checks and API evidence, including partial progress.
 - `boot-0.log` (plus `boot-1.log` for service): serial boot/command output.
 - `scenario.log`: readable scenario transcript.
@@ -122,7 +122,7 @@ python3 scripts/mister-vm/test_unit.py
 python3 scripts/mister-vm/test_integration.py
 ```
 
-12 unit tests cover simulator parsing and checksum-cache behavior without network/VM dependencies. Seven integration tests cover parallel local/release launch, published-release persistence, invalid input, wrong version, timeout, termination and propagation of unrelated `SystemExit` exceptions. Intentional `FAIL:` run lines are expected; unittest's final `OK` determines suite success. Integration tests require setup, pinned release download and local `_build/mister_arm/zaparoo.sh`; override `--assets` / `--binary` when needed.
+16 unit tests cover simulator parsing, FIFO command framing and checksum-cache behavior without network/VM dependencies. Seven integration tests cover parallel local/release launch, published-release persistence, invalid input, wrong version, timeout, termination and propagation of unrelated `SystemExit` exceptions. Intentional `FAIL:` run lines are expected; unittest's final `OK` determines suite success. Integration tests require setup, pinned release download and local `_build/mister_arm/zaparoo.sh`; override `--assets` / `--binary` when needed.
 
 Tests verify process exit, released ports (accounting for TCP TIME_WAIT), immutable base/kernel and disk cleanup. One integration case intentionally retains disks per suite execution.
 

--- a/scripts/mister-vm/README.md
+++ b/scripts/mister-vm/README.md
@@ -1,0 +1,129 @@
+# MiSTer VM integration rig
+
+Headless ARM VM running unchanged MiSTer Zaparoo against stock MiSTer userspace, a config-adapted official kernel, real exFAT/ext4 filesystems and a small Main substitute. Tests internal service/platform behavior, **not FPGA game execution**.
+
+Sources and scripts are versioned here. Downloads, compiler outputs, disks, guest state and results stay under ignored `_scratch/`. No host mounts, bridges, USB grants or automatic package installation.
+
+## Prerequisites
+
+Tested host: Fedora 44 x86-64, QEMU 10.2.2, Python 3.14, ARM GCC 10.2.1.
+
+- Linux x86-64 host, Python **3.12+**.
+- `qemu-system-arm` supporting `virt-10.2`, `qemu-img`, `mke2fs`, `debugfs`, `mkfs.exfat`, `7z`.
+- Kernel build tools: `make`, host GCC, ARM Linux hard-float cross-compiler, binutils, flex, bison, Perl, LZ4 and kernel build dependencies. OpenSSL headers must include ENGINE support; ELF development headers may also be required.
+- Several GiB free space for source/build outputs and images. Sparse disks have 2 GiB virtual capacity per base/overlay, not necessarily 2 GiB physical allocation.
+- WebSocket client for runner/integration tests. Install into a project-local venv if needed:
+
+```sh
+python3 -m venv _scratch/mister-vm-venv
+_scratch/mister-vm-venv/bin/pip install -r scripts/mister-vm/requirements.txt
+```
+
+Examples below use `python3`; use the venv interpreter instead when dependencies are there. Unit tests and setup use standard library only. Do not use `python -O`; runner requires assertions.
+
+Compiler provisioning remains a host prerequisite, not a hidden download. GCC 10.2.1 is verified; other compiler versions are not yet validated. Setup records compiler version and output hashes, not a claim of bit-identical builds across toolchains.
+
+## Prepare assets
+
+From repository root:
+
+```sh
+python3 scripts/mister-vm/setup.py --cross-compile arm-linux-gnueabihf-
+```
+
+If compiler is not on PATH, supply its absolute filename prefix, ending in `-`:
+
+```sh
+python3 scripts/mister-vm/setup.py \
+  --cross-compile /path/to/toolchain/bin/arm-none-linux-gnueabihf-
+```
+
+This downloads/checks kernel and userspace hashes from `pins.json`, builds the kernel, edits a copy of stock init offline with `debugfs`, creates regular image files and populates exFAT inside a provisioning VM. Base image contains no Zaparoo binary or user database; each test installs its selected binary.
+
+Defaults:
+
+- Assets: `_scratch/mister-vm-assets/`
+- Download cache: `_scratch/mister-vm-downloads/`
+
+Options: `--assets PATH`, `--download-cache PATH`, `--jobs N`, `--host-include PATH`, `--host-bin PATH`. Last two allow existing local headers/tools without changing host installation. In this investigation the existing scratch GCC 10.2.1, ENGINE headers and LZ4 were supplied with these options; ordinary hosts with those dependencies installed do not need the overrides.
+
+Populate verified cache separately, without building:
+
+```sh
+python3 scripts/mister-vm/setup.py --download-only
+```
+
+Completed setup is idempotent: validates input pins and base/kernel hashes, then returns. Incomplete setup fails closed on rerun; inspect `kernel-build.log`, `rootfs-build.log`, `provision.log` and `FAILED`, then choose a fresh `--assets` path. No automatic destructive reset. Bad/incomplete downloads remain for diagnosis; no automatic checksum repinning or replacement of invalid cached assets.
+
+Do not rebuild or modify a base while overlays depend on it. Kernel source remains unmodified: only configuration enables virtio/PL011/RTC and disables physical FPGA drivers. Stock init adaptations disable SSH/FTP/Samba, replace framebuffer console with serial shell, discard audio and provide controlled startup. VM setup never runs the Windows installer.
+
+## Run local build
+
+Build Core using its normal repository workflow (`task mister:build-arm`), then:
+
+```sh
+python3 scripts/mister-vm/run.py --binary _build/mister_arm/zaparoo.sh
+python3 scripts/mister-vm/run.py --binary _build/mister_arm/zaparoo.sh --scenario service
+```
+
+`launch` is default scenario. Despite `.sh` extension, selected input must be an extracted ELF32 little-endian ARM executable—not an archive or shell script. Runner verifies copied binary hash inside guest before starting it.
+
+## Run pinned published release
+
+```sh
+python3 scripts/mister-vm/setup.py --release-only
+python3 scripts/mister-vm/run.py \
+  --binary _scratch/mister-vm-assets/releases/2.17.2/zaparoo.sh \
+  --expect-version 2.17.2
+python3 scripts/mister-vm/run.py \
+  --binary _scratch/mister-vm-assets/releases/2.17.2/zaparoo.sh \
+  --expect-version 2.17.2 --scenario service
+```
+
+Published MiSTer **2.17.2 passed both scenarios**. Archive URL/hash are pinned; only the exact `zaparoo.sh` member is copied to a fixed output path. No release publication, updater metadata, signing or rollout action is performed. Other release versions can be supplied as local binaries; their API compatibility is not assumed.
+
+## Scenarios
+
+**Launch:** boot/environment/hash checks → health/API/file reader → real indexing → scan synthetic SNES path with spaces/ampersand → generated MGL/FIFO → simulated SNES/real active media → hold removal → Menu/closed play history. Includes missing-media characterization.
+
+**Service:** boot/hash/API/SQLite checks → real scan/removal → restart with exact history entry and reader identity preserved → API stops → sync and cold boot of same private overlay → history/identity preserved and tmpfs reset. This is orderly persistence, not unclean-power-loss durability.
+
+Core intentionally trusts media paths to avoid scanning large ZIPs during launch. Successful submission/optimistic active media is **not verified game loading**. Missing-media test keeps these observations separate; it does not demand hot-path path validation.
+
+Main substitute supports only Menu and one-file SNES MGL, using actual FIFO reads and truncating status-file writes. Its delay and rejection policy are synthetic, not established hardware Main parity. No manual-selection/recents, save states, USB/NFC or physical timing coverage.
+
+## Isolation, artifacts and failures
+
+Each invocation owns an overlay directly backed by `sd.raw`, read-only fixture-transfer disk, unique artifact directory and dynamic **localhost-only** port. QEMU user networking uses `restrict=on`; no host filesystem sharing. Parallel invocations are tested. A port bind collision fails at boot before API access.
+
+Options:
+
+- `--assets PATH`: select prepared assets.
+- `--expect-version STRING`: exact API version assertion.
+- `--timeout SECONDS`: whole-run deadline, default 360; bounded shutdown/evidence finalization follows expiry.
+- `--keep-disk`: retain overlay/fixture disk for diagnosis; no automatic resume.
+
+Artifacts under `<assets>/runs/<unique-id>/`:
+
+- `run.json`: overall outcome, input/source hashes, QEMU version, port, process exits, base integrity and cleanup evidence.
+- `results.json`, `notifications.json`: scenario checks and API evidence, including partial progress.
+- `boot-0.log` (plus `boot-1.log` for service): serial boot/command output.
+- `scenario.log`: readable scenario transcript.
+- `failure.txt`: traceback when run fails.
+
+Early setup errors can lack guest logs. Exit 0 means success; exit 1 means failure. `run.json` is authoritative if scenario succeeds but integrity/cleanup subsequently fails.
+
+QEMU is reaped on success, failure, deadline and SIGTERM. Writable disks/staging are deleted by default; artifacts remain. SIGKILL or host failure cannot guarantee cleanup. Never delete an active run's directory. Retained guest disks can contain generated identity/runtime data: keep them local and uncommitted. Use trusted Zaparoo binaries; this is not a hardened hostile-code sandbox.
+
+## Test tooling
+
+```sh
+python3 scripts/mister-vm/test_unit.py
+python3 scripts/mister-vm/test_integration.py
+```
+
+12 unit tests cover simulator parsing and checksum-cache behavior without network/VM dependencies. Six integration tests cover parallel local/release launch, published-release persistence, invalid input, wrong version, timeout and termination. Intentional `FAIL:` run lines are expected; unittest's final `OK` determines suite success. Integration tests require setup, pinned release download and local `_build/mister_arm/zaparoo.sh`; override `--assets` / `--binary` when needed.
+
+Tests verify process exit, released ports (accounting for TCP TIME_WAIT), immutable base/kernel and disk cleanup. One integration case intentionally retains disks per suite execution.
+
+No CI job is added yet: host compiler/QEMU prerequisites and runtime/storage budget should be selected explicitly before wiring into mandatory CI.

--- a/scripts/mister-vm/fixtures.py
+++ b/scripts/mister-vm/fixtures.py
@@ -1,0 +1,65 @@
+"""Deterministic synthetic guest fixtures; no copyrighted media or host mounts."""
+from pathlib import Path
+import shutil
+import subprocess
+
+SOURCE = Path(__file__).resolve().parent
+CONFIG = '''error_reporting = false
+debug_logging = true
+[audio]
+scan_feedback = false
+[updates]
+check = false
+install = false
+[readers]
+auto_detect = false
+[[readers.connect]]
+driver = "file"
+path = "/tmp/vm-reader.token"
+'''
+MAIN = '''#!/bin/sh
+ln -sf /dev/null /dev/MrAudio
+printf MENU > /tmp/CORENAME
+'''
+STARTUP = '''#!/bin/sh
+printf 'VM_USER_STARTUP\\n'
+'''
+PREPARE = '''#!/bin/sh
+set -eu
+[ -b /dev/vda1 ]
+mkdir /tmp/outer
+mount -t exfat /dev/vda1 /tmp/outer
+cp -r /tmp/payload/sd/. /tmp/outer/
+sync
+umount /tmp/outer
+printf 'VM_DISK_PREPARED\\n'
+'''
+
+
+def text(path, content):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def ext4(stage, image, size):
+    with image.open('xb') as stream:
+        stream.truncate(size)
+    subprocess.run(['mke2fs', '-q', '-t', 'ext4', '-F', '-O', '^orphan_file,^metadata_csum_seed',
+                    '-d', str(stage), str(image)], check=True, timeout=120)
+
+
+def build(stage, image, binary, scenario):
+    stage.mkdir(exist_ok=False)
+    (stage / 'Scripts').mkdir()
+    shutil.copyfile(binary, stage / 'Scripts/zaparoo.sh')
+    text(stage / 'zaparoo/config.toml', CONFIG + f'scan_mode = "{"hold" if scenario == "launch" else "tap"}"\n')
+    text(stage / 'MiSTer', MAIN)
+    if scenario == 'launch':
+        shutil.copyfile(SOURCE / 'main-sim.py', stage / 'main-sim.py')
+        text(stage / 'games/SNES/VM Test & Game.sfc', 'Synthetic fixture; not a playable game.\n')
+        text(stage / '_Console/SNES_20260905.rbf', 'Synthetic RBF; never program an FPGA.\n')
+        text(stage / 'menu.rbf', 'Synthetic Menu.\n')
+        text(stage / 'fixtures/missing.mgl', '''<mistergamedescription><rbf>_Console/SNES</rbf>
+<file delay="2" type="f" index="0" path="../../../../../media/fat/games/SNES/Missing.sfc"/>
+</mistergamedescription>''')
+    ext4(stage, image, max(128 * 1024 * 1024, binary.stat().st_size * 2 + 32 * 1024 * 1024))

--- a/scripts/mister-vm/main-sim.py
+++ b/scripts/mister-vm/main-sim.py
@@ -50,6 +50,14 @@ def resolve(command):
     return 'SNES', str(game)
 
 
+def frames(data):
+    # Writes under PIPE_BUF are atomic, but one read still returns every
+    # command queued since the last read. Splitting keeps a coalesced read from
+    # looking like a single command with embedded control characters. A
+    # newline-less remainder is a command in its own right, as Main treats it.
+    return [x for x in data.split(b'\n') if x]
+
+
 def event(kind, **data):
     with Path('/tmp/mister-sim-events.jsonl').open('a') as stream:
         stream.write(json.dumps(dict(kind=kind, time=time.time(), **data)) + '\n')
@@ -76,17 +84,15 @@ def main():
     try:
         while True:
             poll.poll()
-            raw = os.read(fd, 1023)
-            if raw.endswith(b'\n'):
-                raw = raw[:-1]
-            try:
-                command = raw.decode('utf-8')
-                event('command', command=command)
-                core, game = resolve(command)
-                time.sleep(0.1)  # Synthetic delay, not calibrated FPGA loading.
-                publish(core, game)
-            except (ValueError, OSError, ET.ParseError) as exc:
-                event('rejected', reason=str(exc))
+            for raw in frames(os.read(fd, 65536)):
+                try:
+                    command = raw.decode('utf-8')
+                    event('command', command=command)
+                    core, game = resolve(command)
+                    time.sleep(0.1)  # Synthetic delay, not calibrated FPGA loading.
+                    publish(core, game)
+                except (ValueError, OSError, ET.ParseError) as exc:
+                    event('rejected', reason=str(exc))
     finally:
         os.close(fd)
 

--- a/scripts/mister-vm/main-sim.py
+++ b/scripts/mister-vm/main-sim.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""One-system Main boundary substitute, not FPGA emulation or hardware parity.
+
+Owns FIFO, CORENAME and RBFNAME only. Never writes ACTIVEGAME or Core databases.
+"""
+import json
+import os
+from pathlib import Path
+import select
+import time
+import xml.etree.ElementTree as ET
+
+ROOT = Path('/media/fat')
+
+
+def resolve(command):
+    if not command.startswith('load_core '):
+        raise ValueError('unsupported command')
+    argument = command[len('load_core '):]
+    if any(ord(char) < 32 for char in argument):
+        raise ValueError('control character or combined commands')
+    path = Path(os.path.normpath(str(ROOT / argument)))
+    if path == ROOT / 'menu.rbf':
+        if not path.is_file():
+            raise ValueError('menu fixture missing')
+        return 'MENU', None
+    if path.suffix.lower() != '.mgl' or path.stat().st_size > 16384:
+        raise ValueError('unsupported or oversized launch file')
+    data = path.read_text()
+    if '<!DOCTYPE' in data or '<!ENTITY' in data:
+        raise ValueError('XML declarations unsupported')
+    document = ET.fromstring(data)
+    if document.tag != 'mistergamedescription' or document.attrib:
+        raise ValueError('unsupported MGL root')
+    if [child.tag for child in document] != ['rbf', 'file']:
+        raise ValueError('expected one SNES file')
+    if document[0].text != '_Console/SNES' or document[0].attrib:
+        raise ValueError('unsupported core')
+    attributes = document[1].attrib
+    if set(attributes) != {'delay', 'type', 'index', 'path'}:
+        raise ValueError('unsupported file attributes')
+    if (attributes['delay'], attributes['type'], attributes['index']) != ('2', 'f', '0'):
+        raise ValueError('unsupported slot')
+    game = Path(os.path.normpath(str(ROOT / 'games/SNES' / attributes['path'])))
+    if game.parent != ROOT / 'games/SNES' or game.suffix != '.sfc' or not game.is_file():
+        raise ValueError('missing or unsupported SNES game')
+    cores = list((ROOT / '_Console').glob('SNES_*.rbf'))
+    if len(cores) != 1 or not cores[0].is_file():
+        raise ValueError('expected one SNES RBF')
+    return 'SNES', str(game)
+
+
+def event(kind, **data):
+    with Path('/tmp/mister-sim-events.jsonl').open('a') as stream:
+        stream.write(json.dumps(dict(kind=kind, time=time.time(), **data)) + '\n')
+
+
+def publish(core, game=None):
+    # Truncating writes, as in Main; no atomic-rename substitute for inotify.
+    Path('/tmp/CORENAME').write_text(core)
+    Path('/tmp/RBFNAME').write_text(core)
+    Path('/tmp/mister-sim-status.json').write_text(json.dumps(dict(core=core, game=game)))
+    event('state', core=core, game=game)
+
+
+def main():
+    Path('/tmp/mister-sim-events.jsonl').write_text('')
+    fifo = Path('/dev/MiSTer_cmd')
+    if fifo.exists():
+        fifo.unlink()
+    os.mkfifo(str(fifo), 0o666)
+    fd = os.open(str(fifo), os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC)
+    poll = select.poll()
+    poll.register(fd, select.POLLIN)
+    publish('MENU')
+    try:
+        while True:
+            poll.poll()
+            raw = os.read(fd, 1023)
+            if raw.endswith(b'\n'):
+                raw = raw[:-1]
+            try:
+                command = raw.decode('utf-8')
+                event('command', command=command)
+                core, game = resolve(command)
+                time.sleep(0.1)  # Synthetic delay, not calibrated FPGA loading.
+                publish(core, game)
+            except (ValueError, OSError, ET.ParseError) as exc:
+                event('rejected', reason=str(exc))
+    finally:
+        os.close(fd)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/mister-vm/pins.json
+++ b/scripts/mister-vm/pins.json
@@ -1,0 +1,21 @@
+{
+  "kernel": {
+    "url": "https://codeload.github.com/MiSTer-devel/Linux-Kernel_MiSTer/tar.gz/5fcfae36975b217f6ab82b501065f3b13173ae15",
+    "name": "kernel.tar.gz",
+    "sha256": "fda82daa065b08bd0e43b472f4e14cb833e0e1ed54065d86dd25eaf72e107f83",
+    "prefix": "Linux-Kernel_MiSTer-5fcfae36975b217f6ab82b501065f3b13173ae15"
+  },
+  "userspace": {
+    "url": "https://raw.githubusercontent.com/MiSTer-devel/SD-Installer-Win64_MiSTer/b8531c7848526d9a8227841923cc4a493cb6e631/release_20250402.7z",
+    "name": "release_20250402.7z",
+    "sha256": "5d087d9c501b2bc50aaf918146e7bf30e5981c08268d5a0e67a3233a4da642ba",
+    "member": "files/linux/linux.img",
+    "image_sha256": "4acd6edaaeca7474b1f1be5e40dc0fb6828950dd6f8a033b4bcd8f26f8201a70"
+  },
+  "release": {
+    "version": "2.17.2",
+    "url": "https://github.com/ZaparooProject/zaparoo-core/releases/download/v2.17.2/zaparoo-mister_arm-2.17.2.zip",
+    "name": "zaparoo-mister_arm-2.17.2.zip",
+    "sha256": "e81d78ae277396986415913637c26ac9e48a49181309fe0d117d68836f3025ae"
+  }
+}

--- a/scripts/mister-vm/requirements.txt
+++ b/scripts/mister-vm/requirements.txt
@@ -1,0 +1,1 @@
+websockets==16.0

--- a/scripts/mister-vm/run.py
+++ b/scripts/mister-vm/run.py
@@ -37,6 +37,14 @@ def digest(path):
         return hashlib.file_digest(stream, 'sha256').hexdigest()
 
 
+def verify_prepared(assets, base_hash, kernel_hash):
+    # The end-of-run comparison only proves this run changed nothing. Setup's
+    # record is what proves the assets are still the ones it prepared.
+    prepared = json.loads((assets / 'ready.json').read_text())
+    if base_hash != prepared['base_sha256'] or kernel_hash != prepared['kernel_sha256']:
+        raise RuntimeError('Prepared base image or kernel does not match setup record')
+
+
 def validate_binary(path):
     if not path.is_file():
         raise ValueError('Expected regular ARM ELF binary')
@@ -60,8 +68,8 @@ def main():
     if not 1 <= args.timeout <= 3600:
         parser.error('--timeout must be between 1 and 3600 seconds')
     assets, binary = args.assets.resolve(), args.binary.resolve()
-    if not assets.is_dir() or (assets / 'setup.lock').exists() or (assets / 'FAILED').exists():
-        parser.error('Asset directory absent or setup in progress; run setup.py first')
+    if not assets.is_dir() or not (assets / 'ready.json').is_file() or (assets / 'setup.lock').exists() or (assets / 'FAILED').exists():
+        parser.error('Asset directory absent, incomplete or setup in progress; run setup.py first')
     runs = assets / 'runs'
     if runs.is_symlink():
         parser.error('Refusing symlinked runs directory')
@@ -81,6 +89,7 @@ def main():
             if not shutil.which(command):
                 raise RuntimeError('Required executable missing: ' + command)
         state['base_sha256'], state['kernel_sha256'] = digest(base), digest(kernel)
+        verify_prepared(assets, state['base_sha256'], state['kernel_sha256'])
         state['binary_sha256'] = digest(binary)
         state['sources'] = {p.name: digest(p) for p in SOURCE.iterdir() if p.suffix in ('.py', '.json', '.txt')}
         state['qemu'] = subprocess.run(['qemu-system-arm', '--version'], check=True, capture_output=True, text=True, timeout=10).stdout.splitlines()[0]

--- a/scripts/mister-vm/run.py
+++ b/scripts/mister-vm/run.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Run a disposable MiSTer VM scenario using local prepared assets."""
+import argparse
+import contextlib
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import signal
+import socket
+import subprocess
+import time
+import traceback
+import uuid
+
+import fixtures
+from scenarios import Harness, launch, service
+
+SOURCE = Path(__file__).resolve().parent
+DEFAULT_ASSETS = SOURCE.parents[1] / '_scratch/mister-vm-assets'
+
+
+class Deadline(BaseException):
+    pass
+
+
+def timed_out(_signal, _frame):
+    raise Deadline('Whole-run deadline exceeded')
+
+
+def interrupted(_signal, _frame):
+    raise KeyboardInterrupt('Run interrupted')
+
+
+def digest(path):
+    with path.open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def validate_binary(path):
+    if not path.is_file():
+        raise ValueError('Expected regular ARM ELF binary')
+    with path.open('rb') as stream:
+        header = stream.read(20)
+    if len(header) != 20 or header[:6] != b'\x7fELF\x01\x01' or header[18:20] != b'\x28\x00':
+        raise ValueError('Expected little-endian ELF32 ARM, not an archive or shell script')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--assets', type=Path, default=DEFAULT_ASSETS)
+    parser.add_argument('--binary', type=Path, required=True)
+    parser.add_argument('--scenario', choices=('launch', 'service'), default='launch')
+    parser.add_argument('--expect-version')
+    parser.add_argument('--timeout', type=int, default=360)
+    parser.add_argument('--keep-disk', action='store_true')
+    args = parser.parse_args()
+    if not __debug__:
+        parser.error('Assertions required; do not use optimized Python')
+    if not 1 <= args.timeout <= 3600:
+        parser.error('--timeout must be between 1 and 3600 seconds')
+    assets, binary = args.assets.resolve(), args.binary.resolve()
+    if not assets.is_dir() or (assets / 'setup.lock').exists() or (assets / 'FAILED').exists():
+        parser.error('Asset directory absent or setup in progress; run setup.py first')
+    runs = assets / 'runs'
+    if runs.is_symlink():
+        parser.error('Refusing symlinked runs directory')
+    runs.mkdir(exist_ok=True)
+    output = runs / (time.strftime('%Y%m%dT%H%M%S') + '-' + uuid.uuid4().hex[:12])
+    output.mkdir()
+    state = dict(passed=False, output=str(output), scenario=args.scenario, binary=str(binary), started=time.time())
+    stage, image, disk = output / 'staging', output / 'fixtures.ext4', output / 'disk.qcow2'
+    base, kernel = assets / 'sd.raw', assets / 'kernel-out/arch/arm/boot/zImage'
+    reservation, harness = socket.socket(), None
+    old_alarm = signal.signal(signal.SIGALRM, timed_out)
+    old_term = signal.signal(signal.SIGTERM, interrupted)
+    signal.alarm(args.timeout)
+    try:
+        validate_binary(binary)
+        for command in ('qemu-system-arm', 'qemu-img', 'mke2fs'):
+            if not shutil.which(command):
+                raise RuntimeError('Required executable missing: ' + command)
+        state['base_sha256'], state['kernel_sha256'] = digest(base), digest(kernel)
+        state['binary_sha256'] = digest(binary)
+        state['sources'] = {p.name: digest(p) for p in SOURCE.iterdir() if p.suffix in ('.py', '.json', '.txt')}
+        state['qemu'] = subprocess.run(['qemu-system-arm', '--version'], check=True, capture_output=True, text=True, timeout=10).stdout.splitlines()[0]
+        reservation.bind(('127.0.0.1', 0))
+        state['port'] = reservation.getsockname()[1]
+        fixtures.build(stage, image, binary, args.scenario)
+        if digest(stage / 'Scripts/zaparoo.sh') != state['binary_sha256']:
+            raise RuntimeError('Input binary changed during copy')
+        subprocess.run(['qemu-img', 'create', '-f', 'qcow2', '-F', 'raw', '-b', str(base), str(disk)], check=True, capture_output=True, timeout=20)
+        (output / 'run.json').write_text(json.dumps(state, indent=2) + '\n')
+        harness = Harness(assets, output, state['port'], state['binary_sha256'], args.expect_version)
+        # A competing bind after release makes QEMU fail before API access.
+        reservation.close()
+        with (output / 'scenario.log').open('x') as log, contextlib.redirect_stdout(log), contextlib.redirect_stderr(log):
+            try:
+                {'launch': launch, 'service': service}[args.scenario](harness)
+                harness.save(True)
+            finally:
+                harness.close()
+        state['passed'] = True
+    except BaseException as exc:
+        state['error'] = type(exc).__name__ + ': ' + str(exc)
+        (output / 'failure.txt').write_text(traceback.format_exc())
+        if harness:
+            harness.save(False)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        reservation.close()
+        try:
+            if harness:
+                harness.close()
+                state['processes'] = harness.processes
+            if 'base_sha256' in state:
+                state['base_unchanged'] = digest(base) == state['base_sha256']
+                state['kernel_unchanged'] = digest(kernel) == state['kernel_sha256']
+                if not state['base_unchanged'] or not state['kernel_unchanged']:
+                    raise RuntimeError('Base image or kernel changed during run')
+            if stage.exists():
+                shutil.rmtree(stage)
+            if not args.keep_disk:
+                disk.unlink(missing_ok=True)
+                image.unlink(missing_ok=True)
+            state['disk_retained'] = disk.exists()
+        except Exception as exc:
+            state['passed'] = False
+            state['cleanup_error'] = str(exc)
+        if not (output / 'results.json').exists():
+            (output / 'results.json').write_text(json.dumps(dict(passed=False, checks=[])) + '\n')
+        state['finished'] = time.time()
+        (output / 'run.json').write_text(json.dumps(state, indent=2) + '\n')
+        signal.signal(signal.SIGALRM, old_alarm)
+        signal.signal(signal.SIGTERM, old_term)
+    print(('PASS: ' if state['passed'] else 'FAIL: ') + str(output))
+    if 'error' in state:
+        print(state['error'])
+    return 0 if state['passed'] else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/mister-vm/run.py
+++ b/scripts/mister-vm/run.py
@@ -21,7 +21,7 @@ DEFAULT_ASSETS = SOURCE.parents[1] / '_scratch/mister-vm-assets'
 
 
 class Deadline(BaseException):
-    pass
+    """Escape retry wrappers; handled explicitly at the runner boundary."""
 
 
 def timed_out(_signal, _frame):
@@ -101,7 +101,7 @@ def main():
             finally:
                 harness.close()
         state['passed'] = True
-    except BaseException as exc:
+    except (Exception, Deadline, KeyboardInterrupt) as exc:
         state['error'] = type(exc).__name__ + ': ' + str(exc)
         (output / 'failure.txt').write_text(traceback.format_exc())
         if harness:

--- a/scripts/mister-vm/scenarios.py
+++ b/scripts/mister-vm/scenarios.py
@@ -1,0 +1,191 @@
+"""Public API scenarios against real daemon; no direct database/state mutation."""
+import json
+import shlex
+import time
+
+from websockets.sync.client import connect
+from websockets.exceptions import WebSocketException
+from vm import VM
+
+GAME = '/media/fat/games/SNES/VM Test & Game.sfc'
+MISSING = '/media/fat/games/SNES/Missing.sfc'
+TOKEN = '**delay:1'
+
+
+def wait(read, predicate, timeout=90):
+    until = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < until:
+        try:
+            last = read()
+            if predicate(last):
+                return last
+        except (OSError, ValueError, RuntimeError, WebSocketException) as exc:
+            last = str(exc)
+        time.sleep(0.2)
+    raise TimeoutError(str(last))
+
+
+class Harness:
+    def __init__(self, assets, output, port, binary_hash, expected_version):
+        self.assets, self.output, self.port = assets, output, port
+        self.binary_hash, self.expected_version = binary_hash, expected_version
+        self.vm, self.socket = None, None
+        self.checks, self.notifications, self.processes = [], [], []
+        self.request_id = 0
+
+    def record(self, name, evidence):
+        self.checks.append(dict(check=name, evidence=evidence))
+        print(name, json.dumps(evidence), flush=True)
+        self.save(False)
+        return evidence
+
+    def save(self, passed):
+        (self.output / 'results.json').write_text(json.dumps(dict(passed=passed, checks=self.checks), indent=2) + '\n')
+        (self.output / 'notifications.json').write_text(json.dumps(self.notifications, indent=2) + '\n')
+
+    def disconnect(self):
+        if self.socket is not None:
+            try:
+                self.socket.close()
+            finally:
+                self.socket = None
+
+    def close(self):
+        try:
+            self.disconnect()
+        finally:
+            if self.vm is not None:
+                try:
+                    self.vm.close()
+                finally:
+                    self.processes.append(dict(pid=self.vm.process.pid, exit_code=self.vm.process.returncode))
+                    self.vm = None
+
+    def rpc(self, method, params=None):
+        if self.socket is None:
+            self.socket = connect(f'ws://127.0.0.1:{self.port}/api/v0.1', open_timeout=3, close_timeout=3, proxy=None)
+        self.request_id += 1
+        try:
+            self.socket.send(json.dumps(dict(jsonrpc='2.0', id=self.request_id, method=method, params=params)))
+            while True:
+                data = json.loads(self.socket.recv(timeout=3))
+                if data.get('id') == self.request_id:
+                    if 'error' in data:
+                        raise RuntimeError(data['error'])
+                    return data['result']
+                self.notifications.append(data)
+        except (OSError, WebSocketException):
+            self.disconnect()
+            raise
+
+    def boot(self, install=True):
+        self.vm = VM(self.assets, self.output / 'disk.qcow2', self.output / f'boot-{len(self.processes)}.log',
+                     port=self.port, fixtures=self.output / 'fixtures.ext4')
+        self.vm.wait(b'# ')
+        if install:
+            self.vm.cmd('mkdir /tmp/fixtures; mount -o ro /dev/vda /tmp/fixtures && cp -r /tmp/fixtures/. /media/fat/ && umount /tmp/fixtures')
+        self.vm.cmd('i=0; until ip -4 addr show eth0 | grep -q "inet 10.0.2.15/"; do i=$((i+1)); [ "$i" -lt 45 ] || break; sleep 1; done; ip -4 addr show eth0 | grep "inet 10.0.2.15/"')
+        self.vm.cmd('test -c /dev/uinput && test "$(grep -c ^processor /proc/cpuinfo)" = 2 && grep " / ext4 ro" /proc/mounts && grep " /media/fat exfat rw" /proc/mounts && grep " /tmp tmpfs " /proc/mounts && grep " /run tmpfs " /proc/mounts')
+        value = self.vm.cmd('sha256sum /media/fat/Scripts/zaparoo.sh')
+        assert self.binary_hash + '  /media/fat/Scripts/zaparoo.sh' in value
+        self.record('selected_binary_installed', self.binary_hash)
+
+    def start(self):
+        self.vm.cmd('/media/fat/Scripts/zaparoo.sh -service start')
+        version = wait(lambda: self.rpc('version'), lambda r: r.get('platform') == 'mister')
+        self.record('api_ready', version)
+        if self.expected_version is not None:
+            assert version['version'] == self.expected_version, f'Expected {self.expected_version}, got {version["version"]}'
+        assert self.rpc('health') == {'status': 'ok'}
+        readers = wait(lambda: self.rpc('readers'), lambda r: any(x.get('driver') == 'file' and x.get('connected') for x in r.get('readers', [])))
+        self.record('reader_connected', readers)
+        return next(x for x in readers['readers'] if x['driver'] == 'file')
+
+    def scan(self, text):
+        self.vm.cmd('printf %s ' + shlex.quote(text) + ' > /tmp/vm-reader.token')
+
+    def guest(self, expression):
+        code = 'import json; print("VM_JSON:"+json.dumps(' + expression + '))'
+        result = self.vm.cmd('python3 -c ' + shlex.quote(code))
+        return json.loads(next(x[8:] for x in result.splitlines() if x.startswith('VM_JSON:')))
+
+    def state(self):
+        return self.guest('json.load(open("/tmp/mister-sim-status.json"))')
+
+    def events(self):
+        return self.guest('[json.loads(x) for x in open("/tmp/mister-sim-events.jsonl")]')
+
+
+def launch(h):
+    h.boot()
+    h.vm.cmd('python3 /media/fat/main-sim.py >/tmp/mister-sim.stderr 2>&1 & sim=$!; echo "$sim"')
+    wait(h.state, lambda r: r['core'] == 'MENU')
+    assert h.start()['scanMode'] == 'hold'
+    h.rpc('media.generate', {'systems': ['SNES']})
+    h.record('indexed_fixture', wait(lambda: h.rpc('media.search', {'systems': ['SNES']}), lambda r: any(x['path'] == GAME for x in r['results']), 180))
+    h.scan(GAME)
+    h.record('simulator_snes', wait(h.state, lambda r: r['core'] == 'SNES' and r['game'] == GAME))
+    h.record('active_media', wait(lambda: h.rpc('media'), lambda r: any(x['mediaPath'] == GAME and x['systemId'] == 'SNES' for x in r['active'])))
+    h.record('token_success', wait(lambda: h.rpc('tokens.history'), lambda r: any(x['text'] == GAME and x['success'] for x in r['entries'])))
+    mgl = h.guest('open("/media/fat/.LASTLAUNCH.mgl").read()')
+    assert '&amp;' in mgl
+    h.record('generated_mgl', mgl)
+    session = wait(lambda: h.rpc('media.history'), lambda r: any(x['mediaPath'] == GAME for x in r['entries']))['entries'][0]
+    h.scan('')
+    h.record('removal_menu', wait(h.state, lambda r: r['core'] == 'MENU'))
+    h.record('media_cleared', wait(lambda: h.rpc('media'), lambda r: not r['active']))
+    h.record('session_closed', wait(lambda: h.rpc('media.history'), lambda r: any(x['mediaPath'] == GAME and x['startedAt'] == session['startedAt'] and x.get('endedAt') for x in r['entries'])))
+    wait(lambda: h.rpc('tokens'), lambda r: not r['active'])
+    h.vm.cmd("printf %s 'load_core /media/fat/fixtures/missing.mgl' > /dev/MiSTer_cmd")
+    wait(h.events, lambda r: r[-1]['kind'] == 'rejected')
+    assert h.state()['core'] == 'MENU' and not h.rpc('media')['active']
+    h.scan(MISSING)
+    h.record('trusted_path_history', wait(lambda: h.rpc('tokens.history'), lambda r: any(x['text'] == MISSING and x['success'] for x in r['entries'])))
+    # Owner-confirmed contract: submission is not verified loading. Never add
+    # ZIP inspection to Core's hot path to satisfy this synthetic observer.
+    assert h.state()['core'] == 'MENU'
+    assert any(x['mediaPath'] == MISSING for x in h.rpc('media')['active'])
+    events = h.events()
+    assert events[-2]['command'] == 'load_core /media/fat/.LASTLAUNCH.mgl'
+    assert events[-1]['kind'] == 'rejected'
+    h.record('fifo_events', events)
+    h.scan('')
+    wait(lambda: h.rpc('tokens'), lambda r: not r['active'])
+    h.vm.cmd('/media/fat/Scripts/zaparoo.sh -service stop && sync')
+
+
+def service(h):
+    h.boot()
+    reader = h.start()
+    identity = reader['readerId']
+    h.vm.cmd('test -s /media/fat/zaparoo/user.db && test -s /media/fat/zaparoo/media.db')
+    before = h.rpc('tokens.history')['entries']
+    h.scan(TOKEN)
+    h.record('reader_scan', wait(lambda: h.rpc('tokens'), lambda r: any(x['text'] == TOKEN for x in r['active'])))
+    history = wait(lambda: h.rpc('tokens.history'), lambda r: any(x['text'] == TOKEN and x['success'] and x not in before for x in r['entries']))
+    entry = next(x for x in history['entries'] if x['text'] == TOKEN and x not in before)
+    h.record('new_history_entry', entry)
+    h.scan('')
+    h.record('reader_removal', wait(lambda: h.rpc('tokens'), lambda r: not r['active']))
+    h.vm.cmd('/media/fat/Scripts/zaparoo.sh -service restart')
+    h.disconnect()
+    wait(lambda: h.rpc('version'), lambda r: r['platform'] == 'mister')
+    h.record('restart_identity', wait(lambda: h.rpc('readers'), lambda r: any(x.get('readerId') == identity and x['connected'] for x in r['readers'])))
+    h.record('restart_history', wait(lambda: h.rpc('tokens.history'), lambda r: entry in r['entries']))
+    h.vm.cmd('/media/fat/Scripts/zaparoo.sh -service stop && sync')
+    h.disconnect()
+    try:
+        h.rpc('health')
+    except (OSError, WebSocketException):
+        h.record('api_stopped', True)
+    else:
+        raise AssertionError('API responds after service stop')
+    h.close()
+    h.boot(install=False)
+    assert h.start()['readerId'] == identity
+    h.record('cold_boot_history', wait(lambda: h.rpc('tokens.history'), lambda r: entry in r['entries']))
+    tokens = h.rpc('tokens')
+    assert not tokens.get('active') and not tokens.get('last')
+    h.record('tmpfs_reset', tokens)
+    h.vm.cmd('test ! -s /tmp/vm-reader.token && /media/fat/Scripts/zaparoo.sh -service stop && sync')

--- a/scripts/mister-vm/setup.py
+++ b/scripts/mister-vm/setup.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Download pinned assets, build virtual-board kernel, provision file-only SD."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import struct
+import subprocess
+import tarfile
+import time
+import urllib.request
+import zipfile
+
+import fixtures
+from vm import VM
+
+SOURCE = Path(__file__).resolve().parent
+DEFAULT = SOURCE.parents[1] / '_scratch/mister-vm-assets'
+PINS = json.loads((SOURCE / 'pins.json').read_text())
+
+
+def digest(path):
+    with path.open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def fetch(pin, cache):
+    cache.mkdir(parents=True, exist_ok=True)
+    target = cache / pin['name']
+    if not target.exists():
+        partial = target.with_name(target.name + '.part')
+        try:
+            with partial.open('xb') as out, urllib.request.urlopen(pin['url'], timeout=30) as response:
+                start, total = time.monotonic(), 0
+                while data := response.read(1024 * 1024):
+                    total += len(data)
+                    if total > 512 * 1024 * 1024 or time.monotonic() - start > 600:
+                        raise RuntimeError('Download exceeded size/time bound')
+                    out.write(data)
+            if digest(partial) != pin['sha256']:
+                raise RuntimeError('Download checksum mismatch: ' + pin['name'])
+            partial.rename(target)
+        except BaseException:
+            # Do not remove another process's existing partial download.
+            # Failed owned partials remain available for diagnosis.
+            raise
+    if digest(target) != pin['sha256']:
+        raise RuntimeError('Cached checksum mismatch: ' + str(target))
+    return target
+
+
+def release(assets, cache):
+    pin = PINS['release']
+    archive = fetch(pin, cache)
+    out = assets / 'releases' / pin['version']
+    record = out / 'release.json'
+    binary = out / 'zaparoo.sh'
+    if record.exists():
+        old = json.loads(record.read_text())
+        if old['archive_sha256'] != pin['sha256'] or digest(binary) != old['binary_sha256']:
+            raise RuntimeError('Existing release assets differ; choose a fresh asset directory')
+        print(binary)
+        return
+    out.mkdir(parents=True, exist_ok=False)
+    with zipfile.ZipFile(archive) as zipped:
+        members = [x for x in zipped.infolist() if Path(x.filename).name == 'zaparoo.sh' and not x.is_dir()]
+        if len(members) != 1 or members[0].file_size > 200 * 1024 * 1024:
+            raise RuntimeError('Expected exactly one bounded zaparoo.sh member')
+        with zipped.open(members[0]) as src, binary.open('xb') as dst:
+            shutil.copyfileobj(src, dst)
+    with binary.open('rb') as stream:
+        if stream.read(6) != b'\x7fELF\x01\x01':
+            raise RuntimeError('Published member is not an ELF32 little-endian binary')
+    record.write_text(json.dumps(dict(version=pin['version'], url=pin['url'], archive_sha256=pin['sha256'], binary_sha256=digest(binary)), indent=2) + '\n')
+    print(binary)
+
+
+def build_kernel(assets, cache, compiler, host_include, host_bin, jobs):
+    archive = fetch(PINS['kernel'], cache)
+    extracted = assets / 'source'
+    extracted.mkdir()
+    with tarfile.open(archive) as tar:
+        # Pin verification precedes extraction. Data filter also confines
+        # symlinks/paths and rejects device nodes from the source archive.
+        tar.extractall(extracted, filter='data')
+    src = extracted / PINS['kernel']['prefix']
+    out = assets / 'kernel-out'
+    out.mkdir()
+    args = ['make', '-C', str(src), f'O={out}', 'ARCH=arm', f'CROSS_COMPILE={compiler}']
+    if host_include:
+        args.append(f'HOSTCFLAGS=-O2 -I{host_include}')
+    env = dict(os.environ, SOURCE_DATE_EPOCH='1636588800', KBUILD_BUILD_TIMESTAMP='Thu Nov 11 00:00:00 UTC 2021',
+               KBUILD_BUILD_USER='vm-spike', KBUILD_BUILD_HOST='mister-virt', KBUILD_BUILD_VERSION='1')
+    if host_bin:
+        env['PATH'] = str(host_bin) + os.pathsep + env['PATH']
+    with (assets / 'kernel-build.log').open('x') as log:
+        def run(command):
+            subprocess.run(command, env=env, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=1800)
+        run(args + ['MiSTer_defconfig'])
+        cmd = [str(src / 'scripts/config'), '--file', str(out / '.config')]
+        for name in ('ARCH_VIRT', 'SERIAL_AMBA_PL011', 'SERIAL_AMBA_PL011_CONSOLE', 'VIRTIO_MMIO', 'VIRTIO_BLK', 'VIRTIO_NET', 'RTC_DRV_PL031'):
+            cmd += ['--enable', name]
+        for name in ('ARCH_INTEL_SOCFPGA', 'FB_MISTER', 'SND_MISTER_AUDIO', 'GCC_PLUGINS', 'LOCALVERSION_AUTO'):
+            cmd += ['--disable', name]
+        run(cmd + ['--set-str', 'LOCALVERSION', '-mister-virt-spike'])
+        run(args + ['olddefconfig'])
+        run(args + [f'-j{jobs}', 'zImage'])
+    diff = subprocess.run([str(src / 'scripts/diffconfig'), str(src / 'arch/arm/configs/MiSTer_defconfig'), str(out / '.config')], capture_output=True, text=True, check=True, timeout=30)
+    (assets / 'kernel-config-delta.txt').write_text(diff.stdout)
+
+
+def sparse(path, size):
+    with path.open('xb') as out:
+        out.truncate(size)
+
+
+def prepare_image(assets, cache):
+    archive = fetch(PINS['userspace'], cache)
+    stock = assets / 'stock.img'
+    with stock.open('xb') as out:
+        subprocess.run(['7z', 'e', '-so', str(archive), PINS['userspace']['member']], stdout=out, stderr=subprocess.PIPE, check=True, timeout=180)
+    if digest(stock) != PINS['userspace']['image_sha256']:
+        raise RuntimeError('Stock rootfs checksum mismatch')
+    stage = assets / 'provision-staging'
+    inner = stage / 'sd/linux/linux.img'
+    inner.parent.mkdir(parents=True)
+    shutil.copyfile(stock, inner)
+
+    def debug(command, path=inner):
+        return subprocess.run(['debugfs', '-R', command, str(path)], capture_output=True, text=True, check=True, timeout=30).stdout
+
+    original = debug('cat /etc/inittab', stock)
+    lines = [x for x in original.splitlines() if not any(word in x for word in ('/sbin/agetty', '/sbin/gpm', '/bin/loadkeys', '/bin/setfont'))]
+    lines.append('ttyAMA0::respawn:/bin/sh')
+    inittab = assets / 'guest-inittab'
+    inittab.write_text('\n'.join(lines) + '\n')
+    commands = assets / 'debugfs.commands'
+    commands.write_text('\n'.join(['rm /etc/inittab', f'write {json.dumps(str(inittab))} /etc/inittab',
+                                  'set_inode_field /etc/inittab mode 0100644', 'rm /etc/init.d/S50sshd',
+                                  'rm /etc/init.d/S50proftpd', 'rm /etc/init.d/S91smb']) + '\n')
+    result = subprocess.run(['debugfs', '-w', '-f', str(commands), str(inner)], check=True, capture_output=True, text=True, timeout=60)
+    (assets / 'rootfs-build.log').write_text(result.stdout + result.stderr)
+    if debug('cat /etc/inittab') != inittab.read_text():
+        raise RuntimeError('Offline init edit did not apply')
+    for path in ('/etc/init.d/S50sshd', '/etc/init.d/S50proftpd', '/etc/init.d/S91smb'):
+        if 'Inode:' in debug('stat ' + path):
+            raise RuntimeError('Offline service disable failed: ' + path)
+    fixtures.text(stage / 'sd/MiSTer', fixtures.MAIN)
+    fixtures.text(stage / 'sd/linux/user-startup.sh', fixtures.STARTUP)
+    fixtures.text(stage / 'prepare.sh', fixtures.PREPARE)
+    (stage / 'sd/config').mkdir()
+    payload = assets / 'payload.ext4'
+    fixtures.ext4(stage, payload, 768 * 1024 * 1024)
+    size, start = 2 * 1024 * 1024 * 1024, 2048
+    sectors = size // 512 - start
+    partition, outer = assets / 'outer.exfat', assets / 'sd.raw'
+    sparse(partition, sectors * 512)
+    subprocess.run(['mkfs.exfat', '-L', 'MISTERVM', str(partition)], check=True, capture_output=True, timeout=60)
+    sparse(outer, size)
+    mbr = bytearray(512)
+    mbr[446:462] = struct.pack('<B3sB3sII', 0, b'\x00\x02\x00', 7, b'\xfe\xff\xff', start, sectors)
+    mbr[510:512] = b'\x55\xaa'
+    with outer.open('r+b') as dst, partition.open('rb') as src:
+        dst.write(mbr)
+        offset = start * 512
+        while block := src.read(1024 * 1024):
+            if block.strip(b'\0'):
+                dst.seek(offset)
+                dst.write(block)
+            offset += len(block)
+    vm = VM(assets, outer, assets / 'provision.log', fixtures=payload, provision=True)
+    try:
+        vm.wait(b'# ')
+        result = vm.cmd('mount -t proc proc /proc; mount -t sysfs sysfs /sys; mount -t tmpfs tmpfs /tmp; mkdir /tmp/payload; mount -o ro /dev/vdb /tmp/payload; sh /tmp/payload/prepare.sh', timeout=240)
+        if 'VM_DISK_PREPARED' not in result:
+            raise RuntimeError('Guest did not confirm provisioning')
+    finally:
+        vm.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--assets', type=Path, default=DEFAULT)
+    parser.add_argument('--download-cache', type=Path, default=DEFAULT.parent / 'mister-vm-downloads')
+    parser.add_argument('--cross-compile', default='arm-linux-gnueabihf-')
+    parser.add_argument('--host-include', type=Path)
+    parser.add_argument('--host-bin', type=Path)
+    parser.add_argument('--jobs', type=int, default=8)
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument('--release-only', action='store_true')
+    action.add_argument('--download-only', action='store_true', help='Populate verified kernel/userspace cache without building')
+    args = parser.parse_args()
+    assets, cache = args.assets.resolve(), args.download_cache.resolve()
+    if args.release_only:
+        release(assets, cache)
+        return
+    if args.download_only:
+        for name in ('kernel', 'userspace'):
+            print(fetch(PINS[name], cache))
+        return
+    if not 1 <= args.jobs <= 64:
+        parser.error('--jobs must be between 1 and 64')
+    ready = assets / 'ready.json'
+    if ready.exists():
+        old = json.loads(ready.read_text())
+        if old['pins'] != PINS or old['base_sha256'] != digest(assets / 'sd.raw') or old['kernel_sha256'] != digest(assets / 'kernel-out/arch/arm/boot/zImage'):
+            raise RuntimeError('Existing assets differ; choose a fresh asset directory')
+        print('Already ready:', assets)
+        return
+    if assets.exists() and any(p.name != 'releases' for p in assets.iterdir()):
+        raise RuntimeError('Incomplete/existing assets; preserve evidence and choose a fresh --assets path')
+    if '/' in args.cross_compile:
+        args.cross_compile = str(Path(args.cross_compile).resolve())
+    if args.host_include:
+        args.host_include = args.host_include.resolve()
+    if args.host_bin:
+        args.host_bin = args.host_bin.resolve()
+    for command in ('make', 'gcc', 'flex', 'bison', 'debugfs', 'mke2fs', 'mkfs.exfat', '7z', 'qemu-system-arm', args.cross_compile + 'gcc'):
+        if not shutil.which(command):
+            raise RuntimeError('Install required build tool first: ' + command)
+    assets.mkdir(parents=True, exist_ok=True)
+    lock = assets / 'setup.lock'
+    with lock.open('x') as stream:
+        stream.write('setup in progress\n')
+    try:
+        compiler = subprocess.run([args.cross_compile + 'gcc', '--version'], capture_output=True, text=True, check=True, timeout=10).stdout.splitlines()[0]
+        build_kernel(assets, cache, args.cross_compile, args.host_include, args.host_bin, args.jobs)
+        prepare_image(assets, cache)
+        ready.write_text(json.dumps(dict(pins=PINS, compiler=compiler, base_sha256=digest(assets / 'sd.raw'),
+                                         kernel_sha256=digest(assets / 'kernel-out/arch/arm/boot/zImage')), indent=2) + '\n')
+        print('Ready:', assets)
+    except BaseException:
+        (assets / 'FAILED').write_text('Setup incomplete; preserve logs and choose a fresh asset directory.\n')
+        raise
+    finally:
+        lock.unlink(missing_ok=True)
+
+
+def interrupted(_signal, _frame):
+    raise KeyboardInterrupt('Setup interrupted')
+
+
+if __name__ == '__main__':
+    signal.signal(signal.SIGTERM, interrupted)
+    main()

--- a/scripts/mister-vm/setup.py
+++ b/scripts/mister-vm/setup.py
@@ -31,22 +31,21 @@ def fetch(pin, cache):
     cache.mkdir(parents=True, exist_ok=True)
     target = cache / pin['name']
     if not target.exists():
+        # Failed partials are never cleaned up: the file may belong to a
+        # concurrent download, and an owned one is evidence for diagnosis.
         partial = target.with_name(target.name + '.part')
-        try:
-            with partial.open('xb') as out, urllib.request.urlopen(pin['url'], timeout=30) as response:
-                start, total = time.monotonic(), 0
-                while data := response.read(1024 * 1024):
-                    total += len(data)
-                    if total > 512 * 1024 * 1024 or time.monotonic() - start > 600:
-                        raise RuntimeError('Download exceeded size/time bound')
-                    out.write(data)
-            if digest(partial) != pin['sha256']:
-                raise RuntimeError('Download checksum mismatch: ' + pin['name'])
-            partial.rename(target)
-        except BaseException:
-            # Do not remove another process's existing partial download.
-            # Failed owned partials remain available for diagnosis.
-            raise
+        if partial.exists():
+            raise RuntimeError('Partial download in progress or left by a failed run: ' + str(partial))
+        with partial.open('xb') as out, urllib.request.urlopen(pin['url'], timeout=30) as response:
+            start, total = time.monotonic(), 0
+            while data := response.read(1024 * 1024):
+                total += len(data)
+                if total > 512 * 1024 * 1024 or time.monotonic() - start > 600:
+                    raise RuntimeError('Download exceeded size/time bound')
+                out.write(data)
+        if digest(partial) != pin['sha256']:
+            raise RuntimeError('Download checksum mismatch: ' + pin['name'])
+        partial.rename(target)
     if digest(target) != pin['sha256']:
         raise RuntimeError('Cached checksum mismatch: ' + str(target))
     return target

--- a/scripts/mister-vm/test_integration.py
+++ b/scripts/mister-vm/test_integration.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Explicit VM tests using setup.py assets, local binary and pinned release."""
+import argparse
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+import unittest
+
+SOURCE = Path(__file__).resolve().parent
+ASSETS = SOURCE.parents[1] / '_scratch/mister-vm-assets'
+BINARY = SOURCE.parents[1] / '_build/mister_arm/zaparoo.sh'
+
+
+class IntegrationTests(unittest.TestCase):
+    def command(self, binary=None, extra=()):
+        return [sys.executable, str(SOURCE / 'run.py'), '--assets', str(ASSETS), '--binary', str(binary or BINARY), *extra]
+
+    def evidence(self, process, expected):
+        self.assertEqual(process.returncode, expected, process.stdout + (process.stderr or ''))
+        line = next(x for x in process.stdout.splitlines() if x.startswith(('PASS: ', 'FAIL: ')))
+        output = Path(line.split(': ', 1)[1])
+        self.assertEqual(output.parent, ASSETS / 'runs')
+        state = json.loads((output / 'run.json').read_text())
+        self.assertEqual(state['passed'], expected == 0)
+        self.assertNotIn('cleanup_error', state)
+        self.assertFalse((output / 'staging').exists())
+        self.assertTrue((output / 'results.json').exists())
+        if 'base_sha256' in state:
+            self.assertTrue(state['base_unchanged'])
+            self.assertTrue(state['kernel_unchanged'])
+        for item in state.get('processes', []):
+            self.assertIsNotNone(item['exit_code'])
+            with self.assertRaises(ProcessLookupError):
+                os.kill(item['pid'], 0)
+        if 'port' in state:
+            with socket.socket() as listener:
+                listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                listener.bind(('127.0.0.1', state['port']))
+                listener.listen(1)
+        if not state.get('disk_retained'):
+            self.assertFalse((output / 'disk.qcow2').exists())
+            self.assertFalse((output / 'fixtures.ext4').exists())
+        print(line, flush=True)
+        return output, state
+
+    def test_parallel_launch(self):
+        release = ASSETS / 'releases/2.17.2/zaparoo.sh'
+        commands = [self.command(release, ('--expect-version', '2.17.2', '--keep-disk')), self.command()]
+        children = [subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True) for cmd in commands]
+        results = []
+        try:
+            for child in children:
+                stdout, _ = child.communicate(timeout=420)
+                results.append(self.evidence(subprocess.CompletedProcess(child.args, child.returncode, stdout, ''), 0))
+        finally:
+            for child in children:
+                if child.poll() is None:
+                    child.terminate()
+                    child.communicate(timeout=30)
+        self.assertNotEqual(results[0][0], results[1][0])
+        self.assertNotEqual(results[0][1]['port'], results[1][1]['port'])
+        self.assertTrue(results[0][1]['disk_retained'])
+        for output, state in results:
+            checks = json.loads((output / 'results.json').read_text())['checks']
+            self.assertEqual(next(x['evidence'] for x in checks if x['check'] == 'selected_binary_installed'), state['binary_sha256'])
+
+    def test_service_release(self):
+        result = subprocess.run(self.command(ASSETS / 'releases/2.17.2/zaparoo.sh', ('--scenario', 'service', '--expect-version', '2.17.2')), capture_output=True, text=True, timeout=420)
+        output, state = self.evidence(result, 0)
+        self.assertEqual(len(state['processes']), 2)
+        checks = json.loads((output / 'results.json').read_text())['checks']
+        self.assertIn('cold_boot_history', [x['check'] for x in checks])
+
+    def test_version_failure(self):
+        result = subprocess.run(self.command(extra=('--expect-version', 'intentional-mismatch')), capture_output=True, text=True, timeout=180)
+        output, state = self.evidence(result, 1)
+        self.assertIn('Expected intentional-mismatch', state['error'])
+        self.assertTrue((output / 'failure.txt').exists())
+
+    def test_deadline(self):
+        result = subprocess.run(self.command(extra=('--timeout', '12')), capture_output=True, text=True, timeout=90)
+        _, state = self.evidence(result, 1)
+        self.assertIn('Deadline', state['error'])
+
+    def test_bad_binary(self):
+        result = subprocess.run(self.command(SOURCE / 'fixtures.py'), capture_output=True, text=True, timeout=30)
+        _, state = self.evidence(result, 1)
+        self.assertIn('ELF32', state['error'])
+
+    def test_termination(self):
+        before = set((ASSETS / 'runs').iterdir())
+        child = subprocess.Popen(self.command(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        try:
+            ready, end = False, time.monotonic() + 60
+            while time.monotonic() < end and child.poll() is None:
+                for path in set((ASSETS / 'runs').iterdir()) - before:
+                    log = path / 'boot-0.log'
+                    if log.exists() and b'__VM_DONE_' in log.read_bytes():
+                        ready = True
+                        break
+                if ready:
+                    break
+                time.sleep(0.1)
+            self.assertTrue(ready)
+            child.terminate()
+            stdout, _ = child.communicate(timeout=30)
+            _, state = self.evidence(subprocess.CompletedProcess(child.args, child.returncode, stdout, ''), 1)
+            self.assertIn('KeyboardInterrupt', state['error'])
+        finally:
+            if child.poll() is None:
+                child.terminate()
+                child.communicate(timeout=30)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--assets', type=Path, default=ASSETS)
+    parser.add_argument('--binary', type=Path, default=BINARY)
+    args, rest = parser.parse_known_args()
+    ASSETS, BINARY = args.assets.resolve(), args.binary.resolve()
+    unittest.main(argv=[sys.argv[0], *rest])

--- a/scripts/mister-vm/test_integration.py
+++ b/scripts/mister-vm/test_integration.py
@@ -84,6 +84,7 @@ class IntegrationTests(unittest.TestCase):
         with (
             patch.object(sys, 'argv', self.command()[1:]),
             patch.object(run, 'digest', return_value='fixture-hash'),
+            patch.object(run, 'verify_prepared'),
             patch.object(run.shutil, 'which', return_value='/fixture/tool'),
             patch.object(run.subprocess, 'run', return_value=subprocess.CompletedProcess([], 0, 'QEMU fixture\n')),
             patch.object(run.fixtures, 'build', side_effect=SystemExit(23)),

--- a/scripts/mister-vm/test_integration.py
+++ b/scripts/mister-vm/test_integration.py
@@ -9,6 +9,9 @@ import subprocess
 import sys
 import time
 import unittest
+from unittest.mock import patch
+
+import run
 
 SOURCE = Path(__file__).resolve().parent
 ASSETS = SOURCE.parents[1] / '_scratch/mister-vm-assets'
@@ -74,6 +77,20 @@ class IntegrationTests(unittest.TestCase):
         self.assertEqual(len(state['processes']), 2)
         checks = json.loads((output / 'results.json').read_text())['checks']
         self.assertIn('cold_boot_history', [x['check'] for x in checks])
+
+    def test_system_exit_propagates(self):
+        # Framework exits must survive the runner boundary; only its explicit
+        # deadline and user interruption signals become failed-run reports.
+        with (
+            patch.object(sys, 'argv', self.command()[1:]),
+            patch.object(run, 'digest', return_value='fixture-hash'),
+            patch.object(run.shutil, 'which', return_value='/fixture/tool'),
+            patch.object(run.subprocess, 'run', return_value=subprocess.CompletedProcess([], 0, 'QEMU fixture\n')),
+            patch.object(run.fixtures, 'build', side_effect=SystemExit(23)),
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                run.main()
+        self.assertEqual(raised.exception.code, 23)
 
     def test_version_failure(self):
         result = subprocess.run(self.command(extra=('--expect-version', 'intentional-mismatch')), capture_output=True, text=True, timeout=180)

--- a/scripts/mister-vm/test_unit.py
+++ b/scripts/mister-vm/test_unit.py
@@ -69,6 +69,22 @@ class SimulatorTests(unittest.TestCase):
             sim.resolve(self.command)
 
 
+class FramingTests(unittest.TestCase):
+    def test_single_command(self):
+        self.assertEqual(sim.frames(b'load_core menu.rbf\n'), [b'load_core menu.rbf'])
+
+    def test_coalesced_reads_stay_separate(self):
+        # Two writes queued between reads must not become one rejected command.
+        self.assertEqual(sim.frames(b'load_core a.mgl\nload_core menu.rbf\n'),
+                         [b'load_core a.mgl', b'load_core menu.rbf'])
+
+    def test_unterminated_command_is_a_frame(self):
+        self.assertEqual(sim.frames(b'fb_cmd0 rgb32 0 1'), [b'fb_cmd0 rgb32 0 1'])
+
+    def test_blank_writes_ignored(self):
+        self.assertEqual(sim.frames(b'\n\n'), [])
+
+
 class FetchTests(unittest.TestCase):
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory()

--- a/scripts/mister-vm/test_unit.py
+++ b/scripts/mister-vm/test_unit.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Fast tests; no QEMU, network, compiler or prepared assets required."""
+import hashlib
+import importlib.util
+import io
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+from xml.sax.saxutils import escape
+
+import setup
+
+spec = importlib.util.spec_from_file_location('main_sim', Path(__file__).parent / 'main-sim.py')
+sim = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sim)
+
+
+class SimulatorTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        old_root = sim.ROOT
+        self.addCleanup(setattr, sim, 'ROOT', old_root)
+        sim.ROOT = Path(self.temp.name)
+        (sim.ROOT / '_Console').mkdir()
+        (sim.ROOT / 'games/SNES').mkdir(parents=True)
+        self.rbf = sim.ROOT / '_Console/SNES_20260905.rbf'
+        self.rbf.write_text('fixture')
+        (sim.ROOT / 'menu.rbf').write_text('fixture')
+        self.game = sim.ROOT / 'games/SNES/VM Test & Game.sfc'
+        self.game.write_text('fixture')
+        self.mgl = sim.ROOT / 'test.mgl'
+        self.mgl.write_text('<mistergamedescription><rbf>_Console/SNES</rbf><file delay="2" type="f" index="0" path="' + escape(str(self.game)) + '"/></mistergamedescription>')
+        self.command = 'load_core ' + str(self.mgl)
+
+    def test_menu(self):
+        self.assertEqual(sim.resolve('load_core menu.rbf'), ('MENU', None))
+
+    def test_snes_xml(self):
+        self.assertEqual(sim.resolve(self.command), ('SNES', str(self.game)))
+
+    def test_missing_game(self):
+        self.game.unlink()
+        with self.assertRaisesRegex(ValueError, 'missing'):
+            sim.resolve(self.command)
+
+    def test_missing_rbf(self):
+        self.rbf.unlink()
+        with self.assertRaisesRegex(ValueError, 'RBF'):
+            sim.resolve(self.command)
+
+    def test_wrong_slot(self):
+        self.mgl.write_text(self.mgl.read_text().replace('index="0"', 'index="1"'))
+        with self.assertRaisesRegex(ValueError, 'slot'):
+            sim.resolve(self.command)
+
+    def test_combined_command(self):
+        with self.assertRaisesRegex(ValueError, 'combined'):
+            sim.resolve(self.command + '\nload_core menu.rbf')
+
+    def test_unknown_command(self):
+        with self.assertRaisesRegex(ValueError, 'unsupported'):
+            sim.resolve('unknown')
+
+    def test_entities(self):
+        self.mgl.write_text('<!DOCTYPE x [<!ENTITY y "z">]>' + self.mgl.read_text())
+        with self.assertRaisesRegex(ValueError, 'XML declarations'):
+            sim.resolve(self.command)
+
+
+class FetchTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.cache = Path(self.temp.name)
+        self.data = b'pinned fixture'
+        self.pin = dict(name='fixture.tar.gz', url='https://example.invalid/fixture', sha256=hashlib.sha256(self.data).hexdigest())
+
+    def test_verified_download(self):
+        with patch('urllib.request.urlopen', return_value=io.BytesIO(self.data)):
+            target = setup.fetch(self.pin, self.cache)
+        self.assertEqual(target.read_bytes(), self.data)
+        self.assertFalse(target.with_name(target.name + '.part').exists())
+
+    def test_valid_cache_never_downloads(self):
+        (self.cache / self.pin['name']).write_bytes(self.data)
+        with patch('urllib.request.urlopen', side_effect=AssertionError('Unexpected network')):
+            setup.fetch(self.pin, self.cache)
+
+    def test_invalid_cache_not_overwritten(self):
+        target = self.cache / self.pin['name']
+        target.write_bytes(b'wrong')
+        with self.assertRaisesRegex(RuntimeError, 'Cached checksum'):
+            setup.fetch(self.pin, self.cache)
+        self.assertEqual(target.read_bytes(), b'wrong')
+
+    def test_invalid_download_not_promoted(self):
+        with patch('urllib.request.urlopen', return_value=io.BytesIO(b'wrong')):
+            with self.assertRaisesRegex(RuntimeError, 'Download checksum'):
+                setup.fetch(self.pin, self.cache)
+        self.assertFalse((self.cache / self.pin['name']).exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/mister-vm/vm.py
+++ b/scripts/mister-vm/vm.py
@@ -29,6 +29,9 @@ class VM:
                      '-drive', f'if=none,id=outer,file={drive(disk)},format=raw',
                      '-device', 'virtio-blk-device,drive=outer']
         else:
+            # QEMU allocates virtio-mmio transports in reverse of -device order,
+            # so the guest enumerates the last block device added as vda. With a
+            # fixtures disk present the overlay is therefore vdb, not vda.
             root = '/dev/vdb1' if fixtures else '/dev/vda1'
             args += ['-append', f'console=ttyAMA0,115200 root={root} loop=linux/linux.img loop.max_part=8 ro rootwait',
                      '-drive', f'if=none,id=root,file={drive(disk)},format=qcow2',

--- a/scripts/mister-vm/vm.py
+++ b/scripts/mister-vm/vm.py
@@ -1,0 +1,96 @@
+"""Headless MiSTer guest transport. All writable disks belong to caller."""
+import os
+from pathlib import Path
+import selectors
+import subprocess
+import time
+
+
+def drive(path):
+    return str(Path(path).resolve()).replace(',', ',,')
+
+
+class VM:
+    def __init__(self, assets, disk, log, port=None, fixtures=None, provision=False):
+        assets = Path(assets)
+        self.log = Path(log).open('xb')
+        self.buffer = b''
+        self.selector = selectors.DefaultSelector()
+        args = ['qemu-system-arm', '-machine', 'virt-10.2,highmem=off,gic-version=2',
+                '-cpu', 'cortex-a15', '-smp', '2', '-m', '511', '-accel', 'tcg',
+                '-kernel', str(assets / 'kernel-out/arch/arm/boot/zImage'),
+                '-display', 'none', '-serial', 'stdio', '-monitor', 'none', '-no-reboot']
+        if provision:
+            args += ['-append', 'console=ttyAMA0,115200 root=/dev/vdc ro rootwait init=/bin/sh',
+                     '-drive', f'if=none,id=root,file={drive(assets / "stock.img")},format=raw,readonly=on',
+                     '-device', 'virtio-blk-device,drive=root', '-nic', 'none',
+                     '-drive', f'if=none,id=payload,file={drive(fixtures)},format=raw,readonly=on',
+                     '-device', 'virtio-blk-device,drive=payload',
+                     '-drive', f'if=none,id=outer,file={drive(disk)},format=raw',
+                     '-device', 'virtio-blk-device,drive=outer']
+        else:
+            root = '/dev/vdb1' if fixtures else '/dev/vda1'
+            args += ['-append', f'console=ttyAMA0,115200 root={root} loop=linux/linux.img loop.max_part=8 ro rootwait',
+                     '-drive', f'if=none,id=root,file={drive(disk)},format=qcow2',
+                     '-device', 'virtio-blk-device,drive=root',
+                     '-netdev', f'user,id=n,restrict=on,hostfwd=tcp:127.0.0.1:{port}-:7497',
+                     '-device', 'virtio-net-device,netdev=n,mac=52:54:00:4d:53:01', '-rtc', 'base=utc']
+            if fixtures:
+                args += ['-drive', f'if=none,id=fixtures,file={drive(fixtures)},format=raw,readonly=on',
+                         '-device', 'virtio-blk-device,drive=fixtures']
+        try:
+            self.process = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            self.selector.register(self.process.stdout, selectors.EVENT_READ)
+        except BaseException:
+            if hasattr(self, 'process'):
+                self.close()
+            else:
+                self.log.close()
+                self.selector.close()
+            raise
+
+    def wait(self, marker, timeout=120):
+        until = time.monotonic() + timeout
+        while marker not in self.buffer:
+            if b'Kernel panic' in self.buffer:
+                raise RuntimeError('Guest kernel panic: ' + self.buffer[-3000:].decode(errors='replace'))
+            if time.monotonic() >= until:
+                raise TimeoutError(f'Waiting for {marker!r}: {self.buffer[-2000:]!r}')
+            for key, _ in self.selector.select(0.25):
+                data = os.read(key.fd, 65536)
+                if not data:
+                    raise RuntimeError('QEMU exited: ' + self.buffer[-3000:].decode(errors='replace'))
+                self.log.write(data)
+                self.log.flush()
+                self.buffer += data
+        end = self.buffer.index(marker) + len(marker)
+        result, self.buffer = self.buffer[:end], self.buffer[end:]
+        return result.decode(errors='replace')
+
+    def cmd(self, command, timeout=120):
+        # Split marker prevents matching terminal echo rather than completion.
+        line = command + "; rc=$?; printf '\\n%s%s%s\\n' __VM_ DONE_ $rc\n"
+        self.process.stdin.write(line.encode())
+        self.process.stdin.flush()
+        result = self.wait(b'__VM_DONE_', timeout)
+        status = self.wait(b'\n', 10).strip()
+        print(result, flush=True)
+        if status != '0':
+            raise RuntimeError(f'Guest command exited {status}: {command}')
+        return result
+
+    def close(self):
+        if self.log.closed:
+            return
+        try:
+            if self.process.poll() is None:
+                self.process.terminate()
+            try:
+                remaining, _ = self.process.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                remaining, _ = self.process.communicate()
+            self.log.write(remaining or b'')
+        finally:
+            self.selector.close()
+            self.log.close()


### PR DESCRIPTION
## Summary
- Add checksum-pinned MiSTer kernel/userspace setup and a disposable ARM VM runner.
- Exercise launch and service restart/cold-boot persistence with unchanged local or published Core binaries.
- Include isolated disks/ports, failure artifacts, cleanup checks, and setup documentation.

Validated with published MiSTer 2.17.2, 16 unit tests, and 7 VM integration tests. Main simulation stays limited to Menu and one-file SNES MGL; FPGA emulation and launch-path ZIP validation are intentionally excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a disposable, headless MiSTer VM integration rig for validating service and media-launch behavior.
  - Added setup and run commands supporting local builds, pinned releases, configurable timeouts, retained disk images, and detailed execution artifacts.
  - Added launch and service scenarios covering scanning, media loading, persistence, token handling, and failure cases.

- **Documentation**
  - Added comprehensive guidance for prerequisites, asset preparation, usage, scenarios, outputs, and limitations.

- **Tests**
  - Added unit and integration coverage for VM setup, execution, validation, cleanup, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
