### PR TITLE
fix(service): reject stale hold-owner cleanup

### DIFF
--- a/pkg/service/context.go
+++ b/pkg/service/context.go
@@ -34,6 +34,14 @@ import (
 	uievents "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/events"
 )
 
+// softwareTokenUpdate publishes a launch owner, or conditionally clears the
+// owner after a timed exit. A nil token is scoped to both captured generations.
+type softwareTokenUpdate struct {
+	token           *tokens.Token
+	ownerGeneration uint64
+	exitGeneration  uint64
+}
+
 // ServiceContext holds the shared dependencies threaded through all
 // service-layer functions. Created once in Start() and passed by pointer.
 type ServiceContext struct {
@@ -45,7 +53,7 @@ type ServiceContext struct {
 	LimitsManager       *playtime.LimitsManager
 	PlaybackManager     audio.PlaybackManager
 	UI                  *uievents.Service
-	LaunchSoftwareQueue chan *tokens.Token
+	LaunchSoftwareQueue chan softwareTokenUpdate
 	PlaylistQueue       chan *playlists.Playlist
 	ConfirmQueue        chan chan error
 	LaunchGuardCancel   chan struct{}

--- a/pkg/service/hold_owner_test.go
+++ b/pkg/service/hold_owner_test.go
@@ -1,0 +1,222 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// The unbuffered ownership send followed by a confirmation round trip fences
+// the reader loop: even a rejected clear has finished before assertions run.
+func applySoftwareUpdate(
+	t *testing.T,
+	queue chan softwareTokenUpdate,
+	confirmQueue chan chan error,
+	update softwareTokenUpdate,
+) {
+	t.Helper()
+	select {
+	case queue <- update:
+	case <-time.After(behaviorTimeout):
+		t.Fatal("reader manager did not receive ownership update")
+	}
+	result := make(chan error, 1)
+	select {
+	case confirmQueue <- result:
+	case <-time.After(behaviorTimeout):
+		t.Fatal("reader manager did not receive synchronization request")
+	}
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, ErrNoStagedToken)
+	case <-time.After(behaviorTimeout):
+		t.Fatal("reader manager did not finish ownership update")
+	}
+}
+
+func TestReaderManager_SoftwareTokenClearGenerations(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name           string
+		replacementUID string
+		exitGeneration uint64
+		wantClear      bool
+	}{
+		{name: "current_exit", exitGeneration: 1, wantClear: true},
+		{name: "different_owner", replacementUID: "new-card", exitGeneration: 1},
+		{name: "same_card_new_launch", replacementUID: "card", exitGeneration: 1},
+		{name: "stale_exit_generation", exitGeneration: 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			env := setupReaderManager(t)
+			owner := &tokens.Token{UID: "card", Text: "game.nes", ReaderID: "reader"}
+			applySoftwareUpdate(t, env.softwareQueue, env.confirmQueue, softwareTokenUpdate{token: owner})
+			current := owner
+			if tt.replacementUID != "" {
+				replacement := *owner
+				replacement.UID = tt.replacementUID
+				current = &replacement
+				applySoftwareUpdate(t, env.softwareQueue, env.confirmQueue, softwareTokenUpdate{token: current})
+			}
+
+			// Deliver the old completion only after the replacement was applied.
+			// Equal token contents still represent a new launch ownership epoch.
+			applySoftwareUpdate(t, env.softwareQueue, env.confirmQueue, softwareTokenUpdate{
+				ownerGeneration: 1,
+				exitGeneration:  tt.exitGeneration,
+			})
+			if tt.wantClear {
+				assert.Nil(t, env.st.GetSoftwareToken())
+			} else {
+				assert.Same(t, current, env.st.GetSoftwareToken())
+			}
+		})
+	}
+}
+
+func TestScanBehavior_StaleClearPreservesRemoval(t *testing.T) {
+	t.Parallel()
+
+	for _, delayedHook := range []bool{false, true} {
+		name := "exit_timer"
+		if delayedHook {
+			name = "delayed_on_remove"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			env := setupScanBehaviorWithSoftwareQueue(t, config.ScanModeHold, 1, make(chan softwareTokenUpdate))
+			queue := env.svc.LaunchSoftwareQueue
+			confirmQueue := env.svc.ConfirmQueue
+			applySoftwareUpdate(t, queue, confirmQueue, softwareTokenUpdate{
+				token: &tokens.Token{UID: "old-card", Text: "old-game", ReaderID: testReader2ID},
+			})
+
+			hookStarted := make(chan struct{})
+			releaseHook := make(chan struct{})
+			var releaseOnce sync.Once
+			unblockHook := func() { releaseOnce.Do(func() { close(releaseHook) }) }
+			t.Cleanup(unblockHook)
+			if delayedHook {
+				require.NoError(t, env.cfg.LoadTOML(`[readers.scan]
+mode = "hold"
+on_remove = '**delay:1||**input.keyboard:{f2}||**input.keyboard:{escape}'`))
+				platform, ok := env.svc.Platform.(*mocks.MockPlatform)
+				require.True(t, ok)
+				platform.On("KeyboardPress", "{f2}").Unset()
+				platform.On("KeyboardPress", "{f2}").Run(func(_ mock.Arguments) {
+					close(hookStarted)
+					<-releaseHook
+				}).Return(nil).Once()
+				platform.On("KeyboardPress", "{escape}").Run(func(_ mock.Arguments) {
+					env.keyboardCh <- "{escape}"
+				}).Return(nil).Once()
+			}
+
+			env.sendGameScan("new-card", env.gamePath("new.rom"))
+			env.waitForLaunch(t)
+			env.waitForSoftwareTokenUID(t, "new-card")
+			owner := env.st.GetSoftwareToken()
+			env.sendRemoval()
+			ctx, cancel := context.WithTimeout(t.Context(), behaviorTimeout)
+			defer cancel()
+			if delayedHook {
+				select {
+				case <-hookStarted:
+				case <-ctx.Done():
+					t.Fatal("delayed removal hook did not start")
+				}
+			} else {
+				require.NoError(t, env.clock.BlockUntilContext(ctx, 1))
+			}
+
+			// The old exit completes only after the new owner's removal is
+			// pending. Rejection must precede hook and timer cancellation.
+			applySoftwareUpdate(t, queue, confirmQueue, softwareTokenUpdate{
+				ownerGeneration: 1,
+				exitGeneration:  3,
+			})
+			require.Same(t, owner, env.st.GetSoftwareToken())
+			if delayedHook {
+				unblockHook()
+				require.Equal(t, "{escape}", env.waitForKeyboard(t))
+			}
+			require.NoError(t, env.clock.BlockUntilContext(ctx, 1))
+			env.clock.Advance(time.Second)
+			env.waitForStop(t)
+			require.Eventually(t, func() bool {
+				return env.st.GetSoftwareToken() == nil
+			}, behaviorTimeout, time.Millisecond, "current exit did not clear ownership")
+		})
+	}
+}
+
+func TestTimedExit_ClearKeepsCapturedGenerationsWhilePlaylistBlocked(t *testing.T) {
+	t.Parallel()
+	fx := newTimedExitStopFixture(t, nil)
+	t.Cleanup(fx.st.StopService)
+	fx.svc.PlaylistQueue = make(chan *playlists.Playlist)
+	clock := clockwork.NewFakeClock()
+	var exitGeneration atomic.Uint64
+	timedExit(fx.svc, clock, nil, &exitGeneration, &fx.owner, 7)
+	capturedGeneration := exitGeneration.Load()
+	clock.Advance(time.Millisecond)
+
+	select {
+	case <-fx.stopCalled:
+	case <-time.After(behaviorTimeout):
+		t.Fatal("exit did not stop the launcher")
+	}
+	// Playlist cleanup cannot finish until the receive below. Change ownership
+	// and invalidate the timer while its completion is still blocked.
+	replacement := fx.owner
+	replacement.UID = "new-card"
+	fx.st.SetSoftwareToken(&replacement)
+	cancelTimedExit(nil, &exitGeneration)
+	select {
+	case pls := <-fx.svc.PlaylistQueue:
+		require.Nil(t, pls)
+	case <-time.After(behaviorTimeout):
+		t.Fatal("exit did not clear the playlist")
+	}
+	select {
+	case update := <-fx.svc.LaunchSoftwareQueue:
+		assert.Nil(t, update.token)
+		assert.Equal(t, uint64(7), update.ownerGeneration)
+		assert.Equal(t, capturedGeneration, update.exitGeneration)
+		assert.NotEqual(t, exitGeneration.Load(), update.exitGeneration)
+	case <-time.After(behaviorTimeout):
+		t.Fatal("exit did not publish its conditional owner clear")
+	}
+}

