### PR TITLE
fix: resolve Windows browse roots and history tags

### DIFF
--- a/pkg/api/methods/media_active_test.go
+++ b/pkg/api/methods/media_active_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
@@ -317,7 +318,7 @@ func TestHandleActiveMedia_WithMediaIDAndRelativePath(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, "NES", mediaPath).
 		Return([]database.TagInfo{}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42}}, nil)
 
 	env := requests.RequestEnv{
@@ -364,7 +365,7 @@ func TestHandleMedia_WithActiveMediaIDAndRelativePath(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, "NES", mediaPath).
 		Return([]database.TagInfo{}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42}}, nil)
 	mockMediaDB.On("GetOptimizationStatus").Return("", nil)
 	mockMediaDB.On("GetLastGenerated").Return(time.Now(), nil).Maybe()

--- a/pkg/api/methods/media_history_test.go
+++ b/pkg/api/methods/media_history_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -127,7 +128,10 @@ func TestHandleMediaHistory_WithMediaIDAndRelativePath(t *testing.T) {
 			PlayTime:   60,
 		},
 	}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath, missingPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{
+		pathutil.CanonicalMediaPath(mediaPath),
+		pathutil.CanonicalMediaPath(missingPath),
+	}).
 		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42}}, nil)
 
 	env := requests.RequestEnv{
@@ -168,7 +172,10 @@ func TestHandleMediaHistory_IncludesCoverStatus(t *testing.T) {
 			{DBID: 2, SystemID: "NES", MediaPath: coveredPath, MediaName: "Covered", StartTime: now},
 			{DBID: 1, SystemID: "NES", MediaPath: uncoveredPath, MediaName: "Uncovered", StartTime: now},
 		}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{coveredPath, uncoveredPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{
+		pathutil.CanonicalMediaPath(coveredPath),
+		pathutil.CanonicalMediaPath(uncoveredPath),
+	}).
 		Return([]database.MediaPathID{
 			{SystemID: "NES", Path: coveredPath, DBID: 20, MediaTitleDBID: 200},
 			{SystemID: "NES", Path: uncoveredPath, DBID: 10, MediaTitleDBID: 100},
@@ -222,7 +229,7 @@ func TestHandleMediaHistory_EnrichmentFailuresAreNonFatal(t *testing.T) {
 		{
 			name: "media identity lookup",
 			setup: func(_ *testing.T, mockMediaDB *helpers.MockMediaDBI) {
-				mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+				mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 					Return(nil, errors.New("identity lookup failed"))
 				mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, mock.Anything).
 					Return(map[int64][]database.TagInfo{}, nil).Maybe()
@@ -235,7 +242,7 @@ func TestHandleMediaHistory_EnrichmentFailuresAreNonFatal(t *testing.T) {
 			expectTagLookup: true,
 			setup: func(t *testing.T, mockMediaDB *helpers.MockMediaDBI) {
 				t.Helper()
-				mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+				mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 					Return([]database.MediaPathID{{
 						SystemID: "NES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420,
 					}}, nil)
@@ -252,7 +259,7 @@ func TestHandleMediaHistory_EnrichmentFailuresAreNonFatal(t *testing.T) {
 			expectTagLookup: true,
 			setup: func(t *testing.T, mockMediaDB *helpers.MockMediaDBI) {
 				t.Helper()
-				mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+				mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 					Return([]database.MediaPathID{{
 						SystemID: "NES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420,
 					}}, nil)
@@ -300,7 +307,7 @@ func TestMediaResponseMediaIDs_BoundsSlowLookup(t *testing.T) {
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mediaPath := filepath.Join(string(filepath.Separator), "games", "slow.nes")
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 		Run(func(args mock.Arguments) {
 			ctx, ok := args.Get(0).(context.Context)
 			require.True(t, ok)
@@ -647,7 +654,10 @@ func TestHandleMediaHistory_IncludesTags(t *testing.T) {
 			{DBID: 2, SystemID: "NES", MediaPath: taggedPath, MediaName: "Tagged", StartTime: now},
 			{DBID: 1, SystemID: "NES", MediaPath: untaggedPath, MediaName: "Untagged", StartTime: now},
 		}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{taggedPath, untaggedPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{
+		pathutil.CanonicalMediaPath(taggedPath),
+		pathutil.CanonicalMediaPath(untaggedPath),
+	}).
 		Return([]database.MediaPathID{
 			{SystemID: "NES", Path: taggedPath, DBID: 20, MediaTitleDBID: 200},
 			{SystemID: "NES", Path: untaggedPath, DBID: 10, MediaTitleDBID: 100},
@@ -690,7 +700,10 @@ func TestHandleMediaHistory_UnresolvedMediaOmitsTags(t *testing.T) {
 			{DBID: 2, SystemID: "NES", MediaPath: resolvedPath, MediaName: "Resolved", StartTime: now},
 			{DBID: 1, SystemID: "NES", MediaPath: missingPath, MediaName: "Missing", StartTime: now},
 		}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{resolvedPath, missingPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{
+		pathutil.CanonicalMediaPath(resolvedPath),
+		pathutil.CanonicalMediaPath(missingPath),
+	}).
 		Return([]database.MediaPathID{
 			{SystemID: "NES", Path: resolvedPath, DBID: 20, MediaTitleDBID: 200},
 		}, nil)
@@ -728,7 +741,7 @@ func TestHandleMediaHistory_NoResolvedMediaSkipsTagLookup(t *testing.T) {
 		Return([]database.MediaHistoryEntry{
 			{DBID: 1, SystemID: "NES", MediaPath: mediaPath, MediaName: "Missing", StartTime: time.Now()},
 		}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 		Return([]database.MediaPathID{}, nil)
 	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, mock.Anything).
 		Return(map[int64][]database.TagInfo{}, nil).Maybe()
@@ -759,7 +772,7 @@ func TestHandleMediaHistory_CoverFailureDoesNotAffectTags(t *testing.T) {
 		Return([]database.MediaHistoryEntry{
 			{DBID: 1, SystemID: "NES", MediaPath: mediaPath, MediaName: "History", StartTime: time.Now()},
 		}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420}}, nil)
 	mockMediaDB.On("GetMediaCoverStatus", mock.Anything, refs).
 		Return(nil, errors.New("cover lookup failed"))
@@ -795,7 +808,7 @@ func TestHandleMediaHistory_RepeatedMediaRowsShareOneRef(t *testing.T) {
 			{DBID: 2, SystemID: "NES", MediaPath: mediaPath, MediaName: "Repeat", StartTime: now.Add(-time.Hour)},
 			{DBID: 1, SystemID: "NES", MediaPath: mediaPath, MediaName: "Repeat", StartTime: now.Add(-2 * time.Hour)},
 		}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420}}, nil).
 		Once()
 	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, []database.MediaRef{{MediaDBID: 42, MediaTitleDBID: 420}}).

--- a/pkg/api/methods/media_history_top_test.go
+++ b/pkg/api/methods/media_history_top_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -107,7 +108,7 @@ func TestHandleMediaHistoryTop_WithMediaIDAndRelativePath(t *testing.T) {
 			LastPlayedAt:  now,
 		},
 	}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 		Return([]database.MediaPathID{{SystemID: "SNES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420}}, nil)
 
 	env := requests.RequestEnv{
@@ -481,7 +482,11 @@ func TestHandleMediaHistoryTop_IncludesTags(t *testing.T) {
 				TotalPlayTime: 100, SessionCount: 1, LastPlayedAt: now,
 			},
 		}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{taggedPath, untaggedPath, missingPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{
+		pathutil.CanonicalMediaPath(taggedPath),
+		pathutil.CanonicalMediaPath(untaggedPath),
+		pathutil.CanonicalMediaPath(missingPath),
+	}).
 		Return([]database.MediaPathID{
 			{SystemID: "SNES", Path: taggedPath, DBID: 42, MediaTitleDBID: 420},
 			{SystemID: "SNES", Path: untaggedPath, DBID: 43, MediaTitleDBID: 430},
@@ -535,7 +540,7 @@ func TestHandleMediaHistoryTop_TagLookupFailureIsNonFatal(t *testing.T) {
 				TotalPlayTime: 300, SessionCount: 3, LastPlayedAt: time.Now(),
 			},
 		}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 		Return([]database.MediaPathID{{SystemID: "SNES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420}}, nil)
 	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, []database.MediaRef{{MediaDBID: 42, MediaTitleDBID: 420}}).
 		Run(func(args mock.Arguments) {
@@ -574,7 +579,7 @@ func TestHandleMediaHistoryTop_IdentityLookupFailureIsNonFatal(t *testing.T) {
 				TotalPlayTime: 300, SessionCount: 3, LastPlayedAt: time.Now(),
 			},
 		}, nil)
-	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(mediaPath)}).
 		Return(nil, errors.New("identity lookup failed"))
 	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, mock.Anything).
 		Return(map[int64][]database.TagInfo{}, nil).Maybe()

--- a/pkg/api/methods/media_history_winpath_test.go
+++ b/pkg/api/methods/media_history_winpath_test.go
@@ -1,0 +1,68 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// History keeps the path a launch was given, and on Windows that can be the
+// native backslash form, while Media.Path is always the canonical
+// forward-slash form. The enrichment lookup must bridge the two or every
+// Windows history entry for a file comes back without its tags. The
+// canonicaliser folds backslashes on every OS, so this reproduces anywhere.
+func TestMediaHistoryTagsResolveNativeWindowsPaths(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+	ids := addTestMediaPaths(t, mediaDB, "C:/roms/NES/Alpha.nes")
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, ids[0], nil,
+		[]database.MediaTagRef{{Type: "user", Tag: "hidden"}}))
+
+	_, err := userDB.AddMediaHistory(&database.MediaHistoryEntry{
+		SystemID: "NES", SystemName: "NES", MediaPath: `C:\roms\NES\Alpha.nes`, MediaName: "Alpha",
+		StartTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context: ctx, Database: &database.Database{MediaDB: mediaDB, UserDB: userDB},
+		Config: &config.Instance{},
+	}
+	history, err := HandleMediaHistory(withParams(&env, `{}`))
+	require.NoError(t, err)
+	response, ok := history.(models.MediaHistoryResponse)
+	require.True(t, ok)
+	require.Len(t, response.Entries, 1)
+	assert.Contains(t, response.Entries[0].Tags, database.TagInfo{Type: "user", Tag: "hidden"})
+}

--- a/pkg/api/methods/media_response_helpers.go
+++ b/pkg/api/methods/media_response_helpers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	"github.com/rs/zerolog/log"
@@ -131,7 +132,12 @@ func resolveMediaPathIDs(
 		return map[mediaPathRef]database.MediaPathID{}, nil
 	}
 
+	// Media.Path is stored in canonical forward-slash form, but history and
+	// playtime rows keep the path the launch was given, which on Windows can
+	// carry backslashes. Look up by the canonical form and hand each row back
+	// under the caller's own ref, or Windows entries never get their tags.
 	wanted := make(map[mediaPathRef]bool, len(refs))
+	refsByCanonical := make(map[mediaPathRef][]mediaPathRef, len(refs))
 	paths := make([]string, 0, len(refs))
 	seenPaths := make(map[string]bool, len(refs))
 	for _, ref := range refs {
@@ -139,9 +145,12 @@ func resolveMediaPathIDs(
 			continue
 		}
 		wanted[ref] = true
-		if !seenPaths[ref.Path] {
-			seenPaths[ref.Path] = true
-			paths = append(paths, ref.Path)
+		canonical := pathutil.CanonicalMediaPath(ref.Path)
+		key := mediaPathRef{SystemID: ref.SystemID, Path: canonical}
+		refsByCanonical[key] = append(refsByCanonical[key], ref)
+		if !seenPaths[canonical] {
+			seenPaths[canonical] = true
+			paths = append(paths, canonical)
 		}
 	}
 	if len(paths) == 0 {
@@ -159,8 +168,8 @@ func resolveMediaPathIDs(
 		if row.DBID <= 0 {
 			continue
 		}
-		ref := mediaPathRef{SystemID: row.SystemID, Path: row.Path}
-		if wanted[ref] {
+		key := mediaPathRef{SystemID: row.SystemID, Path: pathutil.CanonicalMediaPath(row.Path)}
+		for _, ref := range refsByCanonical[key] {
 			resolved[ref] = row
 		}
 	}

--- a/pkg/api/methods/media_response_helpers_test.go
+++ b/pkg/api/methods/media_response_helpers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/audio"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
@@ -72,10 +73,15 @@ func TestMediaIDsByPath_DeduplicatesRefsAndSkipsInvalidRefs(t *testing.T) {
 		{SystemID: "NES", Path: ""},
 	}
 
-	mockDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathOne, pathTwo}).Return(
+	// The database holds canonical forward-slash paths, so the lookup is made
+	// in that form whatever form the refs arrived in, and rows come back
+	// under the refs as given.
+	canonicalOne := pathutil.CanonicalMediaPath(pathOne)
+	canonicalTwo := pathutil.CanonicalMediaPath(pathTwo)
+	mockDB.On("FindMediaIDsByPaths", mock.Anything, []string{canonicalOne, canonicalTwo}).Return(
 		[]database.MediaPathID{
-			{SystemID: "NES", Path: pathOne, DBID: 10},
-			{SystemID: "NES", Path: pathTwo, DBID: 11},
+			{SystemID: "NES", Path: canonicalOne, DBID: 10},
+			{SystemID: "NES", Path: canonicalTwo, DBID: 11},
 		}, nil,
 	)
 
@@ -233,7 +239,7 @@ func TestMediaIDsByPath_IgnoresRowsForUnrequestedSystems(t *testing.T) {
 
 	// The same path can exist under multiple systems; only the requested
 	// (system, path) pair should be resolved.
-	mockDB.On("FindMediaIDsByPaths", mock.Anything, []string{path}).Return(
+	mockDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathutil.CanonicalMediaPath(path)}).Return(
 		[]database.MediaPathID{
 			{SystemID: "NES", Path: path, DBID: 10},
 			{SystemID: "FDS", Path: path, DBID: 22},

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -1774,7 +1774,11 @@ func TestScrapeQueueKeepsScopeAcrossTheQueue(t *testing.T) {
 	ClearScrapingStatus()
 	t.Cleanup(ClearScrapingStatus)
 	db := testhelpers.NewMockMediaDBI()
-	scope := &database.ScrapeScope{SystemID: "SNES", Path: "/roms/SNES/game.sfc", MediaID: 7}
+	// Scope validation requires a path that is absolute on this OS; a Unix
+	// path is relative on Windows.
+	scopePath, err := database.CanonicalScrapePath(browseTestAbsPath("roms", "SNES", "game.sfc"), false)
+	require.NoError(t, err)
+	scope := &database.ScrapeScope{SystemID: "SNES", Path: scopePath, MediaID: 7}
 	running := database.ScrapingOperation{
 		Version: 1, Status: mediadb.IndexingStatusPending,
 		ScraperID: "manual", RunID: "retained", Systems: []string{"SNES"}, Scope: scope,

--- a/pkg/database/mediadb/browse_root_counts_winpath_test.go
+++ b/pkg/database/mediadb/browse_root_counts_winpath_test.go
@@ -1,0 +1,78 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A Windows media path has no leading slash, but the browse cache hangs every
+// filesystem directory under "/", so C:/roms/ is stored as /C:/roms/. The root
+// listing looked the root up in the platform's own form and never found it,
+// reporting every filesystem root on Windows as empty and dropping it from
+// media.browse. The cache is pure string handling, so the same keys reproduce
+// the miss on any OS.
+func TestBrowseRootCountsFindWindowsRootsInTheCache(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	t.Cleanup(cleanup)
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	insertSystemMedia(t, mediaDB, system, "Alpha", "C:/roms/NES/Alpha.nes")
+	insertSystemMedia(t, mediaDB, system, "Beta", "C:/roms/NES/Beta.nes")
+	insertSystemMedia(t, mediaDB, system, "Gamma", "C:/roms/NES/Folder/Gamma.nes")
+	require.NoError(t, mediaDB.PopulateBrowseCache(ctx))
+	ready, err := sqlBrowseCacheReady(ctx, mediaDB.sql.Load())
+	require.NoError(t, err)
+	require.True(t, ready, "the cached root counts are what this test covers")
+
+	// Roots arrive as the platform reports them: cleaned forward-slash form
+	// from most platforms, native backslashes from Windows.
+	for _, root := range []string{"C:/roms", `C:\roms`, "C:/roms/NES"} {
+		counts, countErr := mediaDB.BrowseRootCounts(ctx, []string{root}, false)
+		require.NoError(t, countErr)
+		require.NotNil(t, counts[root], "root %q must be answered from the cache", root)
+		assert.Equal(t, 3, *counts[root], "root %q", root)
+	}
+
+	// Hidden rows are subtracted by Media.Path prefix, which is the
+	// forward-slash form whatever the root looked like.
+	hideMediaPaths(t, mediaDB, "C:/roms/NES/Folder/Gamma.nes")
+	for _, root := range []string{"C:/roms", `C:\roms`} {
+		counts, countErr := mediaDB.BrowseRootCounts(ctx, []string{root}, true)
+		require.NoError(t, countErr)
+		require.NotNil(t, counts[root])
+		assert.Equal(t, 2, *counts[root], "root %q with one hidden file", root)
+	}
+
+	// The same key mismatch hid cached directory listings behind the media
+	// fallback; the cache must answer for the Windows prefix directly.
+	_, found, err := sqlBrowseDirectoriesFromCache(ctx, mediaDB.sql.Load(), database.BrowseDirectoriesOptions{
+		PathPrefix: "C:/roms/NES/",
+	})
+	require.NoError(t, err)
+	assert.True(t, found, "the cache must know the Windows directory")
+}

--- a/pkg/database/mediadb/browse_root_counts_winpath_test.go
+++ b/pkg/database/mediadb/browse_root_counts_winpath_test.go
@@ -69,10 +69,13 @@ func TestBrowseRootCountsFindWindowsRootsInTheCache(t *testing.T) {
 	}
 
 	// The same key mismatch hid cached directory listings behind the media
-	// fallback; the cache must answer for the Windows prefix directly.
-	_, found, err := sqlBrowseDirectoriesFromCache(ctx, mediaDB.sql.Load(), database.BrowseDirectoriesOptions{
-		PathPrefix: "C:/roms/NES/",
-	})
-	require.NoError(t, err)
-	assert.True(t, found, "the cache must know the Windows directory")
+	// fallback; the cache must answer for the Windows prefix directly, in
+	// either separator form.
+	for _, prefix := range []string{"C:/roms/NES/", `C:\roms\NES\`} {
+		_, found, dirErr := sqlBrowseDirectoriesFromCache(ctx, mediaDB.sql.Load(), database.BrowseDirectoriesOptions{
+			PathPrefix: prefix,
+		})
+		require.NoError(t, dirErr)
+		assert.True(t, found, "the cache must know the Windows directory %q", prefix)
+	}
 }

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -541,8 +541,21 @@ func sqlBrowseCacheStatus(ctx context.Context, db sqlQueryable) (browseCacheStat
 	return browseCacheStale, nil
 }
 
+// browseCacheDirKey converts a browse path into the key the cache builder
+// stores it under. browseCacheAncestorDirs hangs every filesystem directory
+// under "/", so a Windows directory such as C:/roms/ is stored as /C:/roms/.
+// Looking it up in the form callers hold never matched, which made every
+// cache lookup on Windows a miss: the root listing then reported every
+// filesystem root as empty and left it out.
+func browseCacheDirKey(dirPath string) string {
+	if dirPath == "" || strings.HasPrefix(dirPath, "/") || strings.Contains(dirPath, "://") {
+		return dirPath
+	}
+	return "/" + dirPath
+}
+
 func sqlBrowseDirID(ctx context.Context, db sqlQueryable, dirPath string) (id int64, ok bool, err error) {
-	err = db.QueryRowContext(ctx, `SELECT DBID FROM BrowseDirs WHERE Path = ?`, dirPath).Scan(&id)
+	err = db.QueryRowContext(ctx, `SELECT DBID FROM BrowseDirs WHERE Path = ?`, browseCacheDirKey(dirPath)).Scan(&id)
 	if err == sql.ErrNoRows {
 		return 0, false, nil
 	}
@@ -4053,7 +4066,11 @@ func sqlBrowseRootCounts(
 		if counts[root] == nil {
 			continue
 		}
-		visible := max(*counts[root]-hidden.countUnder(browseRouteCacheKey(root), nil), 0)
+		// Hidden rows carry Media.Path, which is the cleaned forward-slash
+		// form; a root arrives as the platform reports it, which on Windows
+		// has backslashes and would match nothing.
+		prefix := browseRouteCacheKey(browseCacheNormalizePath(root))
+		visible := max(*counts[root]-hidden.countUnder(prefix, nil), 0)
 		counts[root] = &visible
 	}
 	return counts, nil
@@ -4081,7 +4098,10 @@ func sqlBrowseRootCountsFromCache(
 	for _, root := range rootDirs {
 		count := 0
 		counts[root] = &count
-		dirID, ok, lookupErr := sqlBrowseDirID(ctx, db, browseRouteCacheKey(root))
+		// The platform reports roots in native form; the cache keys them
+		// cleaned with forward slashes.
+		key := browseRouteCacheKey(browseCacheNormalizePath(root))
+		dirID, ok, lookupErr := sqlBrowseDirID(ctx, db, key)
 		if lookupErr != nil {
 			return nil, lookupErr
 		}
@@ -4090,7 +4110,7 @@ func sqlBrowseRootCountsFromCache(
 		}
 		var dbCount int
 		query := `SELECT COALESCE(SUM(FileCount), 0) FROM BrowseDirCounts WHERE ChildDirDBID = ?`
-		if browseRouteCacheKey(root) != "/" {
+		if key != "/" {
 			query += ` AND ParentDirDBID != ChildDirDBID`
 		}
 		if scanErr := db.QueryRowContext(ctx, query, dirID).Scan(&dbCount); scanErr != nil {

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -542,16 +542,21 @@ func sqlBrowseCacheStatus(ctx context.Context, db sqlQueryable) (browseCacheStat
 }
 
 // browseCacheDirKey converts a browse path into the key the cache builder
-// stores it under. browseCacheAncestorDirs hangs every filesystem directory
-// under "/", so a Windows directory such as C:/roms/ is stored as /C:/roms/.
-// Looking it up in the form callers hold never matched, which made every
-// cache lookup on Windows a miss: the root listing then reported every
-// filesystem root as empty and left it out.
+// stores it under. The path is normalized the way the builder normalizes media
+// paths, so native backslash separators match, and browseCacheAncestorDirs
+// hangs every filesystem directory under "/", so a Windows directory such as
+// C:/roms/ is stored as /C:/roms/. Looking it up in the form callers hold
+// never matched, which made every cache lookup on Windows a miss: the root
+// listing then reported every filesystem root as empty and left it out.
 func browseCacheDirKey(dirPath string) string {
-	if dirPath == "" || strings.HasPrefix(dirPath, "/") || strings.Contains(dirPath, "://") {
+	if dirPath == "" || strings.Contains(dirPath, "://") {
 		return dirPath
 	}
-	return "/" + dirPath
+	key := browseRouteCacheKey(browseCacheNormalizePath(dirPath))
+	if strings.HasPrefix(key, "/") {
+		return key
+	}
+	return "/" + key
 }
 
 func sqlBrowseDirID(ctx context.Context, db sqlQueryable, dirPath string) (id int64, ok bool, err error) {


### PR DESCRIPTION
- The browse cache keys every filesystem directory under "/", so `C:/roms/` is stored as `/C:/roms/`. Root count lookups used the form the platform reports and never matched on Windows, so every filesystem root counted as empty and was left out of the `media.browse` root listing. Hidden-entry subtraction for roots also compared native backslash paths against forward-slash media paths.
- History rows keep the path a launch was given, which on Windows can use backslashes, while `Media.Path` is canonical forward-slash. Media ID lookups for `media.history`, `media.history.top` and active media now use the canonical path and map rows back to the original refs, so Windows entries get their tags.
- `TestScrapeQueueKeepsScopeAcrossTheQueue` used `/roms/SNES/game.sfc`, which is relative on Windows and fails scope validation.
- These are the two `pkg/api/methods` failures in main's Windows CI job since #1449 and #1452. Adds `*_winpath_test.go` regression tests that run on every OS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Windows-style media paths, including paths using backslashes.
  - Media history entries now correctly resolve associated tags across different path formats.
  - Browse directory counts and cached listings now work reliably for Windows drive-letter paths.
  - Hidden media is correctly excluded from browse count totals.
  - Media lookup and scrape behavior is now more consistent across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->