### PR TITLE
fix(daemon): recover stale service PID files safely

### DIFF
--- a/cmd/batocera/main.go
+++ b/cmd/batocera/main.go
@@ -143,10 +143,8 @@ func run() error {
 	flags.Post(cfg, pl)
 
 	// try to auto-start service if it's not running already
-	running, runningErr := svc.Running()
-	// A stale PID file is cleared by Start under the start gate, so it must
-	// not abort auto-start here.
-	if runningErr != nil && !daemon.IsStalePIDConflict(runningErr) {
+	running, runningErr := svc.RunningForAutoStart()
+	if runningErr != nil {
 		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {

--- a/cmd/batocera/main.go
+++ b/cmd/batocera/main.go
@@ -144,7 +144,9 @@ func run() error {
 
 	// try to auto-start service if it's not running already
 	running, runningErr := svc.Running()
-	if runningErr != nil {
+	// A stale PID file is cleared by Start under the start gate, so it must
+	// not abort auto-start here.
+	if runningErr != nil && !daemon.IsStalePIDConflict(runningErr) {
 		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {

--- a/cmd/libreelec/main.go
+++ b/cmd/libreelec/main.go
@@ -88,7 +88,9 @@ func run() error {
 
 	// try to auto-start service if it's not running already
 	running, runningErr := svc.Running()
-	if runningErr != nil {
+	// A stale PID file is cleared by Start under the start gate, so it must
+	// not abort auto-start here.
+	if runningErr != nil && !daemon.IsStalePIDConflict(runningErr) {
 		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {

--- a/cmd/libreelec/main.go
+++ b/cmd/libreelec/main.go
@@ -87,10 +87,8 @@ func run() error {
 	flags.Post(cfg, pl)
 
 	// try to auto-start service if it's not running already
-	running, runningErr := svc.Running()
-	// A stale PID file is cleared by Start under the start gate, so it must
-	// not abort auto-start here.
-	if runningErr != nil && !daemon.IsStalePIDConflict(runningErr) {
+	running, runningErr := svc.RunningForAutoStart()
+	if runningErr != nil {
 		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {

--- a/cmd/mister/main.go
+++ b/cmd/mister/main.go
@@ -208,10 +208,8 @@ func run() error {
 	}
 
 	// try to auto-start service if it's not running already
-	running, runningErr := svc.Running()
-	// A stale PID file is cleared by Start under the start gate, so it must
-	// not abort auto-start here.
-	if runningErr != nil && !daemon.IsStalePIDConflict(runningErr) {
+	running, runningErr := svc.RunningForAutoStart()
+	if runningErr != nil {
 		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {

--- a/cmd/mister/main.go
+++ b/cmd/mister/main.go
@@ -209,7 +209,9 @@ func run() error {
 
 	// try to auto-start service if it's not running already
 	running, runningErr := svc.Running()
-	if runningErr != nil {
+	// A stale PID file is cleared by Start under the start gate, so it must
+	// not abort auto-start here.
+	if runningErr != nil && !daemon.IsStalePIDConflict(runningErr) {
 		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {

--- a/cmd/mistex/main.go
+++ b/cmd/mistex/main.go
@@ -172,10 +172,8 @@ func run() error {
 		_, _ = fmt.Println("Added Zaparoo to MiSTeX startup.")
 	}
 
-	running, runningErr := svc.Running()
-	// A stale PID file is cleared by Start under the start gate, so it must
-	// not abort auto-start here.
-	if runningErr != nil && !daemon.IsStalePIDConflict(runningErr) {
+	running, runningErr := svc.RunningForAutoStart()
+	if runningErr != nil {
 		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {

--- a/cmd/mistex/main.go
+++ b/cmd/mistex/main.go
@@ -173,7 +173,9 @@ func run() error {
 	}
 
 	running, runningErr := svc.Running()
-	if runningErr != nil {
+	// A stale PID file is cleared by Start under the start gate, so it must
+	// not abort auto-start here.
+	if runningErr != nil && !daemon.IsStalePIDConflict(runningErr) {
 		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -242,6 +242,22 @@ func IsStalePIDConflict(err error) bool {
 	return errors.As(err, &conflict)
 }
 
+// RunningForAutoStart reports whether the service is already running, for a
+// caller that will start it if not.
+//
+// It differs from Running in one way: a stale PID file left by a reused PID is
+// reported as not running rather than as an error, because Start clears that
+// under the start gate. Every platform wrapper checks this before auto-starting,
+// and returning the error there left the service unstartable from the only
+// entry point most users have. Any other error still stands.
+func (s *Service) RunningForAutoStart() (bool, error) {
+	running, err := s.Running()
+	if err != nil && !IsStalePIDConflict(err) {
+		return false, err
+	}
+	return running, nil
+}
+
 // Running returns true if the service is running.
 func (s *Service) Running() (bool, error) {
 	pid, err := s.Pid()

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -233,6 +233,15 @@ func servicePIDConflictError(pid int) error {
 	return &servicePIDMismatchError{pid: pid}
 }
 
+// IsStalePIDConflict reports whether err is the PID-file conflict that Start
+// clears under the start gate. Callers that auto-start the service must treat
+// it as "not running" and let Start recover it, otherwise a reused PID leaves
+// the service unstartable from the wrapper.
+func IsStalePIDConflict(err error) bool {
+	var conflict *servicePIDMismatchError
+	return errors.As(err, &conflict)
+}
+
 // Running returns true if the service is running.
 func (s *Service) Running() (bool, error) {
 	pid, err := s.Pid()
@@ -1342,15 +1351,28 @@ func (s *Service) serviceProcessIdentity(pid int) (bool, error) {
 }
 
 func serviceScriptIdentity(exePath string, cmdline []byte, dataDir string) bool {
-	// A data argument to cat/tail/etc. is not service identity. The supported
-	// shell-backed caches are executed as interpreter argv[1] by the shebang.
+	// A data argument to cat/tail/etc. is not service identity, so only a known
+	// interpreter can vouch for a shell-backed cache.
 	switch filepath.Base(exePath) {
-	case "sh", "bash", "dash", "busybox":
-		args := strings.Split(string(cmdline), "\x00")
-		return len(args) > 1 && pathLooksLikeServiceBinary(args[1], dataDir)
+	case "sh", "bash", "dash", "ash", "busybox", "ksh", "zsh":
 	default:
 		return false
 	}
+	// The kernel places the script after any shebang option, so the interpreted
+	// script is the first argument that is not a flag. Misreading it as foreign
+	// would let Start delete a live service's PID file and start a second one.
+	for _, arg := range strings.Split(string(cmdline), "\x00")[1:] {
+		if arg == "-c" || arg == "-s" {
+			// The program text comes from the next argument or stdin, so a
+			// matching path after this point is data rather than the script.
+			return false
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		return pathLooksLikeServiceBinary(arg, dataDir)
+	}
+	return false
 }
 
 func procDir() string {

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -218,11 +218,19 @@ func validatePIDFileInfo(info os.FileInfo) error {
 	return nil
 }
 
-func servicePIDConflictError(pid int) error {
-	return fmt.Errorf(
+type servicePIDMismatchError struct {
+	pid int
+}
+
+func (e *servicePIDMismatchError) Error() string {
+	return fmt.Sprintf(
 		"service PID file points to live process %d that does not match the Zaparoo service binary",
-		pid,
+		e.pid,
 	)
+}
+
+func servicePIDConflictError(pid int) error {
+	return &servicePIDMismatchError{pid: pid}
 }
 
 // Running returns true if the service is running.
@@ -237,7 +245,11 @@ func (s *Service) Running() (bool, error) {
 	}
 
 	if pidRunning(pid) {
-		if s.pidMatchesService(pid) {
+		matches, identityErr := s.serviceProcessIdentity(pid)
+		if identityErr != nil {
+			return false, fmt.Errorf("error identifying service PID %d: %w", pid, identityErr)
+		}
+		if matches {
 			return true, nil
 		}
 		log.Warn().
@@ -1089,6 +1101,23 @@ func (s *Service) Start() error {
 	defer release()
 
 	running, err := s.Running()
+	var conflict *servicePIDMismatchError
+	if errors.As(err, &conflict) {
+		// Only Start may recover a confirmed foreign PID, under the same gate
+		// that protects PID publication. Never signal the unrelated process.
+		pid, pidErr := s.Pid()
+		if pidErr != nil {
+			return pidErr
+		}
+		if pid != conflict.pid {
+			return errors.New("service PID changed during start")
+		}
+		if removeErr := s.removePidFile(); removeErr != nil {
+			return removeErr
+		}
+		log.Warn().Int("pid", pid).Msg("removed stale service PID file without signaling unrelated process")
+		err = nil
+	}
 	if err != nil {
 		return err
 	}
@@ -1283,27 +1312,45 @@ func pidIsZombie(pid int) bool {
 }
 
 func (s *Service) pidMatchesService(pid int) bool {
+	matches, _ := s.serviceProcessIdentity(pid)
+	return matches
+}
+
+// Unknown identity must not be treated as a confirmed PID reuse: removing its
+// PID file could let Start create a second service when procfs is inaccessible.
+func (s *Service) serviceProcessIdentity(pid int) (bool, error) {
 	if runtime.GOOS != "linux" {
-		return true
+		return true, nil
 	}
 
 	dataDir := helpers.DataDir(s.pl)
-	exePath, err := os.Readlink(filepath.Join(procDir(), strconv.Itoa(pid), "exe"))
-	if err == nil && pathLooksLikeServiceBinary(exePath, dataDir) {
-		return true
+	exePath, exeErr := os.Readlink(filepath.Join(procDir(), strconv.Itoa(pid), "exe"))
+	exePath = strings.TrimSuffix(exePath, " (deleted)")
+	if exeErr == nil && pathLooksLikeServiceBinary(exePath, dataDir) {
+		return true, nil
 	}
 
 	cmdlinePath := filepath.Join(procDir(), strconv.Itoa(pid), "cmdline")
 	cmdline, err := os.ReadFile(cmdlinePath) //nolint:gosec // reads process status for service management
 	if err != nil {
+		return false, fmt.Errorf("reading process command line: %w", err)
+	}
+	if exeErr != nil {
+		return false, fmt.Errorf("reading process executable: %w", exeErr)
+	}
+	return serviceScriptIdentity(exePath, cmdline, dataDir), nil
+}
+
+func serviceScriptIdentity(exePath string, cmdline []byte, dataDir string) bool {
+	// A data argument to cat/tail/etc. is not service identity. The supported
+	// shell-backed caches are executed as interpreter argv[1] by the shebang.
+	switch filepath.Base(exePath) {
+	case "sh", "bash", "dash", "busybox":
+		args := strings.Split(string(cmdline), "\x00")
+		return len(args) > 1 && pathLooksLikeServiceBinary(args[1], dataDir)
+	default:
 		return false
 	}
-	for _, arg := range strings.Split(string(cmdline), "\x00") {
-		if pathLooksLikeServiceBinary(arg, dataDir) {
-			return true
-		}
-	}
-	return false
 }
 
 func procDir() string {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -758,6 +758,15 @@ func TestRunningForAutoStartToleratesStalePIDFile(t *testing.T) {
 	assert.False(t, running)
 	assert.True(t, pidRunning(process.Process.Pid), "the unrelated process must be untouched")
 	assert.FileExists(t, pidFile, "and its PID file is Start's to clear, not this call's")
+
+	// Only the recoverable conflict is tolerated. A PID file that cannot be
+	// read at all is a real fault, and reporting it as "not running" would
+	// start a second service on top of whatever the unreadable file described.
+	require.NoError(t, os.WriteFile(pidFile, []byte("not a pid"), 0o600))
+	running, err = svc.RunningForAutoStart()
+	require.Error(t, err, "an unreadable PID file must not be reported as not running")
+	assert.False(t, running)
+	assert.False(t, IsStalePIDConflict(err))
 }
 
 func TestStartRecoversLiveUnrelatedPID(t *testing.T) {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -723,6 +723,43 @@ func TestRunningReturnsFalseForLiveUnrelatedPID(t *testing.T) {
 	assert.False(t, IsStalePIDConflict(errors.New("some other failure")))
 }
 
+// The platform wrappers all call this before auto-starting. Running reports a
+// reused PID as an error, and returning that from here left the service
+// unstartable from the only entry point most users have, because Start (which
+// clears it) was never reached.
+func TestRunningForAutoStartToleratesStalePIDFile(t *testing.T) {
+	requireLinuxProc(t, "service PID identity checks")
+
+	svc := newTestService(t)
+	pidFile := filepath.Join(svc.pl.Settings().TempDir, config.PidFile)
+
+	// No PID file at all: plainly not running, no error.
+	running, err := svc.RunningForAutoStart()
+	require.NoError(t, err)
+	assert.False(t, running)
+
+	process := exec.CommandContext(context.Background(), "sleep", "1000")
+	require.NoError(t, process.Start())
+	t.Cleanup(func() {
+		_ = process.Process.Kill()
+		_ = process.Wait()
+	})
+	require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(process.Process.Pid)), 0o600))
+
+	// Running still reports the conflict, so callers that must not touch an
+	// unrelated process keep seeing it.
+	_, runningErr := svc.Running()
+	require.Error(t, runningErr)
+	assert.True(t, IsStalePIDConflict(runningErr))
+
+	// The auto-start path sees "not running" and leaves it to Start.
+	running, err = svc.RunningForAutoStart()
+	require.NoError(t, err, "a reused PID must not stop the wrapper auto-starting")
+	assert.False(t, running)
+	assert.True(t, pidRunning(process.Process.Pid), "the unrelated process must be untouched")
+	assert.FileExists(t, pidFile, "and its PID file is Start's to clear, not this call's")
+}
+
 func TestStartRecoversLiveUnrelatedPID(t *testing.T) {
 	requireLinuxProc(t, "service PID identity checks")
 

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -30,6 +30,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net"
@@ -714,6 +715,12 @@ func TestRunningReturnsFalseForLiveUnrelatedPID(t *testing.T) {
 	assert.Contains(t, runningErr.Error(), "does not match the Zaparoo service binary")
 	assert.True(t, pidRunning(process.Process.Pid))
 	assert.FileExists(t, pidFile)
+	// The platform wrappers auto-start on this error instead of aborting, so
+	// Start can clear the stale file. Without this the recovery is unreachable
+	// from the only entry point users have.
+	assert.True(t, IsStalePIDConflict(runningErr))
+	assert.False(t, IsStalePIDConflict(nil))
+	assert.False(t, IsStalePIDConflict(errors.New("some other failure")))
 }
 
 func TestStartRecoversLiveUnrelatedPID(t *testing.T) {
@@ -769,6 +776,34 @@ func TestServiceScriptIdentityRejectsDataArguments(t *testing.T) {
 	assert.True(t, serviceScriptIdentity("/bin/busybox", []byte("sh\x00"+service+"\x00"), dataDir))
 	assert.False(t, serviceScriptIdentity("/bin/tail", []byte("tail\x00"+service+"\x00"), dataDir))
 	assert.False(t, serviceScriptIdentity("/bin/sh", []byte("sh\x00-c\x00"+service+"\x00"), dataDir))
+	assert.False(t, serviceScriptIdentity("/bin/sh", []byte("sh\x00-s\x00"+service+"\x00"), dataDir))
+	// A data argument after the script is not identity either.
+	assert.False(t, serviceScriptIdentity(
+		"/bin/sh", []byte("sh\x00/opt/other.sh\x00"+service+"\x00"), dataDir))
+}
+
+// The kernel puts a shebang option at argv[1] and the script after it, so an
+// interpreter list that only reads argv[1] reports a live service as foreign
+// and lets Start remove its PID file and start a second one.
+func TestServiceScriptIdentityAcceptsShebangOptionAndBusyboxShells(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	service := filepath.Join(dataDir, "zaparoo.0123456789abcdef.sh")
+
+	// "#!/bin/sh -e" => argv = [sh, -e, <script>, ...]
+	assert.True(t, serviceScriptIdentity(
+		"/bin/sh", []byte("sh\x00-e\x00"+service+"\x00-service\x00exec\x00"), dataDir))
+	assert.True(t, serviceScriptIdentity(
+		"/bin/sh", []byte("sh\x00--\x00"+service+"\x00"), dataDir))
+	// Buildroot images resolve /bin/sh to a standalone applet, not to busybox.
+	assert.True(t, serviceScriptIdentity("/bin/ash", []byte("sh\x00"+service+"\x00"), dataDir))
+	assert.True(t, serviceScriptIdentity("/bin/ksh", []byte("sh\x00"+service+"\x00"), dataDir))
+	assert.True(t, serviceScriptIdentity("/bin/zsh", []byte("sh\x00"+service+"\x00"), dataDir))
+	// An unrelated interpreter still cannot vouch for the path.
+	assert.False(t, serviceScriptIdentity("/usr/bin/python3", []byte("python3\x00"+service+"\x00"), dataDir))
+	// An empty cmdline (kernel thread) must not be identity.
+	assert.False(t, serviceScriptIdentity("/bin/sh", nil, dataDir))
 }
 
 func TestUnavailableProcessIdentityIsNotPIDConflict(t *testing.T) {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -716,23 +716,69 @@ func TestRunningReturnsFalseForLiveUnrelatedPID(t *testing.T) {
 	assert.FileExists(t, pidFile)
 }
 
-func TestStartFailsForLiveUnrelatedPID(t *testing.T) {
+func TestStartRecoversLiveUnrelatedPID(t *testing.T) {
 	requireLinuxProc(t, "service PID identity checks")
 
 	svc := newTestService(t)
-	settings := svc.pl.Settings()
-	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+	pidFile := filepath.Join(svc.pl.Settings().TempDir, config.PidFile)
+	eventLog := filepath.Join(t.TempDir(), "events.log")
+	t.Setenv(config.AppEnv, writeFakeServiceScript(t, pidFile, eventLog))
 
 	process := exec.CommandContext(context.Background(), "sleep", "1000")
 	require.NoError(t, process.Start())
-	t.Cleanup(func() { _ = process.Process.Kill() })
+	t.Cleanup(func() {
+		_ = process.Process.Kill()
+		_ = process.Wait()
+	})
 	require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(process.Process.Pid)), 0o600))
+	t.Cleanup(func() {
+		pid, err := svc.Pid()
+		if err == nil && pid > 0 && pid != process.Process.Pid {
+			require.NoError(t, svc.Stop())
+		}
+	})
 
-	err := svc.Start()
+	// Competing ensures must recover the stale file and publish only one PID.
+	const racers = 4
+	results := make(chan error, racers)
+	for range racers {
+		go func() { results <- svc.Start() }()
+	}
+	for range racers {
+		require.NoError(t, <-results)
+	}
+	pid, err := svc.Pid()
+	require.NoError(t, err)
+	assert.NotEqual(t, process.Process.Pid, pid)
+	assert.True(t, requireServiceRunning(t, svc))
+	assert.True(t, pidRunning(process.Process.Pid), "unrelated process must not be signaled")
+
+	// An idempotent ensure after recovery must retain the same service.
+	require.NoError(t, svc.Start())
+	nextPID, err := svc.Pid()
+	require.NoError(t, err)
+	assert.Equal(t, pid, nextPID)
+}
+
+func TestServiceScriptIdentityRejectsDataArguments(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	service := filepath.Join(dataDir, "zaparoo.0123456789abcdef.sh")
+	assert.True(t, serviceScriptIdentity("/bin/sh", []byte("sh\x00"+service+"\x00-service\x00exec\x00"), dataDir))
+	assert.True(t, serviceScriptIdentity("/bin/busybox", []byte("sh\x00"+service+"\x00"), dataDir))
+	assert.False(t, serviceScriptIdentity("/bin/tail", []byte("tail\x00"+service+"\x00"), dataDir))
+	assert.False(t, serviceScriptIdentity("/bin/sh", []byte("sh\x00-c\x00"+service+"\x00"), dataDir))
+}
+
+func TestUnavailableProcessIdentityIsNotPIDConflict(t *testing.T) {
+	requireLinuxProc(t, "service PID identity checks")
+
+	matches, err := newTestService(t).serviceProcessIdentity(-1)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not match the Zaparoo service binary")
-	assert.True(t, pidRunning(process.Process.Pid))
-	assert.FileExists(t, pidFile)
+	assert.False(t, matches)
+	var conflict *servicePIDMismatchError
+	assert.NotErrorAs(t, err, &conflict, "unknown identity must not authorize PID-file removal")
 }
 
 func TestRestartFailsForLiveUnrelatedPID(t *testing.T) {


### PR DESCRIPTION
## Summary
- Recover a confirmed foreign/reused PID during service `Start`, under the existing start gate, without signaling that process or changing PID-file format.
- Keep unknown/inaccessible process identity fail-closed. `Stop` and `Restart` still refuse unrelated PIDs.
- Distinguish cached service executables and shell script arguments from unrelated processes merely mentioning a service file; retain deleted-executable identity across binary replacement.
- Cover stale-PID recovery with competing starts, healthy-service idempotence, unrelated-process survival and unknown identity.

Ref ZaparooProject/Main_MiSTer#24. This is the Core-owned cleanup companion to Main's watchdog identity check; Core should ship before relying on automatic PID-reuse recovery.

Validated with `task test`, `task lint`, `task deadlock`, `task cross-lint:all` and `task vulncheck`. Original code failed the recovery regression. Vulnerability scan reports no called vulnerable code; it notes uncalled dependency advisories. No device service, deployment or release changes. Work isolated from the owner's active checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daemon startup now recovers from stale PID files that reference unrelated running processes.
  * Unrelated processes are no longer signaled during PID-file recovery.
  * Process identity checks are stricter, improving reliability when validating service processes.
  * Repeated or concurrent starts continue to maintain a single service process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->