--- a/pkg/service/holdpolicy_test.go
+++ b/pkg/service/holdpolicy_test.go
@@ -429,7 +429,7 @@ func TestRunTokenZapScriptDoesNotResolveTraits(t *testing.T) {
 	}, playlists.PlaylistController{Queue: make(chan *playlists.Playlist, 1)}, nil, false)
 	require.NoError(t, err)
 
-	softwareToken := <-svc.LaunchSoftwareQueue
+	softwareToken := (<-svc.LaunchSoftwareQueue).token
 	require.NotNil(t, softwareToken)
 	assert.True(t, softwareToken.Traits.IsEmpty(),
 		"running a script must not resolve traits onto the token running it")

--- a/pkg/service/hooks_beforeexit_test.go
+++ b/pkg/service/hooks_beforeexit_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
@@ -75,7 +74,7 @@ mode = "unrestricted"`))
 		Config:              cfg,
 		State:               st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 1),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 1),
 		PlaylistQueue:       make(chan *playlists.Playlist, 1),
 	}, pressed
 }

--- a/pkg/service/hooks_test.go
+++ b/pkg/service/hooks_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
@@ -62,7 +61,7 @@ func setupHookTest(t *testing.T) *ServiceContext {
 			UserDB:  mockUserDB,
 			MediaDB: mockMediaDB,
 		},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 1),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 1),
 		PlaylistQueue:       make(chan *playlists.Playlist, 1),
 	}
 }

--- a/pkg/service/next_actions_test.go
+++ b/pkg/service/next_actions_test.go
@@ -70,7 +70,7 @@ func setupNextActionTestEnv(t *testing.T) (*ServiceContext, *mocks.MockPlatform,
 		Config:              cfg,
 		State:               st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 10),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 10),
 		PlaylistQueue:       make(chan *playlists.Playlist, 10),
 	}
 	return svc, mockPlatform, cfg

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -326,7 +326,7 @@ func runTokenZapScriptWithContext(
 					softwareToken := *holdToken
 					log.Debug().Msg("media changed, updating hold owner")
 					select {
-					case svc.LaunchSoftwareQueue <- &softwareToken:
+					case svc.LaunchSoftwareQueue <- softwareTokenUpdate{token: &softwareToken}:
 					case <-runCtx.Done():
 						select {
 						case <-svc.State.GetContext().Done():

--- a/pkg/service/queues_beforeexit_test.go
+++ b/pkg/service/queues_beforeexit_test.go
@@ -161,7 +161,7 @@ mode = "unrestricted"`))
 		Config:              cfg,
 		State:               st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 10),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 10),
 		PlaylistQueue:       make(chan *playlists.Playlist, 10),
 	}
 	st.SetBeforeExitHook(func() { runBeforeExitHook(svc) })

