### PR TITLE
fix(zapscript): allow execute in configured launcher controls

### DIFF
--- a/pkg/zapscript/control_test.go
+++ b/pkg/zapscript/control_test.go
@@ -25,11 +25,63 @@ import (
 
 	gozapscript "github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRunControlScript_ExecutePolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, blocked := range []bool{false, true} {
+		name := "without allowlist"
+		if blocked {
+			name = "explicitly blocked"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Instance{}
+			if blocked {
+				require.NoError(t, cfg.LoadTOML(`[zapscript]
+block_commands = ["execute"]`))
+			}
+			// Expand to malformed shell quoting to reach command validation
+			// without launching a process.
+			exprEnv := &gozapscript.ArgExprEnv{Device: gozapscript.ExprEnvDevice{Hostname: "'"}}
+			err := RunControlScript(
+				t.Context(), mocks.NewMockPlatform(), cfg, nil, "**execute:[[device.hostname]]", exprEnv,
+			)
+			if blocked {
+				require.ErrorIs(t, err, ErrCommandBlocked)
+			} else {
+				require.ErrorContains(t, err, "failed to parse execute command")
+			}
+		})
+	}
+}
+
+func TestRunControlScript_ZapLinkCannotExecute(t *testing.T) {
+	t.Parallel()
+
+	const linkURL = "https://zaplink.example.com/control"
+	userDB := &testhelpers.MockUserDBI{}
+	userDB.On("GetZapLinkHost", "https://zaplink.example.com").Return(true, true, nil)
+	userDB.On("GetZapLinkCache", linkURL).Return("**execute:[[device.hostname]]", nil)
+	userDB.On("UpdateZapLinkCache", mock.Anything, mock.Anything).Return(nil).Maybe()
+	db := &database.Database{UserDB: userDB}
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_execute = [".*"]`))
+	exprEnv := &gozapscript.ArgExprEnv{Device: gozapscript.ExprEnvDevice{Hostname: "'"}}
+	err := RunControlScript(t.Context(), mocks.NewMockPlatform(), cfg, db, "**echo:"+linkURL, exprEnv)
+	require.ErrorIs(t, err, ErrRemoteSource)
+	userDB.AssertExpectations(t)
+}
 
 func TestRunControlScript_SingleCommand(t *testing.T) {
 	t.Parallel()

--- a/pkg/zapscript/utils.go
+++ b/pkg/zapscript/utils.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/command"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/rs/zerolog/log"
 )
 
@@ -146,7 +147,7 @@ func cmdExecute(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 
 	if env.Unsafe {
 		return platforms.CmdResult{}, ErrRemoteSource
-	} else if !env.Cfg.IsExecuteAllowed(execStr) {
+	} else if env.Source != tokens.SourceControl && !env.Cfg.IsExecuteAllowed(execStr) {
 		return platforms.CmdResult{}, fmt.Errorf("%w: %s", ErrExecuteNotAllowed, execStr)
 	}
 
@@ -163,7 +164,7 @@ func cmdExecute(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	ctx, cancel := context.WithTimeout(context.Background(), ExecuteTimeout)
 	defer cancel()
 
-	//nolint:gosec // Safe: cmd validated through IsExecuteAllowed allowlist, args properly separated
+	//nolint:gosec // Config-defined controls are trusted executable config; other sources require IsExecuteAllowed.
 	execCmd := exec.CommandContext(ctx, tokenArgs[0], tokenArgs[1:]...)
 
 	var stderr bytes.Buffer

--- a/pkg/zapscript/utils_test.go
+++ b/pkg/zapscript/utils_test.go
@@ -21,6 +21,7 @@ package zapscript
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -239,30 +240,44 @@ allow_execute = [".*"]`))
 	require.Error(t, err, "execute should fail with no args")
 }
 
-// TestCmdExecute_SourceControlRequiresAllowList verifies that commands from
-// SourceControl are subject to the execute allowlist (no bypass).
-func TestCmdExecute_SourceControlRequiresAllowList(t *testing.T) {
+func TestCmdExecute_SourcePolicy(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
-	// No allowlist set — all commands should be blocked
-
-	cmd := zapscript.Command{
-		Name: "execute",
-		Args: []string{"echo hello"},
+	tests := []struct {
+		wantErr error
+		source  string
+		unsafe  bool
+	}{
+		{source: tokens.SourceControl},
+		{source: tokens.SourceControl, unsafe: true, wantErr: ErrRemoteSource},
+		{source: tokens.SourceAPI, wantErr: ErrExecuteNotAllowed},
+		{source: tokens.SourceReader, wantErr: ErrExecuteNotAllowed},
+		{source: tokens.SourcePlaylist, wantErr: ErrExecuteNotAllowed},
+		{source: tokens.SourceHook, wantErr: ErrExecuteNotAllowed},
+		{source: tokens.SourceGMC, wantErr: ErrExecuteNotAllowed},
+		{source: tokens.SourceRemote, wantErr: ErrExecuteNotAllowed},
+		{source: "", wantErr: ErrExecuteNotAllowed},
 	}
 
-	env := platforms.CmdEnv{
-		Cmd:    cmd,
-		Cfg:    cfg,
-		Source: tokens.SourceControl,
-		Unsafe: false,
+	for _, tt := range tests {
+		t.Run(tt.source+"/unsafe="+strconv.FormatBool(tt.unsafe), func(t *testing.T) {
+			t.Parallel()
+
+			// Invalid shell quoting reaches command validation only if allowed,
+			// without spawning a process or depending on an installed executable.
+			_, err := cmdExecute(nil, platforms.CmdEnv{
+				Cmd:    zapscript.Command{Name: "execute", Args: []string{"'"}},
+				Cfg:    &config.Instance{},
+				Source: tt.source,
+				Unsafe: tt.unsafe,
+			})
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.ErrorContains(t, err, "failed to parse execute command")
+			}
+		})
 	}
-
-	_, err := cmdExecute(nil, env)
-
-	require.Error(t, err, "SourceControl commands should be checked against allowlist")
-	assert.Contains(t, err.Error(), "not allowed")
 }
 
 // TestCmdExecute_SourceControlAllowedWhenInList verifies SourceControl commands


### PR DESCRIPTION
Treat installed launcher controls as trusted executable configuration, matching launcher-level execute commands.

- Exempt internally sourced control scripts from allow_execute.
- Preserve direct-script allowlisting, unsafe-source rejection, and command blocks.
- Add regression coverage for control execution, other token sources, and remotely fetched scripts.

Ref #759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Refined command-execution policy for control-linked requests.
  - Allowed trusted, non-unsafe control commands to proceed without standard allowlist checks.
  - Continued blocking unsafe commands from control sources.
  - Maintained execution restrictions for API, reader, playlist, hook, remote, and other unsupported sources.
  - Added validation coverage for malformed commands and remote script execution through control links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->