--- a/pkg/service/queues_playlist_test.go
+++ b/pkg/service/queues_playlist_test.go
@@ -75,7 +75,7 @@ func setupPlaylistTestEnv(t *testing.T) *ServiceContext {
 		Config:              cfg,
 		State:               st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 10),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 10),
 		PlaylistQueue:       make(chan *playlists.Playlist, 10),
 	}
 }
@@ -187,7 +187,7 @@ func TestRunTokenZapScript_ReturnsWhenPlaylistClearBlockedByShutdown(t *testing.
 		Config:              cfg,
 		State:               st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 10),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 10),
 	}
 
 	plq := make(chan *playlists.Playlist)
@@ -253,7 +253,7 @@ func TestRunTokenZapScript_ReturnsWhenSoftwareTokenBlockedByExecutionContext(t *
 	mockReader.On("Capabilities").Return([]readers.Capability{readers.CapabilityRemovable}).Maybe()
 	mockReader.On("ReaderID").Return(readerID).Maybe()
 	svc.State.SetReader(mockReader)
-	svc.LaunchSoftwareQueue = make(chan *tokens.Token)
+	svc.LaunchSoftwareQueue = make(chan softwareTokenUpdate)
 
 	path := filepath.Join(t.TempDir(), "game.rom")
 	mockPlatform.On("LaunchMedia", svc.Config, path, (*platforms.Launcher)(nil), svc.DB,
@@ -748,7 +748,7 @@ func TestRunTokenZapScript_PrimaryPlaylistLaunchPublishesPhysicalOwner(t *testin
 	}, nil, false)
 	require.NoError(t, err)
 
-	softwareToken := <-svc.LaunchSoftwareQueue
+	softwareToken := (<-svc.LaunchSoftwareQueue).token
 	require.NotNil(t, softwareToken)
 	assert.True(t, helpers.TokensEqual(owner, softwareToken))
 	assert.Equal(t, owner.ReaderID, softwareToken.ReaderID)
@@ -883,7 +883,7 @@ func TestRunTokenZapScript_PlaylistLaunchCarriesCardScanMode(t *testing.T) {
 	}, nil, false)
 	require.NoError(t, err)
 
-	softwareToken := <-svc.LaunchSoftwareQueue
+	softwareToken := (<-svc.LaunchSoftwareQueue).token
 	require.NotNil(t, softwareToken)
 	assert.Equal(t, config.ScanModeTap, softwareToken.Traits.ScanMode())
 }
@@ -934,7 +934,7 @@ func TestRunTokenZapScript_PlaylistItemTraitDoesNotOverrideCardScanMode(t *testi
 	}, nil, false)
 	require.NoError(t, err)
 
-	softwareToken := <-svc.LaunchSoftwareQueue
+	softwareToken := (<-svc.LaunchSoftwareQueue).token
 	require.NotNil(t, softwareToken)
 	assert.Equal(t, config.ScanModeTap, softwareToken.Traits.ScanMode(),
 		"playlist item traits must not replace the card's policy")

--- a/pkg/service/reader_manager_test.go
+++ b/pkg/service/reader_manager_test.go
@@ -51,13 +51,14 @@ const (
 )
 
 type readerManagerEnv struct {
-	st           *state.State
-	scanQueue    chan readers.Scan
-	itq          chan tokens.Token
-	confirmQueue chan chan error
-	ui           *uievents.Service
-	notifCh      <-chan models.Notification
-	clock        clockwork.Clock
+	st            *state.State
+	scanQueue     chan readers.Scan
+	itq           chan tokens.Token
+	confirmQueue  chan chan error
+	softwareQueue chan softwareTokenUpdate
+	ui            *uievents.Service
+	notifCh       <-chan models.Notification
+	clock         clockwork.Clock
 }
 
 type countingUIRenderer struct {
@@ -124,7 +125,7 @@ func setupReaderManagerWithRenderer(
 
 	scanQueue := make(chan readers.Scan)
 	itq := make(chan tokens.Token, 10)
-	lsq := make(chan *tokens.Token, 10)
+	lsq := make(chan softwareTokenUpdate)
 	plq := make(chan *playlists.Playlist, 10)
 	cfq := make(chan chan error, 10)
 	lgcq := make(chan struct{}, 1)
@@ -161,13 +162,14 @@ func setupReaderManagerWithRenderer(
 	})
 
 	return &readerManagerEnv{
-		st:           st,
-		scanQueue:    scanQueue,
-		itq:          itq,
-		confirmQueue: cfq,
-		ui:           ui,
-		notifCh:      notifCh,
-		clock:        clk,
+		st:            st,
+		scanQueue:     scanQueue,
+		itq:           itq,
+		confirmQueue:  cfq,
+		softwareQueue: lsq,
+		ui:            ui,
+		notifCh:       notifCh,
+		clock:         clk,
 	}
 }
 
@@ -1482,7 +1484,7 @@ func TestReaderManager_LaunchGuard_MappedTokenStaged(t *testing.T) {
 
 	scanQueue := make(chan readers.Scan)
 	itq := make(chan tokens.Token, 10)
-	lsq := make(chan *tokens.Token, 10)
+	lsq := make(chan softwareTokenUpdate, 10)
 	plq := make(chan *playlists.Playlist, 10)
 	cfq := make(chan chan error, 10)
 
@@ -1824,7 +1826,7 @@ func TestReaderManager_ContextCancellation_ItqSend(t *testing.T) {
 
 	scanQueue := make(chan readers.Scan)
 	itq := make(chan tokens.Token) // unbuffered, no consumer
-	lsq := make(chan *tokens.Token, 10)
+	lsq := make(chan softwareTokenUpdate, 10)
 	plq := make(chan *playlists.Playlist, 10)
 	cfq := make(chan chan error, 10)
 
@@ -1928,7 +1930,7 @@ func TestReaderManager_ContextCancellation_ConfirmItqSend(t *testing.T) {
 
 	scanQueue := make(chan readers.Scan)
 	itq := make(chan tokens.Token) // unbuffered, no consumer
-	lsq := make(chan *tokens.Token, 10)
+	lsq := make(chan softwareTokenUpdate, 10)
 	plq := make(chan *playlists.Playlist, 10)
 	cfq := make(chan chan error, 10)
 

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -311,6 +311,7 @@ func timedExit(
 	exitTimer clockwork.Timer,
 	exitGeneration *atomic.Uint64,
 	owner *tokens.Token,
+	ownerGeneration uint64,
 ) clockwork.Timer {
 	// Every path that does not arm a timer returns nil rather than the timer
 	// it was handed: that one was just cancelled, and a caller keeping it
@@ -421,7 +422,10 @@ func timedExit(
 			}
 		}
 		select {
-		case svc.LaunchSoftwareQueue <- nil:
+		case svc.LaunchSoftwareQueue <- softwareTokenUpdate{
+			ownerGeneration: ownerGeneration,
+			exitGeneration:  generation,
+		}:
 		case <-svc.State.GetContext().Done():
 			return
 		}
@@ -459,6 +463,7 @@ func readerManager(
 	removalHookResults := make(chan removalHookResult, 1)
 	var exitTimer clockwork.Timer
 	var exitGeneration atomic.Uint64
+	var ownerGeneration uint64
 	var removalHookGeneration uint64
 	var activeRemovalHook *pendingRemovalHook
 
@@ -472,7 +477,7 @@ func readerManager(
 		}
 		delete(pendingRemovals, key)
 		owner := withHoldOwnerTraits(svc.State, removedToken)
-		exitTimer = timedExit(svc, clock, exitTimer, &exitGeneration, &owner)
+		exitTimer = timedExit(svc, clock, exitTimer, &exitGeneration, &owner, ownerGeneration)
 	}
 
 	var stagedToken *tokens.Token
@@ -664,7 +669,13 @@ preprocessing:
 				log.Warn().Err(hookResult.err).Msg("on_remove hook blocked exit, media will keep running")
 			}
 			continue preprocessing
-		case stoken := <-svc.LaunchSoftwareQueue:
+		case update := <-svc.LaunchSoftwareQueue:
+			stoken := update.token
+			if stoken == nil && (update.ownerGeneration != ownerGeneration ||
+				update.exitGeneration != exitGeneration.Load()) {
+				log.Debug().Msg("ignoring stale hold-owner clear")
+				continue preprocessing
+			}
 			// A token has launched primary software and now owns hold-mode exit.
 			log.Debug().Msgf("new software token: %v", stoken)
 			if activeRemovalHook != nil && !helpers.TokensEqual(stoken, &activeRemovalHook.token) {
@@ -679,12 +690,15 @@ preprocessing:
 					log.Info().Msg("software token changed, cancelling exit")
 				}
 			}
+			// Even equal tokens can be distinct launches. Timer cancellation alone
+			// cannot distinguish an old exit from a same-card relaunch.
+			ownerGeneration++
 			svc.State.SetSoftwareToken(stoken)
 			if stoken != nil {
 				key := newHoldTokenKey(stoken)
 				if removedToken, ok := pendingRemovals[key]; ok && helpers.TokensEqual(stoken, &removedToken) {
 					delete(pendingRemovals, key)
-					exitTimer = timedExit(svc, clock, exitTimer, &exitGeneration, stoken)
+					exitTimer = timedExit(svc, clock, exitTimer, &exitGeneration, stoken, ownerGeneration)
 				}
 			}
 			continue preprocessing

--- a/pkg/service/readers_test.go
+++ b/pkg/service/readers_test.go
@@ -671,14 +671,14 @@ mode = "unrestricted"`))
 		Config:              cfg,
 		State:               st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 1),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 1),
 		PlaylistQueue:       make(chan *playlists.Playlist, 1),
 	}
 	st.SetBeforeExitHook(func() { runBeforeExitHook(svc) })
 
 	clock := clockwork.NewFakeClock()
 	var exitGeneration atomic.Uint64
-	timedExit(svc, clock, nil, &exitGeneration, &owner)
+	timedExit(svc, clock, nil, &exitGeneration, &owner, 0)
 	clock.Advance(time.Millisecond)
 
 	select {
@@ -746,13 +746,13 @@ scan_mode = "hold"
 	svc := &ServiceContext{
 		Platform: mockPlatform, Config: cfg, State: st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 1),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 1),
 		PlaylistQueue:       make(chan *playlists.Playlist, 1),
 	}
 
 	clock := clockwork.NewFakeClock()
 	var exitGeneration atomic.Uint64
-	timedExit(svc, clock, nil, &exitGeneration, &owner)
+	timedExit(svc, clock, nil, &exitGeneration, &owner, 0)
 
 	// The reader goes away while the delay is still running.
 	st.RemoveReader(readerID)
@@ -817,7 +817,7 @@ func newTimedExitStopFixture(t *testing.T, stopErr error) *timedExitStopFixture 
 	svc := &ServiceContext{
 		Platform: mockPlatform, Config: cfg, State: st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 1),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 1),
 		PlaylistQueue:       make(chan *playlists.Playlist, 1),
 	}
 
@@ -832,7 +832,7 @@ func TestTimedExit_ClearsQueuesAfterStop(t *testing.T) {
 	fx := newTimedExitStopFixture(t, nil)
 	clock := clockwork.NewFakeClock()
 	var exitGeneration atomic.Uint64
-	timedExit(fx.svc, clock, nil, &exitGeneration, &fx.owner)
+	timedExit(fx.svc, clock, nil, &exitGeneration, &fx.owner, 7)
 	clock.Advance(time.Millisecond)
 
 	select {
@@ -842,8 +842,10 @@ func TestTimedExit_ClearsQueuesAfterStop(t *testing.T) {
 		t.Fatal("exit did not clear the playlist")
 	}
 	select {
-	case tok := <-fx.svc.LaunchSoftwareQueue:
-		assert.Nil(t, tok, "a nil token ends the software launch")
+	case update := <-fx.svc.LaunchSoftwareQueue:
+		assert.Nil(t, update.token, "a nil token ends the software launch")
+		assert.Equal(t, uint64(7), update.ownerGeneration)
+		assert.Equal(t, exitGeneration.Load(), update.exitGeneration)
 	case <-time.After(2 * time.Second):
 		t.Fatal("exit did not clear the launch queue")
 	}
@@ -858,7 +860,7 @@ func TestTimedExit_KeepsMediaWhenStopFails(t *testing.T) {
 	fx := newTimedExitStopFixture(t, platforms.ErrStopFailed)
 	clock := clockwork.NewFakeClock()
 	var exitGeneration atomic.Uint64
-	timedExit(fx.svc, clock, nil, &exitGeneration, &fx.owner)
+	timedExit(fx.svc, clock, nil, &exitGeneration, &fx.owner, 0)
 	clock.Advance(time.Millisecond)
 
 	select {
@@ -943,14 +945,14 @@ mode = "unrestricted"`))
 		Config:              cfg,
 		State:               st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 1),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 1),
 		PlaylistQueue:       make(chan *playlists.Playlist, 1),
 	}
 	st.SetBeforeExitHook(func() { runBeforeExitHook(svc) })
 
 	clock := clockwork.NewFakeClock()
 	var exitGeneration atomic.Uint64
-	timedExit(svc, clock, nil, &exitGeneration, &owner)
+	timedExit(svc, clock, nil, &exitGeneration, &owner, 0)
 	clock.Advance(time.Millisecond)
 
 	select {
@@ -1030,14 +1032,14 @@ mode = "unrestricted"`))
 		Config:              cfg,
 		State:               st,
 		DB:                  &database.Database{UserDB: mockUserDB},
-		LaunchSoftwareQueue: make(chan *tokens.Token, 1),
+		LaunchSoftwareQueue: make(chan softwareTokenUpdate, 1),
 		PlaylistQueue:       make(chan *playlists.Playlist, 1),
 	}
 	st.SetBeforeExitHook(func() { runBeforeExitHook(svc) })
 
 	clock := clockwork.NewFakeClock()
 	var exitGeneration atomic.Uint64
-	timedExit(svc, clock, nil, &exitGeneration, &owner)
+	timedExit(svc, clock, nil, &exitGeneration, &owner, 0)
 	clock.Advance(time.Millisecond)
 
 	select {
@@ -1089,7 +1091,7 @@ func TestTimedExitReturnsWhenLaunchQueueBlockedAndContextCancelled(t *testing.T)
 		}).
 		Return(nil).Once()
 
-	launchQueue := make(chan *tokens.Token)
+	launchQueue := make(chan softwareTokenUpdate)
 	svc := &ServiceContext{
 		Platform:            mockPlatform,
 		Config:              cfg,
@@ -1099,7 +1101,7 @@ func TestTimedExitReturnsWhenLaunchQueueBlockedAndContextCancelled(t *testing.T)
 	clock := clockwork.NewFakeClock()
 
 	var exitGeneration atomic.Uint64
-	exitTimer := timedExit(svc, clock, nil, &exitGeneration, &owner)
+	exitTimer := timedExit(svc, clock, nil, &exitGeneration, &owner, 0)
 	require.NotNil(t, exitTimer)
 	clock.Advance(time.Millisecond)
 

--- a/pkg/service/scan_behavior_test.go
+++ b/pkg/service/scan_behavior_test.go
@@ -125,6 +125,17 @@ func setupScanBehavior(
 	exitDelay float32,
 ) *scanBehaviorEnv {
 	t.Helper()
+	// Buffer updates so launch goroutines can finish during shutdown.
+	return setupScanBehaviorWithSoftwareQueue(t, scanMode, exitDelay, make(chan softwareTokenUpdate, 10))
+}
+
+func setupScanBehaviorWithSoftwareQueue(
+	t *testing.T,
+	scanMode string,
+	exitDelay float32,
+	lsq chan softwareTokenUpdate,
+) *scanBehaviorEnv {
+	t.Helper()
 
 	tmpDir := t.TempDir()
 	romsDir := filepath.Join(tmpDir, "roms")
@@ -235,11 +246,8 @@ mode = "unrestricted"`))
 
 	fakeClock := clockwork.NewFakeClock()
 
-	// lsq is buffered so goroutines spawned by processTokenQueue and timedExit
-	// can complete their sends after context cancellation.
 	scanQueue := make(chan readers.Scan)
 	itq := make(chan tokens.Token)
-	lsq := make(chan *tokens.Token, 10)
 	plq := make(chan *playlists.Playlist, 10)
 
 	limitsManager := playtime.NewLimitsManager(db, mockPlatform, cfg, nil, mockPlayer)
@@ -252,6 +260,7 @@ mode = "unrestricted"`))
 		Profiles:            profiles.NewService(db, st),
 		LaunchSoftwareQueue: lsq,
 		PlaylistQueue:       plq,
+		ConfirmQueue:        make(chan chan error),
 		BackgroundWG:        &sync.WaitGroup{},
 	}
 
@@ -1339,12 +1348,8 @@ scan_mode = "hold"`))
 	env.waitForSoftwareTokenUID(t, "game1")
 	env.sendRemovalOn(testReaderID)
 	env.waitForStop(t)
-	// StopActiveLauncher is observed before timedExit queues its final owner
-	// clear. Wait for that clear so it cannot erase the next tap's owner.
-	require.Eventually(t, func() bool {
-		return env.st.GetSoftwareToken() == nil
-	}, behaviorTimeout, time.Millisecond, "hold-reader exit cleanup did not finish")
 
+	// Tap immediately: the previous exit's cleanup may still be in flight.
 	// From then on the tap reader must keep reloading on every tap.
 	for range 2 {
 		env.sendScanOn(testReader2ID, "game2", env.gamePath("tap.rom"))

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -428,7 +428,7 @@ func startService(
 
 	// TODO: convert this to a *token channel
 	itq := make(chan tokens.Token)        // input token queue
-	lsq := make(chan *tokens.Token)       // launch software queue
+	lsq := make(chan softwareTokenUpdate) // launch software queue
 	plq := make(chan *playlists.Playlist) // playlist event queue
 	cfq := make(chan chan error)          // launch guard confirm queue
 	lgcq := make(chan struct{}, 1)        // launch guard cancellation queue


### PR DESCRIPTION
Scope timed-exit owner clears to ownership and exit generations, rejecting stale cleanup before it can cancel newer hooks or timers or erase a newer owner. Same-card relaunches get distinct ownership generations.

Add deterministic regression coverage for delayed cleanup and remove the scan test’s cleanup-wait workaround.

Closes #1453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hold-mode ownership handling when a software token is relaunched before a previous exit completes.
  * Prevented stale cleanup events from clearing a newer software token.
  * Ensured timed exits clear only the token state they originally captured.

* **Tests**
  * Added coverage for relaunches, stale cleanup, blocked playlist cleanup, and scan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->